### PR TITLE
Do some coverage testing, use codecov, pare back supported vers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ sudo: required
 
 install:
   - pip install tox codecov
+  - ./.travis/install.sh
 
 env:
     - TOX_ENV=pyflakes
@@ -24,9 +25,6 @@ env:
     - TOX_ENV=py26-tw132
     - TOX_ENV=py27-tw132
     - TOX_ENV=pypy-tw132
-
-install:
-    - ./.travis/install.sh
 
 script: tox  -c tox.ini -e $TOX_ENV
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,20 @@
 language: python
 python: 2.7
+sudo: required
+
+install:
+  - pip install tox codecov
 
 env:
     - TOX_ENV=pyflakes
     - TOX_ENV=docs
-    - TOX_ENV=py26-twcurrent
     - TOX_ENV=py27-twcurrent
     - TOX_ENV=pypy-twcurrent
-    - TOX_ENV=py26-twtrunk
     - TOX_ENV=py27-twtrunk
     - TOX_ENV=pypy-twtrunk
+    - TOX_ENV=py26-tw153
+    - TOX_ENV=py27-tw153
+    - TOX_ENV=pypy-tw153
     - TOX_ENV=py26-tw150
     - TOX_ENV=py27-tw150
     - TOX_ENV=pypy-tw150
@@ -19,26 +24,14 @@ env:
     - TOX_ENV=py26-tw132
     - TOX_ENV=py27-tw132
     - TOX_ENV=pypy-tw132
-    - TOX_ENV=py26-tw131
-    - TOX_ENV=py27-tw131
-    - TOX_ENV=pypy-tw131
-    - TOX_ENV=py26-tw130
-    - TOX_ENV=py27-tw130
-    - TOX_ENV=pypy-tw130
-    - TOX_ENV=py26-tw123
-    - TOX_ENV=py27-tw123
-    - TOX_ENV=pypy-tw123
-    - TOX_ENV=py26-tw122
-    - TOX_ENV=py27-tw122
-    - TOX_ENV=pypy-tw122
-    - TOX_ENV=py26-tw121
-    - TOX_ENV=py27-tw121
-    - TOX_ENV=pypy-tw121
 
 install:
     - ./.travis/install.sh
 
-script: tox -e $TOX_ENV
+script: tox  -c tox.ini -e $TOX_ENV
+
+after_success:
+    - codecov
 
 notifications:
-    email: false
+  email: false

--- a/README.rst
+++ b/README.rst
@@ -6,6 +6,9 @@ Klein, a Web Micro-Framework
     :target: http://travis-ci.org/twisted/klein
     :alt: Build Status
 
+.. image:: http://codecov.io/github/twisted/klein/coverage.svg?branch=master
+    :target: http://codecov.io/github/twisted/klein?branch=master
+
 Klein is a micro-framework for developing production-ready web services with Python.
 It is 'micro' in that it has an incredibly small API similar to `Bottle <http://bottlepy.org/docs/dev/index.html>`_ and `Flask <http://flask.pocoo.org/>`_.
 It is not 'micro' in that it depends on things outside the standard library.

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,7 @@
 [tox]
 envlist =
-    {py26,py27,pypy}-{twcurrent,twtrunk,tw121,tw122,tw123,tw130,tw131,tw132,tw140,tw150},
+    {py26}-{tw132,tw140,tw150,tw153},
+    {py27,pypy}-{twcurrent,twtrunk,tw132,tw140,tw150,tw153},
     pyflakes, docs, docs-linkcheck
 
 ###########################
@@ -15,14 +16,10 @@ basepython =
 deps =
     coverage
     mock
-    tw121: Twisted==12.1
-    tw122: Twisted==12.2
-    tw123: Twisted==12.3
-    tw130: Twisted==13.0
-    tw131: Twisted==13.1
     tw132: Twisted==13.2
     tw140: Twisted==14.0.2
     tw150: Twisted==15.0
+    tw153: Twisted==15.3
     twcurrent: Twisted
     twtrunk: git+git://github.com/twisted/twisted.git
 commands =


### PR DESCRIPTION
Also make the py26 set fixed, as no more Twisteds working with it will be released.