### PR TITLE
Update Python version compatibility listing

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -8,6 +8,9 @@ Klein, a Web Micro-Framework
 .. image:: https://codecov.io/github/twisted/klein/coverage.svg?branch=master
     :target: https://codecov.io/github/twisted/klein?branch=master
     :alt: Code Coverage
+.. image:: https://img.shields.io/pypi/pyversions/klein.svg
+    :target: https://pypi.python.org/pypi/klein
+    :alt: Python Version Compatibility
 
 Klein is a micro-framework for developing production-ready web services with Python.
 It is 'micro' in that it has an incredibly small API similar to `Bottle <http://bottlepy.org/docs/dev/index.html>`_ and `Flask <http://flask.pocoo.org/>`_.

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,6 @@ if __name__ == "__main__":
             'License :: OSI Approved :: MIT License',
             'Operating System :: OS Independent',
             'Programming Language :: Python',
-            'Programming Language :: Python :: 2.6',
             'Programming Language :: Python :: 2.7',
             'Programming Language :: Python :: 3.4',
             'Programming Language :: Python :: 3.5',


### PR DESCRIPTION
The updates released in 16.12 include a change that introduces dict comprehension that is Python 2.7+

This change updates the `setup.py` compatibility listing to suit, and adds a fancy badge to the README to show Python version coverage. (Note the badge shows what the pypi setup.py version includes, so it will only update when the changes are released)