### PR TITLE
Remove mock from setup.py installation requires

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ python:
     - pypy
 
 install:
-    - pip install -q $TWISTED mock
+    - pip install -q $TWISTED
     - python setup.py -q install
 
 script: trial klein


### PR DESCRIPTION
moves it to travis' config too, so it can use it for tests
for #32, cc @hynek
