### PR TITLE
Add subroute feature

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -8,3 +8,4 @@ Matt Haggard
 Paul Hummer
 Russel Haering
 Tom Most
+Brighid McDonnell

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -19,7 +19,7 @@ Code
 - Propose all patches through a pull request in the `GitHub repo <https://github.com/twisted/klein>`_.
 - Use `Twisted's code style guide <http://twistedmatrix.com/documents/current/core/development/policy/coding-standard.html>`_ for all code you touch, as long as it doesn't break a public API.
 - Make sure your patch has tests, since untested code is buggy code.
-  Klein uses `Twisted trial <http://twistedmatrix.com/documents/current/api/twisted.trial.html>`_ and `tox <https://testrun.org/tox/latest/index.html>`_ for its tests.
+  Klein uses `Twisted Trial <http://twistedmatrix.com/documents/current/api/twisted.trial.html>`_ and `tox <https://testrun.org/tox/latest/index.html>`_ for its tests.
   The command to run the full test suite is ``tox`` with no arguments.
   This will run tests against several versions of Python and Twisted, which can be time-consuming.
   To run tests against only one or a few versions, pass a ``-e`` argument with an environment from the envlist in ``tox.ini``: for example, ``tox -e py27-tw150`` will run tests with Python 2.7 and Twisted 15.0.

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -19,6 +19,12 @@ Code
 - Propose all patches through a pull request in the `GitHub repo <https://github.com/twisted/klein>`_.
 - Use `Twisted's code style guide <http://twistedmatrix.com/documents/current/core/development/policy/coding-standard.html>`_ for all code you touch, as long as it doesn't break a public API.
 - Make sure your patch has tests, since untested code is buggy code.
+  Klein uses `Twisted trial <http://twistedmatrix.com/documents/current/api/twisted.trial.html>`_ and `tox <https://testrun.org/tox/latest/index.html>`_ for its tests.
+  The command to run the full test suite is ``tox`` with no arguments.
+  This will run tests against several versions of Python and Twisted, which can be time-consuming.
+  To run tests against only one or a few versions, pass a ``-e`` argument with an environment from the envlist in ``tox.ini``: for example, ``tox -e py27-tw150`` will run tests with Python 2.7 and Twisted 15.0.
+  To run only one or a few specific tests in the suite, add a filename or fully-qualified Python path to the end of the test invocation: for example, ``tox klein.test.test_app.KleinTestCase.test_foo`` will run only the ``test_foo()`` method of the ``KleinTestCase`` class in ``klein/test/test_app.py``.
+  These two test shortcuts can be combined to give you a quick feedback cycle, but make sure to check on the full test suite from time to time to make sure changes haven't had unexpected side effects.
 - If it's a new feature, add an example into the `examples directory <https://github.com/twisted/klein/tree/master/docs/examples>`_ and add it to the index.
 - Add yourself to ``AUTHORS``.
 - Put ``[WIP]`` in the title if it's a work in progress pull request.

--- a/docs/examples/subroutes.rst
+++ b/docs/examples/subroutes.rst
@@ -1,0 +1,30 @@
+====================
+Example -- Subroutes
+====================
+
+The ``routes`` decorator lets you set up different routes easily, but it can be cumbersome to write many similar routes.
+If you need to write similar routes, the ``subroute`` function can help.
+``subroute`` is a context manager within whose scope all invocations of ``route`` will have a prefix added.
+
+Here is an example app that has routes for ``/branch/lair``, ``/branch/crypt``, and ``/branch/swamp`` all defined in a ``with app.subroute()`` block.
+
+.. code-block:: python
+
+    from klein import Klein
+
+    app = Klein()
+
+    with app.subroute("/branch") as app:
+        @app.route("/lair")
+        def lair(request):
+            return "These stairs lead to the lair of beasts."
+
+        @app.route("/crypt")
+        def crypt(request):
+            return "These stairs lead to an ancient crypt."
+
+        @app.route("/swamp")
+        def swamp(request):
+            return "A stair to a swampy wasteland."
+
+    app.run("localhost", 8080)

--- a/docs/examples/subroutes.rst
+++ b/docs/examples/subroutes.rst
@@ -17,14 +17,14 @@ Here is an example app that has routes for ``/branch/lair``, ``/branch/crypt``, 
     with app.subroute("/branch") as app:
         @app.route("/lair")
         def lair(request):
-            return "These stairs lead to the lair of beasts."
+            return b"These stairs lead to the lair of beasts."
 
         @app.route("/crypt")
         def crypt(request):
