### PR TITLE
endpoint resolution by module

### DIFF
--- a/klein/app.py
+++ b/klein/app.py
@@ -10,6 +10,7 @@ from werkzeug.routing import Map, Rule
 
 from twisted.python import log
 from twisted.python.components import registerAdapter
+from twisted.python.reflect import fullyQualifiedName
 
 from twisted.web.server import Site, Request
 from twisted.internet import reactor
@@ -152,7 +153,7 @@ class Klein(object):
             segment_count -= 1
 
         def deco(f):
-            kwargs.setdefault('endpoint', '.'.join([f.__module__, f.__name__, str(id(f))]))
+            kwargs.setdefault('endpoint', fullyQualifiedName(f))
             if kwargs.pop('branch', False):
                 branchKwargs = kwargs.copy()
                 branchKwargs['endpoint'] = branchKwargs['endpoint'] + '_branch'


### PR DESCRIPTION
suppose you have two modules:

_main.py_

``` python
from klein import Klein

app = Klein()

@app.route('/')
def home(request):
    return 'hello from main home'
```

and in a second module, you defined another home for a different home:

_blog.py_

``` python
from main import app

@app.route('/blog_home')
def home(request):
    return 'hello from blog home'
```

in this case if you point your browser -or something else- to `/` or `/blog_home` in both case it will return `hello from blog home`

this patch fix this issue, hope you'll like it!
