### PR TITLE
Suggest "::" as a value for run(host) to encourage ipv6 support

### DIFF
--- a/klein/app.py
+++ b/klein/app.py
@@ -320,8 +320,10 @@ class Klein(object):
         thing your klein application does.
 
         @param host: The hostname or IP address to bind the listening socket
-            to.  "0.0.0.0" will allow you to listen on all interfaces, and
-            "127.0.0.1" will allow you to listen on just the loopback interface.
+            to.  Examples:
+              "0.0.0.0"   -> all interfaces (ipv4)
+              "::"        -> all interfaces (ipv4+ipv6)
+              "127.0.0.1" -> just the loopback interface.
         @type host: str
 
         @param port: The TCP port to accept HTTP requests on.


### PR DESCRIPTION
The fact that "::" works for ipv4 connections as well surprises me but seems to be true on linux. I'm not sure what layer is making that work.
