### PR TITLE
Expand travis config to run against twisted 12.1 to 13.2 + trunk

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,9 @@ env:
     - TWISTED=Twisted==12.1
     - TWISTED=Twisted==12.2
     - TWISTED=Twisted==12.3
+    - TWISTED=Twisted==13.0
+    - TWISTED=Twisted==13.1
+    - TWISTED=Twisted==13.2
     - TWISTED=svn+svn://svn.twistedmatrix.com/svn/Twisted/trunk
 
 language: python


### PR DESCRIPTION
Current Travis config only tests against Twisted 12.1 to 12.3 + trunk - it should also test against more recent versions.