-            return "These stairs lead to an ancient crypt."
+            return b"These stairs lead to an ancient crypt."
 
         @app.route("/swamp")
         def swamp(request):
-            return "A stair to a swampy wasteland."
+            return b"A stair to a swampy wasteland."
 
     app.run("localhost", 8080)

--- a/klein/app.py
+++ b/klein/app.py
@@ -4,9 +4,12 @@ Applications are great.  Lets have more of them.
 import sys
 import weakref
 
+from collections import namedtuple
+from contextlib import contextmanager
+
 from functools import wraps
 
-from werkzeug.routing import Map, Rule
+from werkzeug.routing import Map, Rule, Submount
 
 from twisted.python import log
 from twisted.python.components import registerAdapter
@@ -191,6 +194,48 @@ class Klein(object):
             return f
 
         return deco
+
+
+    @contextmanager
+    def subroute(self, prefix):
+        """
+        Within this block, C{@route} adds rules to a
+        C{werkzeug.routing.Submount}.
+
+        This is implemented by tinkering with the instance's C{_url_map}
+        variable. A context manager allows us to gracefully use the pattern of
+        "change a variable, do some things with the new value, then put it back
+        to how it was before.
+
+        Named "subroute" to try and give callers a better idea of its
+        relationship to C{@route}.
+
+        Usage:
+        ::
+            with app.subroute("/prefix") as app:
+                @app.route("/foo")
+                def foo_handler(request):
+                    return 'I respond to /prefix/foo'
+
+        @type prefix: string
+        @param prefix: The string that will be prepended to the paths of all
+                       routes established during the with-block.
+        @return: Returns None.
+        """
+
+        _map_before_submount = self._url_map
+
+        submount_map = namedtuple(
+            'submount', ['rules', 'add'])(
+                [], lambda r: submount_map.rules.append(r))
+
+        try:
+            self._url_map = submount_map
+            yield self
+            _map_before_submount.add(
+                Submount(prefix, submount_map.rules))
+        finally:
+            self._url_map = _map_before_submount
 
 
     def handle_errors(self, f_or_exception, *additional_exceptions):

--- a/klein/test/test_app.py
+++ b/klein/test/test_app.py
@@ -74,6 +74,26 @@ class KleinTestCase(unittest.TestCase):
         self.assertEqual(app.execute_endpoint("foo", DummyRequest(1)), "foo")
 
 
+    def test_submountedRoute(self):
+        """
+        L{Klein.subroute} adds functions as routable endpoints.
+        """
+        app = Klein()
+
+        with app.subroute("/sub") as app:
+            @app.route("/prefixed_uri")
+            def foo_endpoint(request):
+                return "foo"
+
+        c = app.url_map.bind("sub/prefixed_uri")
+        self.assertEqual(
+            c.match("/sub/prefixed_uri"), ("foo_endpoint", {}))
+        self.assertEqual(
+            len(app.endpoints), 1)
+        self.assertEqual(
+            app.execute_endpoint("foo_endpoint", DummyRequest(1)), "foo")
+
+
     def test_stackedRoute(self):
         """
         L{Klein.route} can be stacked to create multiple endpoints of

--- a/klein/test/test_app.py
+++ b/klein/test/test_app.py
@@ -83,7 +83,7 @@ class KleinTestCase(unittest.TestCase):
         with app.subroute("/sub") as app:
             @app.route("/prefixed_uri")
             def foo_endpoint(request):
-                return "foo"
+                return b"foo"
 
         c = app.url_map.bind("sub/prefixed_uri")
         self.assertEqual(
@@ -91,7 +91,7 @@ class KleinTestCase(unittest.TestCase):
         self.assertEqual(
             len(app.endpoints), 1)
         self.assertEqual(
-            app.execute_endpoint("foo_endpoint", DummyRequest(1)), "foo")
+            app.execute_endpoint("foo_endpoint", DummyRequest(1)), b"foo")
 
 
     def test_stackedRoute(self):

--- a/tox.ini
+++ b/tox.ini
@@ -28,7 +28,7 @@ deps =
 commands =
     {envpython} --version
     trial --version
-    coverage run --source klein --omit klein/test/* --branch {envdir}/bin/trial klein
+    coverage run --source klein --omit klein/test/* --branch {envdir}/bin/trial {posargs:klein}
     coverage report -m
 
 


### PR DESCRIPTION
Adds a context manager that implements a concise syntax for taking advantage of Werkzeug's `routing.Submount` feature. A unit test and documentation for the new feature are provided, as well as a general documentation enhancement in cbceb6050.