### PR TITLE
Add support for SSL and TCP6 in app.Klein.run

### DIFF
--- a/src/klein/app.py
+++ b/src/klein/app.py
@@ -310,8 +310,8 @@ class Klein(object):
         return deco
 
 
-    def run(self, host, port, logFile=None, proto="tcp", privateKey=None,
-            certificate=None, dhParameters=None):
+    def run(self, host=None, port=None, logFile=None,
+            endpoint_description=None):
         """
         Run a minimal twisted.web server on the specified C{port}, bound to the
         interface specified by C{host} and logging to C{logFile}.
@@ -331,31 +331,21 @@ class Klein(object):
         @param logFile: The file object to log to, by default C{sys.stdout}
         @type logFile: file object
 
-        @param proto: protocol string for endpoint, can be either "tcp" or "ssl"
-        @type proto: str
-
-        @param privateKey: filepath to private key for ssl
-        @type privateKey: str
-
-        @param certificate: filepath to certificate for ssl
-        @type certificate: str
-
-        @param dhParameters: filepath to dh parameters for ssl
-        @type dhParameters: str
+        @param endpoint_description: specification of endpoint. Must contain
+            protocol, port and interface. May contain other optional arguments,
+             e.g. to use SSL: "ssl:443:privateKey=key.pem:certKey=crt.pem"
+        @type endpoint_description: str
         """
         if logFile is None:
             logFile = sys.stdout
 
         log.startLogging(logFile)
-        server_string = "{}:{}:interface={}".format(proto, port, host)
 
-        if privateKey and certificate:
-            server_string += ":privateKey={}:certKey={}".format(privateKey,
-                                                                certificate)
-        if dhParameters:
-            server_string += ":dhParameters={}".format(dhParameters)
+        if not endpoint_description:
+            endpoint_description = "tcp:port={0}:interface={1}".format(port,
+                                                                       host)
 
-        endpoint = endpoints.serverFromString(reactor, server_string)
+        endpoint = endpoints.serverFromString(reactor, endpoint_description)
         endpoint.listen(Site(self.resource()))
         reactor.run()
 

--- a/src/klein/test/test_app.py
+++ b/src/klein/test/test_app.py
@@ -1,7 +1,5 @@
 from __future__ import absolute_import, division
 
-import os
-
 from twisted.trial import unittest
 
 import sys
@@ -230,8 +228,6 @@ class KleinTestCase(unittest.TestCase):
         self.assertEqual(foo_2.bar_calls, [(foo_2, dr2)])
 
 
-
-
     def test_branchDoesntRequireTrailingSlash(self):
         """
         L{Klein.route} should create a branch path which consumes all children,
@@ -302,18 +298,17 @@ class KleinTestCase(unittest.TestCase):
     @patch('klein.app.reactor')
     def test_runTCP6(self, reactor, mock_sfs, mock_log, mock_kr):
         """
-        L{Klein.run} called with ssl protocol and certificate files.
+        L{Klein.run} called with tcp6 endpoint description.
         """
         app = Klein()
         interface = "2001\:0DB8\:f00e\:eb00\:\:1"
-
-        app.run(interface, 8080, proto="tcp6")
-
-        spec = "tcp6:8080:interface={}".format(interface)
+        spec = "tcp6:8080:interface={0}".format(interface)
+        app.run(endpoint_description=spec)
         reactor.run.assert_called_with()
         mock_sfs.assert_called_with(reactor, spec)
         mock_log.startLogging.assert_called_with(sys.stdout)
         mock_kr.assert_called_with(app)
+
 
     @patch('klein.app.KleinResource')
     @patch('klein.app.log')
@@ -321,21 +316,20 @@ class KleinTestCase(unittest.TestCase):
     @patch('klein.app.reactor')
     def test_runSSL(self, reactor, mock_sfs, mock_log, mock_kr):
         """
-        L{Klein.run} called with ssl protocol and certificate files.
+        L{Klein.run} called with SSL endpoint specification.
         """
         app = Klein()
         key = "key.pem"
         cert = "cert.pem"
         dh_params = "dhparam.pem"
-        app.run("localhost", 8080, proto="ssl",
-                privateKey=key, certificate=cert,
-                dhParameters=dh_params)
-
-        spec = "ssl:8080:interface=localhost:privateKey={}:certKey={}:dhParameters={}"
+        spec_template = "ssl:443:privateKey={0}:certKey={1}"
+        spec = spec_template.format(key, cert, dh_params)
+        app.run(endpoint_description=spec)
         reactor.run.assert_called_with()
-        mock_sfs.assert_called_with(reactor, spec.format(key, cert, dh_params))
+        mock_sfs.assert_called_with(reactor, spec)
         mock_log.startLogging.assert_called_with(sys.stdout)
         mock_kr.assert_called_with(app)
+
 
     @patch('klein.app.KleinResource')
     def test_resource(self, mock_kr):


### PR DESCRIPTION
Updates app.Klein.run() so that user will be able to specify protocol (ssl, tcp, tcp6), certificate, private key and dh_parameters. This way it will be possible to easily run HTTPS site with Klein. It will also mean HTTP2 support for Klein will work ok with Twisted > 16.3.0. TLS is not formally required for HTTP2 but most client implementations require it.

cc @glyph @hawkowl 