### PR TITLE
Add codecov badge to README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -5,6 +5,9 @@ Klein, a Web Micro-Framework
 .. image:: https://travis-ci.org/twisted/klein.png?branch=master
     :target: http://travis-ci.org/twisted/klein
     :alt: Build Status
+.. image:: https://codecov.io/github/codecov/codecov-ruby/coverage.svg?branch=master
+    :target: https://codecov.io/github/codecov/codecov-ruby?branch=master
+    :alt: Code Coverage
 
 Klein is a micro-framework for developing production-ready web services with Python.
 It is 'micro' in that it has an incredibly small API similar to `Bottle <http://bottlepy.org/docs/dev/index.html>`_ and `Flask <http://flask.pocoo.org/>`_.


### PR DESCRIPTION
I was looking at the maturity of the project to evaluate its use in [https://github.com/globaleaks/GlobaLeaks](https://github.com/globaleaks/GlobaLeaks) as replacement for cyclone and i found strange that you were not exposing the code coverage badge given such the good results.

This coommit simply add codecov badge to README.rst

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/twisted/klein/94)
<!-- Reviewable:end -->
