### PR TITLE
endpoint resolution by module

### DIFF
--- a/klein/app.py
+++ b/klein/app.py
@@ -10,6 +10,7 @@ from werkzeug.routing import Map, Rule
 
 from twisted.python import log
 from twisted.python.components import registerAdapter
+from twisted.python.reflect import fullyQualifiedName
 
 from twisted.web.server import Site, Request
 from twisted.internet import reactor
@@ -152,7 +153,7 @@ class Klein(object):
             segment_count -= 1
 
         def deco(f):
-            kwargs.setdefault('endpoint', f.__name__)
+            kwargs.setdefault('endpoint', fullyQualifiedName(f))
             if kwargs.pop('branch', False):
                 branchKwargs = kwargs.copy()
                 branchKwargs['endpoint'] = branchKwargs['endpoint'] + '_branch'

--- a/klein/test/test_app.py
+++ b/klein/test/test_app.py
@@ -37,10 +37,10 @@ class KleinTestCase(unittest.TestCase):
             return "foo"
 
         c = app.url_map.bind("foo")
-        self.assertEqual(c.match("/foo"), ("foo", {}))
+        self.assertEqual(c.match("/foo"), ("klein.test.test_app.foo", {}))
         self.assertEqual(len(app.endpoints), 1)
 
-        self.assertEqual(app.execute_endpoint("foo", DummyRequest(1)), "foo")
+        self.assertEqual(app.execute_endpoint("klein.test.test_app.foo", DummyRequest(1)), "foo")
 
 
     def test_stackedRoute(self):
@@ -58,8 +58,8 @@ class KleinTestCase(unittest.TestCase):
         self.assertEqual(len(app.endpoints), 2)
 
         c = app.url_map.bind("foo")
-        self.assertEqual(c.match("/foo"), ("foobar", {}))
-        self.assertEqual(app.execute_endpoint("foobar", DummyRequest(1)), "foobar")
+        self.assertEqual(c.match("/foo"), ("klein.test.test_app.foobar", {}))
+        self.assertEqual(app.execute_endpoint("klein.test.test_app.foobar", DummyRequest(1)), "foobar")
 
         self.assertEqual(c.match("/bar"), ("bar", {}))
         self.assertEqual(app.execute_endpoint("bar", DummyRequest(2)), "foobar")
@@ -77,14 +77,14 @@ class KleinTestCase(unittest.TestCase):
             return "foo"
 
         c = app.url_map.bind("foo")
-        self.assertEqual(c.match("/foo/"), ("foo", {}))
+        self.assertEqual(c.match("/foo/"), ("klein.test.test_app.foo", {}))
         self.assertEqual(
             c.match("/foo/bar"),
-            ("foo_branch", {'__rest__': 'bar'}))
+            ("klein.test.test_app.foo_branch", {'__rest__': 'bar'}))
 
-        self.assertEquals(app.endpoints["foo"].__name__, "foo")
+        self.assertEquals(app.endpoints["klein.test.test_app.foo"].__name__, "foo")
         self.assertEquals(
-            app.endpoints["foo_branch"].__name__,
+            app.endpoints["klein.test.test_app.foo_branch"].__name__,
             "foo")
 
 
@@ -104,8 +104,8 @@ class KleinTestCase(unittest.TestCase):
 
         foo = Foo()
         c = foo.app.url_map.bind("bar")
-        self.assertEqual(c.match("/bar"), ("bar", {}))
-        self.assertEquals(foo.app.execute_endpoint("bar", DummyRequest(1)), "bar")
+        self.assertEqual(c.match("/bar"), ("klein.test.test_app.bar", {}))
+        self.assertEquals(foo.app.execute_endpoint("klein.test.test_app.bar", DummyRequest(1)), "bar")
 
         self.assertEqual(bar_calls, [(foo, DummyRequest(1))])
 
@@ -135,8 +135,8 @@ class KleinTestCase(unittest.TestCase):
         dr1 = DummyRequest(1)
         dr2 = DummyRequest(2)
 
-        foo_1_app.execute_endpoint('bar', dr1)
-        foo_2_app.execute_endpoint('bar', dr2)
+        foo_1_app.execute_endpoint('klein.test.test_app.bar', dr1)
+        foo_2_app.execute_endpoint('klein.test.test_app.bar', dr2)
         self.assertEqual(foo_1.bar_calls, [(foo_1, dr1)])
         self.assertEqual(foo_2.bar_calls, [(foo_2, dr2)])
 
@@ -166,8 +166,8 @@ class KleinTestCase(unittest.TestCase):
         dr1 = DummyRequest(1)
         dr2 = DummyRequest(2)
 
-        foo_1_app.execute_endpoint('bar_branch', dr1)
-        foo_2_app.execute_endpoint('bar_branch', dr2)
+        foo_1_app.execute_endpoint('klein.test.test_app.bar_branch', dr1)
+        foo_2_app.execute_endpoint('klein.test.test_app.bar_branch', dr2)
         self.assertEqual(foo_1.bar_calls, [(foo_1, dr1)])
         self.assertEqual(foo_2.bar_calls, [(foo_2, dr2)])
 
