### PR TITLE
Added logic to handle AF_UNIX sockets

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -4,9 +4,9 @@ Amber Brown/HawkOwl
 Brighid McDonnell
 Corbin Simpson
 David Reid
+Deven Phillips
 Hynek Schlawack
 Matt Haggard
 Paul Hummer
 Russel Haering
 Tom Most
-Deven Phillips

--- a/AUTHORS
+++ b/AUTHORS
@@ -9,3 +9,4 @@ Matt Haggard
 Paul Hummer
 Russel Haering
 Tom Most
+Deven Phillips

--- a/src/klein/__init__.py
+++ b/src/klein/__init__.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import, division
 from klein.app import Klein, run, route, resource
 
 
-__version__ = "15.3.1"
+__version__ = "15.3.2"
 
 __author__  = "The Klein contributors (see AUTHORS)"
 __license__ = "MIT"

--- a/src/klein/__init__.py
+++ b/src/klein/__init__.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import, division
 from klein.app import Klein, run, route, resource
 
 
-__version__ = "15.3.2"
+__version__ = "15.3.1"
 
 __author__  = "The Klein contributors (see AUTHORS)"
 __license__ = "MIT"

--- a/src/klein/resource.py
+++ b/src/klein/resource.py
@@ -1,7 +1,6 @@
 from __future__ import absolute_import, division
 
 from twisted.internet import defer
-import twisted.internet.unix.Server
 from twisted.python import log, failure
 from twisted.python.compat import unicode, intToBytes
 from twisted.web import server

--- a/src/klein/resource.py
+++ b/src/klein/resource.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import, division
 
 from twisted.internet import defer
+import twisted.internet.unix.Server
 from twisted.python import log, failure
 from twisted.python.compat import unicode, intToBytes
 from twisted.web import server
@@ -75,7 +76,11 @@ def _extractURLparts(request):
     @rtype: L{tuple} of L{unicode}, L{unicode}, L{int}, L{unicode}, L{unicode}
     """
     server_name = request.getRequestHostname()
-    server_port = request.getHost().port
+    socket = request.channel.transport.getHandle()
+    if isinstance(socket, twisted.internet.unix.Server):
+        server_port = 0
+    else:
+        server_port = request.getHost().port
     if (bool(request.isSecure()), server_port) not in [
             (True, 443), (False, 80)]:
         server_name = server_name + b":" + intToBytes(server_port)

--- a/src/klein/resource.py
+++ b/src/klein/resource.py
@@ -76,11 +76,10 @@ def _extractURLparts(request):
     @rtype: L{tuple} of L{unicode}, L{unicode}, L{int}, L{unicode}, L{unicode}
     """
     server_name = request.getRequestHostname()
-    socket = request.channel.transport.getHandle()
-    if isinstance(socket, twisted.internet.unix.Server):
-        server_port = 0
-    else:
+    if hasattr(request.getHost(), 'port'):
         server_port = request.getHost().port
+    else:
+        server_port = 0
     if (bool(request.isSecure()), server_port) not in [
             (True, 443), (False, 80)]:
         server_name = server_name + b":" + intToBytes(server_port)

--- a/src/klein/resource.py
+++ b/src/klein/resource.py
@@ -80,7 +80,7 @@ def _extractURLparts(request):
     else:
         server_port = 0
     if (bool(request.isSecure()), server_port) not in [
-            (True, 443), (False, 80)]:
+            (True, 443), (False, 80), (False, 0)]:
         server_name = server_name + b":" + intToBytes(server_port)
 
     script_name = b''

--- a/src/klein/resource.py
+++ b/src/klein/resource.py
@@ -80,7 +80,7 @@ def _extractURLparts(request):
     else:
         server_port = 0
     if (bool(request.isSecure()), server_port) not in [
-            (True, 443), (False, 80), (False, 0)]:
+            (True, 443), (False, 80), (False, 0), (True, 0)]:
         server_name = server_name + b":" + intToBytes(server_port)
 
     script_name = b''

--- a/src/klein/test/test_resource.py
+++ b/src/klein/test/test_resource.py
@@ -8,6 +8,7 @@ from mock import Mock, call
 
 from twisted.internet.defer import succeed, Deferred, fail, CancelledError
 from twisted.internet.error import ConnectionLost
+from twisted.internet.unix import Server
 from twisted.web import server
 from twisted.web.http_headers import Headers
 from twisted.web.resource import Resource
@@ -1103,3 +1104,19 @@ class ExtractURLpartsTests(TestCase):
             set(["SERVER_NAME", "PATH_INFO", "SCRIPT_NAME"]),
             set(part for part, _ in e.errors)
         )
+
+    def test_afUnixSocket(self):
+        """
+        Test proper handling of AF_UNIX sockets
+        """
+        request = requestMock(b"/f\xc3\xb6\xc3\xb6")
+        server_mock = Mock(Server)
+        server_mock.getRequestHostname = u'/var/run/twisted.socket'
+        request.host = server_mock
+        url_scheme, server_name, server_port, path_info, script_name = _extractURLparts(request)
+
+        self.assertIsInstance(url_scheme, unicode)
+        self.assertIsInstance(server_name, unicode)
+        self.assertIsInstance(server_port, int)
+        self.assertIsInstance(path_info, unicode)
+        self.assertIsInstance(script_name, unicode)


### PR DESCRIPTION
Resolves #17 - Inside of Klein's resource.py, the `_extractURLparts` method tries to get the port number without checking to see if the connection is an AF_UNIX socket. This causes and exception because AF_UNIX sockets have no concept of a port number.