@@ -188,7 +188,7 @@ class KleinTestCase(unittest.TestCase):
 
         c = app.url_map.bind("foo")
         self.assertEqual(c.match("/foo/bar"),
-                         ("foo_branch", {"__rest__": "bar"}))
+                         ("klein.test.test_app.foo_branch", {"__rest__": "bar"}))
 
 
     @patch('klein.app.KleinResource')

--- a/klein/test/test_resource.py
+++ b/klein/test/test_resource.py
@@ -222,7 +222,7 @@ class KleinResourceTests(TestCase):
         d = _render(self.kr, request)
         self.assertFired(d)
         self.assertEqual(request.getWrittenData(), 'posted')
-        
+
         d2 = _render(self.kr, request2)
         self.assertFired(d2)
         self.assertEqual(request2.getWrittenData(), 'gotted')
@@ -276,7 +276,7 @@ class KleinResourceTests(TestCase):
 
         self.assertFired(d)
         self.assertEqual(request.getWrittenData(), 'zeus')
-        
+
         d2 = _render(self.kr, request2)
 
         self.assertFired(d2)
@@ -301,9 +301,9 @@ class KleinResourceTests(TestCase):
 
         self.assertFired(d)
         self.assertEqual(request.getWrittenData(), 'zeus')
-        
+
         d2 = _render(self.kr, request2)
-        
+
         self.assertFired(d2)
         self.assertEqual(request2.getWrittenData(), 'ok')
 
@@ -324,7 +324,7 @@ class KleinResourceTests(TestCase):
         self.assertNotFired(d)
 
         deferredResponse.callback('ok')
-        
+
         self.assertFired(d)
         self.assertEqual(request.getWrittenData(), 'ok')
 
@@ -340,7 +340,7 @@ class KleinResourceTests(TestCase):
 
         d = _render(self.kr, request)
 
-        self.assertFired(d)        
+        self.assertFired(d)
         self.assertEqual(request.getWrittenData(), "<h1>foo</h1>")
 
 
@@ -473,7 +473,7 @@ class KleinResourceTests(TestCase):
         d = _render(self.kr, request)
 
         self.assertFired(d)
-        self.assertEqual(request.getWrittenData(), 
+        self.assertEqual(request.getWrittenData(),
             open(
                 os.path.join(
                     os.path.dirname(__file__), "__init__.py")).read())
@@ -492,7 +492,7 @@ class KleinResourceTests(TestCase):
         d = _render(self.kr, request)
 
         self.assertFired(d)
-        self.assertEqual(request.getWrittenData(), 
+        self.assertEqual(request.getWrittenData(),
             open(
                 os.path.join(
                     os.path.dirname(__file__), "__init__.py")).read())
@@ -854,7 +854,7 @@ class KleinResourceTests(TestCase):
         @app.route("/foo/<int:bar>")
         def foo(request, bar):
             krequest = IKleinRequest(request)
-            relative_url[0] = krequest.url_for('foo', {'bar': bar + 1})
+            relative_url[0] = krequest.url_for('klein.test.test_resource.foo', {'bar': bar + 1})
 
         d = _render(self.kr, request)
 
@@ -887,7 +887,7 @@ class KleinResourceTests(TestCase):
         @app.route("/foo/<int:bar>")
         def foo(request, bar):
             krequest = IKleinRequest(request)
-            relative_url[0] = krequest.url_for('foo', {'bar': bar + 1},
+            relative_url[0] = krequest.url_for('klein.test.test_resource.foo', {'bar': bar + 1},
                 force_external=True)
 
         d = _render(self.kr, request)

--- a/klein/test/test_resource.py
+++ b/klein/test/test_resource.py
@@ -11,6 +11,7 @@ from twisted.web.resource import Resource
 from twisted.web.static import File
 from twisted.web.template import Element, XMLString, renderer
 from twisted.web.test.test_web import DummyChannel
+from twisted.python.reflect import fullyQualifiedName
 from werkzeug.exceptions import NotFound
 
 from klein import Klein
@@ -854,7 +855,7 @@ class KleinResourceTests(TestCase):
         @app.route("/foo/<int:bar>")
         def foo(request, bar):
             krequest = IKleinRequest(request)
-            relative_url[0] = krequest.url_for('klein.test.test_resource.foo', {'bar': bar + 1})
+            relative_url[0] = krequest.url_for(fullyQualifiedName(foo), {'bar': bar + 1})
 
         d = _render(self.kr, request)
 
@@ -887,7 +888,7 @@ class KleinResourceTests(TestCase):
         @app.route("/foo/<int:bar>")
         def foo(request, bar):
             krequest = IKleinRequest(request)
-            relative_url[0] = krequest.url_for('klein.test.test_resource.foo', {'bar': bar + 1},
+            relative_url[0] = krequest.url_for(fullyQualifiedName(foo), {'bar': bar + 1},
                 force_external=True)
 
         d = _render(self.kr, request)


### PR DESCRIPTION
fix #53
suppose you have two modules:

*main.py*
```python
from klein import Klein

app = Klein()

@app.route('/')
def home(request):
    return 'hello from main home'
```

and in a second module, you defined another home for a different home:

*blog.py*
```python
from main import app

@app.route('/blog_home')
def home(request):
    return 'hello from blog home'
```

in this case if you point your browser -or something else- to `/` or `/blog_home` in both case it will return `hello from blog home`

this patch fix this issue, hope you'll like it!