### PR TITLE
Use flake8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -74,7 +74,7 @@ matrix:
     - python: 3.5
       env: TOX_ENV=trial-py35-twtrunk
 
-    - python: 2.7
+    - python: 3.5
       env: TOX_ENV=flake8
     - python: 2.7
       env: TOX_ENV=twistedchecker-diff

--- a/.travis.yml
+++ b/.travis.yml
@@ -57,7 +57,7 @@ matrix:
       env: TOX_ENV=trial-py35-twtrunk
 
     - python: 2.7
-      env: TOX_ENV=pyflakes
+      env: TOX_ENV=flake8
     - python: 2.7
       env: TOX_ENV=twistedchecker-diff
     - python: 2.7

--- a/src/klein/__init__.py
+++ b/src/klein/__init__.py
@@ -8,7 +8,7 @@ from ._version import __version__ as _incremental_version
 # Make it a str, for backwards compatibility
 __version__ = _incremental_version.base()
 
-__author__  = "The Klein contributors (see AUTHORS)"
+__author__ = "The Klein contributors (see AUTHORS)"
 __license__ = "MIT"
 __copyright__ = "Copyright 2016 {0}".format(__author__)
 

--- a/src/klein/__init__.py
+++ b/src/klein/__init__.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import, division
 
-from klein.app import Klein, run, route, resource
 from klein._plating import Plating
+from klein.app import Klein, resource, route, run
 
 from ._version import __version__ as _incremental_version
 

--- a/src/klein/__init__.py
+++ b/src/klein/__init__.py
@@ -5,21 +5,23 @@ from klein._plating import Plating
 
 from ._version import __version__ as _incremental_version
 
+
+__all__ = (
+    "Klein",
+    "Plating",
+    "__author__",
+    "__copyright__",
+    "__license__",
+    "__version__",
+    "resource",
+    "route",
+    "run",
+)
+
+
 # Make it a str, for backwards compatibility
 __version__ = _incremental_version.base()
 
 __author__ = "The Klein contributors (see AUTHORS)"
 __license__ = "MIT"
 __copyright__ = "Copyright 2016 {0}".format(__author__)
-
-__all__ = [
-    'Klein',
-    'Plating',
-    '__author__',
-    '__copyright__',
-    '__license__',
-    '__version__',
-    'resource',
-    'route',
-    'run',
-]

--- a/src/klein/_decorators.py
+++ b/src/klein/_decorators.py
@@ -78,5 +78,3 @@ def originalName(function):
         function = fnext
         fnext = getattr(function, "__original__", None)
     return function.__name__
-
-

--- a/src/klein/_plating.py
+++ b/src/klein/_plating.py
@@ -9,14 +9,12 @@ from json import dumps
 from six import integer_types, text_type
 
 from twisted.internet.defer import inlineCallbacks, returnValue
-from twisted.web.template import TagLoader, Element
 from twisted.web.error import MissingRenderMethod
 from twisted.web.template import Element, TagLoader
 
-
-
-from .app import _call
 from ._decorators import bindable, modified
+from .app import _call
+
 
 def _should_return_json(request):
     """
@@ -123,6 +121,7 @@ class Plating(object):
         """
         def mydecorator(method):
             loader = TagLoader(tags)
+
             @modified("plating route renderer", method, routing)
             @bindable
             @inlineCallbacks

--- a/src/klein/_plating.py
+++ b/src/klein/_plating.py
@@ -7,10 +7,12 @@ Templating wrapper support for Klein.
 from functools import wraps
 from json import dumps
 
-from six import text_type, integer_types
+from six import integer_types, text_type
 
-from twisted.web.template import TagLoader, Element
 from twisted.web.error import MissingRenderMethod
+from twisted.web.template import Element, TagLoader
+
+
 
 def _should_return_json(request):
     """
@@ -39,6 +41,7 @@ def _extra_types(input):
     if isinstance(input, (float,) + integer_types):
         return text_type(input)
     return input
+
 
 
 class PlatedElement(Element):
@@ -78,6 +81,7 @@ class PlatedElement(Element):
             return types[type]
         else:
             raise MissingRenderMethod(self, name)
+
 
 
 class Plating(object):

--- a/src/klein/_plating.py
+++ b/src/klein/_plating.py
@@ -9,7 +9,6 @@ from json import dumps
 from six import integer_types, text_type
 
 from twisted.internet.defer import inlineCallbacks, returnValue
-
 from twisted.web.template import TagLoader, Element
 from twisted.web.error import MissingRenderMethod
 from twisted.web.template import Element, TagLoader

--- a/src/klein/_plating.py
+++ b/src/klein/_plating.py
@@ -92,7 +92,6 @@ class Plating(object):
     def __init__(self, defaults=None, tags=None,
                  presentation_slots=frozenset()):
         """
-        
         """
         self._defaults = {} if defaults is None else defaults
         self._loader = TagLoader(tags)
@@ -100,11 +99,11 @@ class Plating(object):
 
     def routed(self, routing, content_template):
         """
-        
         """
         @wraps(routing)
         def mydecorator(method):
             loader = TagLoader(content_template)
+
             @routing
             @wraps(method)
             def mymethod(request, *args, **kw):
@@ -122,12 +121,12 @@ class Plating(object):
                                       b'text/html; charset=utf-8')
                     data[self.CONTENT] = loader.load()
                     return self._elementify(data)
+
             return method
         return mydecorator
 
     def _elementify(self, to_fill_with):
         """
-        
         """
         slot_data = self._defaults.copy()
         slot_data.update(to_fill_with)
@@ -138,7 +137,6 @@ class Plating(object):
 
     def widgeted(self, function):
         """
-        
         """
         @wraps(function)
         def wrapper(*a, **k):

--- a/src/klein/_version.py
+++ b/src/klein/_version.py
@@ -7,6 +7,6 @@ Provides Klein version information.
 
 from incremental import Version
 
-__all__ = ("__version__")
+__all__ = ("__version__",)
 
 __version__ = Version('Klein', 16, 12, 0)

--- a/src/klein/_version.py
+++ b/src/klein/_version.py
@@ -7,5 +7,6 @@ Provides Klein version information.
 
 from incremental import Version
 
+__all__ = ("__version__")
+
 __version__ = Version('Klein', 16, 12, 0)
-__all__ = ["__version__"]

--- a/src/klein/app.py
+++ b/src/klein/app.py
@@ -17,15 +17,12 @@ except ImportError:
     def iscoroutine(*args, **kwargs):
         return False
 
-from werkzeug.routing import Map, Rule, Submount
-
+from twisted.internet import endpoints, reactor
 from twisted.python import log
 from twisted.python.components import registerAdapter
-
 from twisted.web.iweb import IRenderable
+from twisted.web.server import Request, Site
 from twisted.web.template import renderElement
-from twisted.web.server import Site, Request
-from twisted.internet import reactor, endpoints
 
 try:
     from twisted.internet.defer import ensureDeferred
@@ -33,10 +30,12 @@ except ImportError:
     def ensureDeferred(*args, **kwagrs):
         raise NotImplementedError("Coroutines support requires Twisted>=16.6")
 
+from werkzeug.routing import Map, Rule, Submount
+
 from zope.interface import implementer
 
-from klein.resource import KleinResource
 from klein.interfaces import IKleinRequest
+from klein.resource import KleinResource
 
 
 __all__ = (

--- a/src/klein/app.py
+++ b/src/klein/app.py
@@ -198,13 +198,20 @@ class Klein(object):
 
                 @wraps(f)
                 def branch_f(instance, request, *a, **kw):
-                    IKleinRequest(request).branch_segments = kw.pop('__rest__', '').split('/')
+                    IKleinRequest(request).branch_segments = (
+                        kw.pop('__rest__', '').split('/')
+                    )
                     return _call(instance, f, request, *a, **kw)
 
                 branch_f.segment_count = segment_count
 
                 self._endpoints[branchKwargs['endpoint']] = branch_f
-                self._url_map.add(Rule(url.rstrip('/') + '/' + '<path:__rest__>', *args, **branchKwargs))
+                self._url_map.add(
+                    Rule(
+                        url.rstrip('/') + '/' + '<path:__rest__>',
+                        *args, **branchKwargs
+                    )
+                )
 
             @wraps(f)
             def _f(instance, request, *a, **kw):
@@ -314,7 +321,10 @@ class Klein(object):
         # Try to detect calls using the "simple" @app.handle_error syntax by
         # introspecting the first argument - if it isn't a type which
         # subclasses Exception we assume the simple syntax was used.
-        if not isinstance(f_or_exception, type) or not issubclass(f_or_exception, Exception):
+        if (
+            not isinstance(f_or_exception, type) or
+            not issubclass(f_or_exception, Exception)
+        ):
             return self.handle_errors(Exception)(f_or_exception)
 
         def deco(f):
@@ -325,7 +335,9 @@ class Klein(object):
                     return renderElement(request, r)
                 return r
 
-            self._error_handlers.append(([f_or_exception] + list(additional_exceptions), _f))
+            self._error_handlers.append(
+                ([f_or_exception] + list(additional_exceptions), _f)
+            )
             return _f
 
         return deco
@@ -343,7 +355,8 @@ class Klein(object):
 
         @param host: The hostname or IP address to bind the listening socket
             to.  "0.0.0.0" will allow you to listen on all interfaces, and
-            "127.0.0.1" will allow you to listen on just the loopback interface.
+            "127.0.0.1" will allow you to listen on just the loopback
+            interface.
         @type host: str
 
         @param port: The TCP port to accept HTTP requests on.

--- a/src/klein/app.py
+++ b/src/klein/app.py
@@ -38,7 +38,13 @@ from zope.interface import implementer
 from klein.resource import KleinResource
 from klein.interfaces import IKleinRequest
 
-__all__ = ['Klein', 'run', 'route', 'resource']
+
+__all__ = (
+    "Klein",
+    "run",
+    "route",
+    "resource",
+)
 
 
 def _call(instance, f, *args, **kwargs):

--- a/src/klein/interfaces.py
+++ b/src/klein/interfaces.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import, division
 
-from zope.interface import Interface, Attribute
+from zope.interface import Attribute, Interface
 
 
 class IKleinRequest(Interface):

--- a/src/klein/interfaces.py
+++ b/src/klein/interfaces.py
@@ -7,7 +7,10 @@ class IKleinRequest(Interface):
     branch_segments = Attribute("Segments consumed by a branch route.")
     mapper = Attribute("L{werkzeug.routing.MapAdapter}")
 
-    def url_for(self, endpoint, values=None, method=None, force_external=False, append_unknown=True):
+    def url_for(
+        self, endpoint, values=None, method=None,
+        force_external=False, append_unknown=True,
+    ):
         """
         L{werkzeug.routing.MapAdapter.build}
         """

--- a/src/klein/resource.py
+++ b/src/klein/resource.py
@@ -17,7 +17,10 @@ from klein.interfaces import IKleinRequest
 
 
 
-__all__ = ["KleinResource", "ensure_utf8_bytes"]
+__all__ = (
+    "KleinResource",
+    "ensure_utf8_bytes",
+)
 
 
 

--- a/src/klein/resource.py
+++ b/src/klein/resource.py
@@ -3,11 +3,11 @@
 from __future__ import absolute_import, division
 
 from twisted.internet import defer
-from twisted.python import log, failure
-from twisted.python.compat import unicode, intToBytes
+from twisted.python import failure, log
+from twisted.python.compat import intToBytes, unicode
 from twisted.web import server
 from twisted.web.iweb import IRenderable
-from twisted.web.resource import Resource, IResource, getChildForRequest
+from twisted.web.resource import IResource, Resource, getChildForRequest
 from twisted.web.server import NOT_DONE_YET
 from twisted.web.template import renderElement
 

--- a/src/klein/resource.py
+++ b/src/klein/resource.py
@@ -150,8 +150,9 @@ class KleinResource(Resource):
     def render(self, request):
         # Stuff we need to know for the mapper.
         try:
-            url_scheme, server_name, server_port, path_info, script_name = \
+            url_scheme, server_name, server_port, path_info, script_name = (
                 _extractURLparts(request)
+            )
         except _URLDecodeError as e:
             for what, fail in e.errors:
                 log.err(fail, "Invalid encoding in {what}.".format(what=what))
@@ -243,7 +244,9 @@ class KleinResource(Resource):
                     resp = he.get_response({})
 
                     for header, value in resp.headers:
-                        request.setHeader(ensure_utf8_bytes(header), ensure_utf8_bytes(value))
+                        request.setHeader(
+                            ensure_utf8_bytes(header), ensure_utf8_bytes(value)
+                        )
 
                     return ensure_utf8_bytes(he.get_body({}))
                 else:
@@ -252,7 +255,8 @@ class KleinResource(Resource):
 
             error_handler = error_handlers[0]
 
-            # Each error handler is a tuple of (list_of_exception_types, handler_fn)
+            # Each error handler is a tuple of
+            # (list_of_exception_types, handler_fn)
             if failure.check(*error_handler[0]):
                 d = defer.maybeDeferred(self._app.execute_error_handler,
                                         error_handler[1],
@@ -262,7 +266,6 @@ class KleinResource(Resource):
                 return d.addErrback(processing_failed, error_handlers[1:])
 
             return processing_failed(failure, error_handlers[1:])
-
 
         d.addErrback(processing_failed, self._app._error_handlers)
 
@@ -277,6 +280,7 @@ class KleinResource(Resource):
                 if not request_finished[0]:
                     request.finish()
 
-        d.addCallback(write_response).addErrback(log.err, _why="Unhandled Error writing response")
+        d.addCallback(write_response)
+        d.addErrback(log.err, _why="Unhandled Error writing response")
 
         return server.NOT_DONE_YET

--- a/src/klein/test/py3_test_resource.py
+++ b/src/klein/test/py3_test_resource.py
@@ -4,7 +4,7 @@ from klein import Klein
 from klein.resource import KleinResource
 from klein.test.util import TestCase
 
-from .test_resource import LeafResource, requestMock, _render
+from .test_resource import LeafResource, _render, requestMock
 
 
 class PY3KleinResourceTests(TestCase):

--- a/src/klein/test/test_app.py
+++ b/src/klein/test/test_app.py
@@ -1,12 +1,11 @@
 from __future__ import absolute_import, division
 
-from twisted.trial import unittest
-
 import sys
 
 from mock import Mock, patch
 
 from twisted.python.components import registerAdapter
+from twisted.trial import unittest
 
 from klein import Klein
 from klein.app import KleinRequest

--- a/src/klein/test/test_app.py
+++ b/src/klein/test/test_app.py
@@ -101,8 +101,8 @@ class KleinTestCase(unittest.TestCase):
 
     def test_stackedRoute(self):
         """
-        L{Klein.route} can be stacked to create multiple endpoints of
-        a single function.
+        L{Klein.route} can be stacked to create multiple endpoints of a single
+        function.
         """
         app = Klein()
 
@@ -115,10 +115,14 @@ class KleinTestCase(unittest.TestCase):
 
         c = app.url_map.bind("foo")
         self.assertEqual(c.match("/foo"), ("foobar", {}))
-        self.assertEqual(app.execute_endpoint("foobar", DummyRequest(1)), "foobar")
+        self.assertEqual(
+            app.execute_endpoint("foobar", DummyRequest(1)), "foobar"
+        )
 
         self.assertEqual(c.match("/bar"), ("bar", {}))
-        self.assertEqual(app.execute_endpoint("bar", DummyRequest(2)), "foobar")
+        self.assertEqual(
+            app.execute_endpoint("bar", DummyRequest(2)), "foobar"
+        )
 
 
     def test_branchRoute(self):
@@ -150,6 +154,7 @@ class KleinTestCase(unittest.TestCase):
         is defined as a class variable.
         """
         bar_calls = []
+
         class Foo(object):
             app = Klein()
 
@@ -161,7 +166,9 @@ class KleinTestCase(unittest.TestCase):
         foo = Foo()
         c = foo.app.url_map.bind("bar")
         self.assertEqual(c.match("/bar"), ("bar", {}))
-        self.assertEquals(foo.app.execute_endpoint("bar", DummyRequest(1)), "bar")
+        self.assertEquals(
+            foo.app.execute_endpoint("bar", DummyRequest(1)), "bar"
+        )
 
         self.assertEqual(bar_calls, [(foo, DummyRequest(1))])
 

--- a/src/klein/test/test_app.py
+++ b/src/klein/test/test_app.py
@@ -8,10 +8,10 @@ from twisted.python.components import registerAdapter
 from twisted.trial import unittest
 
 from klein import Klein
+from klein._decorators import bindable, modified, originalName
 from klein.app import KleinRequest
 from klein.interfaces import IKleinRequest
 from klein.test.util import EqualityTestsMixin
-from klein._decorators import bindable, originalName, modified
 
 
 
@@ -163,17 +163,22 @@ class KleinTestCase(unittest.TestCase):
         """
         k = Klein()
         calls = []
+
         @k.route("/test")
         @bindable
         def method(*args):
             calls.append(args)
             return 7
+
         req = object()
         k.execute_endpoint("method", req)
+
         class BoundTo(object):
             app = k
+
         b = BoundTo()
         b.app.execute_endpoint("method", req)
+
         self.assertEquals(calls, [(None, req), (b, req)])
         self.assertEqual(originalName(method), "method")
 
@@ -186,11 +191,14 @@ class KleinTestCase(unittest.TestCase):
         def annotate(decoratee):
             decoratee.supersized = True
             return decoratee
+
         def add(a, b):
             return a + b
+
         @modified("supersizer", add, modifier=annotate)
         def megaAdd(a, b):
-            return add(a*1000, b*10000)
+            return add(a * 1000, b * 10000)
+
         self.assertEqual(megaAdd.supersized, True)
         self.assertEqual(add.supersized, True)
         self.assertIn("supersizer for add", str(megaAdd))
@@ -214,11 +222,11 @@ class KleinTestCase(unittest.TestCase):
 
         foo = Foo()
         c = foo.app.url_map.bind("bar")
+
         self.assertEqual(c.match("/bar"), ("bar", {}))
-        self.assertEquals(
+        self.assertEqual(
             foo.app.execute_endpoint("bar", DummyRequest(1)), "bar"
         )
-
         self.assertEqual(bar_calls, [(foo, DummyRequest(1))])
 
 
@@ -249,6 +257,7 @@ class KleinTestCase(unittest.TestCase):
 
         foo_1_app.execute_endpoint('bar', dr1)
         foo_2_app.execute_endpoint('bar', dr2)
+
         self.assertEqual(foo_1.bar_calls, [(foo_1, dr1)])
         self.assertEqual(foo_2.bar_calls, [(foo_2, dr2)])
 
@@ -280,6 +289,7 @@ class KleinTestCase(unittest.TestCase):
 
         foo_1_app.execute_endpoint('bar_branch', dr1)
         foo_2_app.execute_endpoint('bar_branch', dr2)
+
         self.assertEqual(foo_1.bar_calls, [(foo_1, dr1)])
         self.assertEqual(foo_2.bar_calls, [(foo_2, dr2)])
 

--- a/src/klein/test/test_plating.py
+++ b/src/klein/test/test_plating.py
@@ -81,6 +81,7 @@ class PlatingTests(TestCase):
             return {"ok": "test-data-present"}
 
         request, written = self.get(b"/")
+
         self.assertIn(b'<span>test-data-present</span>', written)
         self.assertIn(b'<title>default title unchanged</title>', written)
 
@@ -91,15 +92,18 @@ class PlatingTests(TestCase):
         """
         class AppObj(object):
             app = Klein()
+
             def __init__(self, x):
                 self.x = x
-            @page.routed(app.route("/"),
-                         tags.span(slot('yeah')))
+
+            @page.routed(app.route("/"), tags.span(slot('yeah')))
             def plateInstance(self, request):
                 return {"yeah": "test-instance-data-" + self.x}
+
         obj = AppObj("confirmed")
         self.kr = obj.app.resource()
         request, written = self.get(b"/")
+
         self.assertIn(b'<span>test-instance-data-confirmed</span>', written)
         self.assertIn(b'<title>default title unchanged</title>', written)
 
@@ -142,6 +146,7 @@ class PlatingTests(TestCase):
                     "anLong": 0x10000000000000001}
 
         request, written = self.get(b"/")
+
         self.assertIn(b"<span>7</span>", written)
         self.assertIn(b"<i>3.2</i>", written)
         self.assertIn(b"<b>18446744073709551617</b>", written)
@@ -159,6 +164,7 @@ class PlatingTests(TestCase):
             return {"subplating": [1, 2, 3]}
 
         request, written = self.get(b"/")
+
         self.assertIn(b'<ul><li>1</li><li>2</li><li>3</li></ul>', written)
         self.assertIn(b'<title>default title unchanged</title>', written)
 
@@ -174,6 +180,7 @@ class PlatingTests(TestCase):
             return {"widget": enwidget.widget(3, 4)}
 
         request, written = self.get(b"/")
+
         self.assertIn(b"<span>a: 3</span>", written)
         self.assertIn(b"<span>b: 4</span>", written)
 
@@ -221,6 +228,7 @@ class PlatingTests(TestCase):
         result_one, result_two, result_three = plateMe(
             None, exact_one, exact_two, three=exact_three
         )
+
         self.assertIdentical(result_one, exact_one)
         self.assertIdentical(result_two, exact_two)
         self.assertIdentical(result_three, exact_three)
@@ -240,6 +248,7 @@ class PlatingTests(TestCase):
             return {"title": "uninteresting", "data": "interesting"}
 
         request, written = self.get(b"/?json=1")
+
         self.assertEqual(json.loads(written.decode("utf-8")),
                          {"data": "interesting"})
 

--- a/src/klein/test/test_plating.py
+++ b/src/klein/test/test_plating.py
@@ -253,9 +253,9 @@ class PlatingTests(TestCase):
         """
         from klein._plating import json_serialize
 
-        class reprish(object):
+        class Reprish(object):
             def __repr__(self):
                 return '<blub>'
 
-        te = self.assertRaises(TypeError, json_serialize, {"an": reprish()})
+        te = self.assertRaises(TypeError, json_serialize, {"an": Reprish()})
         self.assertIn("<blub>", str(te))

--- a/src/klein/test/test_plating.py
+++ b/src/klein/test/test_plating.py
@@ -8,13 +8,12 @@ from __future__ import (
 
 import json
 
-from klein import Plating
-from twisted.web.template import tags, slot
 from twisted.web.error import FlattenerError, MissingRenderMethod
+from twisted.web.template import slot, tags
 
-from klein.test.test_resource import requestMock, _render
+from klein import Klein, Plating
+from klein.test.test_resource import _render, requestMock
 from klein.test.util import TestCase
-from klein import Klein
 
 page = Plating(
     defaults={

--- a/src/klein/test/test_resource.py
+++ b/src/klein/test/test_resource.py
@@ -62,7 +62,7 @@ def requestMock(path, method=b"GET", host=b"localhost", port=8080,
 
     def registerProducer(producer, streaming):
         request.producer = producer
-        for x in range(2):
+        for _ in range(2):
             if request.producer:
                 request.producer.resumeProducing()
 

--- a/src/klein/test/test_resource.py
+++ b/src/klein/test/test_resource.py
@@ -1,33 +1,31 @@
 from __future__ import absolute_import, division
 
 import os
-
 from io import BytesIO
 
-from six.moves.urllib.parse import parse_qs
 from mock import Mock, call
 
-from twisted.internet.defer import succeed, Deferred, fail, CancelledError
+from six.moves.urllib.parse import parse_qs
+
+from twisted.internet.defer import CancelledError, Deferred, fail, succeed
 from twisted.internet.error import ConnectionLost
 from twisted.internet.unix import Server
+from twisted.python.compat import _PY3, unicode
 from twisted.web import server
 from twisted.web.http_headers import Headers
 from twisted.web.resource import Resource
 from twisted.web.static import File
 from twisted.web.template import Element, XMLString, renderer
 from twisted.web.test.test_web import DummyChannel
-from twisted.python.compat import unicode, _PY3
+
 from werkzeug.exceptions import NotFound
 
 from klein import Klein
 from klein.interfaces import IKleinRequest
 from klein.resource import (
-    KleinResource,
-    _URLDecodeError,
-    _extractURLparts,
-    ensure_utf8_bytes,
+    KleinResource, _URLDecodeError, _extractURLparts, ensure_utf8_bytes
 )
-from klein.test.util import TestCase, EqualityTestsMixin
+from klein.test.util import EqualityTestsMixin, TestCase
 
 
 def requestMock(path, method=b"GET", host=b"localhost", port=8080,

--- a/src/klein/test/test_resource.py
+++ b/src/klein/test/test_resource.py
@@ -119,7 +119,7 @@ def _render(resource, request, notifyFinish=True):
         else:
             return request.notifyFinish()
     else:
-        raise ValueError("Unexpected return value: %r" % (result,))
+        raise ValueError("Unexpected return value: {!r}".format(result))
 
 
 class SimpleElement(Element):
@@ -251,8 +251,10 @@ class KleinResourceTests(TestCase):
         _pawn = object()
         result = getattr(deferred, 'result', _pawn)
         if result != _pawn:
-            self.fail("Expected deferred not to have fired, "
-                      "but it has: %r" % (deferred,))
+            self.fail(
+                "Expected deferred not to have fired, but it has: {!r}"
+                .format(deferred)
+            )
 
 
     def test_simplePost(self):

--- a/src/klein/test/test_resource.py
+++ b/src/klein/test/test_resource.py
@@ -1096,6 +1096,7 @@ class KleinResourceTests(TestCase):
 
     def test_subroutedBranch(self):
         subapp = Klein()
+
         @subapp.route('/foo')
         def foo(request):
             return b'foo'
@@ -1118,7 +1119,8 @@ class KleinResourceTests(TestCase):
 
         @app.route('/alias', alias=True)
         @app.route('/real')
-        def real(req): return b'42'
+        def real(req):
+            return b'42'
 
         request = requestMock(b'/real')
         d = _render(self.kr, request)
@@ -1131,7 +1133,9 @@ class KleinResourceTests(TestCase):
         request.setResponseCode.assert_called_with(301)
 
         actual_length = len(request.getWrittenData())
-        reported_length = int(request.responseHeaders.getRawHeaders(b'content-length')[0])
+        reported_length = int(
+            request.responseHeaders.getRawHeaders(b'content-length')[0]
+        )
         self.assertEqual(reported_length, actual_length)
 
 
@@ -1143,8 +1147,9 @@ class ExtractURLpartsTests(TestCase):
         """
         Returns the correct types.
         """
-        url_scheme, server_name, server_port, path_info, script_name = \
+        url_scheme, server_name, server_port, path_info, script_name = (
             _extractURLparts(requestMock(b"/f\xc3\xb6\xc3\xb6"))
+        )
 
         self.assertIsInstance(url_scheme, unicode)
         self.assertIsInstance(server_name, unicode)

--- a/src/klein/test/test_resource.py
+++ b/src/klein/test/test_resource.py
@@ -123,9 +123,10 @@ def _render(resource, request, notifyFinish=True):
 
 
 class SimpleElement(Element):
-    loader = XMLString("""
-    <h1 xmlns:t="http://twistedmatrix.com/ns/twisted.web.template/0.1" t:render="name" />
-    """)
+    loader = XMLString(
+        '<h1 xmlns:t="http://twistedmatrix.com/ns/twisted.web.template/0.1" '
+        't:render="name" />'
+    )
 
     def __init__(self, name):
         self._name = name
@@ -203,17 +204,21 @@ class KleinResourceEqualityTests(TestCase, EqualityTestsMixin):
     """
     class _One(object):
         oneKlein = Klein()
+
         @oneKlein.route("/foo")
         def foo(self):
             pass
+
     _one = _One()
 
 
     class _Another(object):
         anotherKlein = Klein()
+
         @anotherKlein.route("/bar")
         def bar(self):
             pass
+
     _another = _Another()
 
 
@@ -430,8 +435,7 @@ class KleinResourceTests(TestCase):
         d = _render(self.kr, request)
 
         self.assertFired(d)
-        self.assertEqual(request.getWrittenData(),
-                b"I am a leaf in the wind.")
+        self.assertEqual(request.getWrittenData(), b"I am a leaf in the wind.")
 
 
     def test_childResourceRendering(self):
@@ -445,8 +449,9 @@ class KleinResourceTests(TestCase):
         d = _render(self.kr, request)
 
         self.assertFired(d)
-        self.assertEqual(request.getWrittenData(),
-                b"I'm a child named betty!")
+        self.assertEqual(
+            request.getWrittenData(), b"I'm a child named betty!"
+        )
 
 
     def test_childrenResourceRendering(self):
@@ -482,9 +487,10 @@ class KleinResourceTests(TestCase):
 
         d = _render(self.kr, request, notifyFinish=False)
 
-        self.assertNotEqual(request.getWrittenData(), b"abcd", "The full "
-                            "response should not have been written at this "
-                            "point.")
+        self.assertNotEqual(
+            request.getWrittenData(), b"abcd",
+            "The full response should not have been written at this point."
+        )
 
         while request.producer:
             request.producer.resumeProducing()
@@ -540,7 +546,11 @@ class KleinResourceTests(TestCase):
 
     def test_staticRoot(self):
         app = self.app
+
         request = requestMock(b"/__init__.py")
+        expected = open(
+            os.path.join(os.path.dirname(__file__), "__init__.py"), 'rb'
+        ).read()
 
         @app.route("/", branch=True)
         def root(request):
@@ -549,10 +559,7 @@ class KleinResourceTests(TestCase):
         d = _render(self.kr, request)
 
         self.assertFired(d)
-        self.assertEqual(request.getWrittenData(),
-            open(
-                os.path.join(
-                    os.path.dirname(__file__), "__init__.py"), 'rb').read())
+        self.assertEqual(request.getWrittenData(), expected)
         self.assertEqual(request.finishCount, 1)
 
 
@@ -560,6 +567,9 @@ class KleinResourceTests(TestCase):
         app = self.app
 
         request = requestMock(b"/static/__init__.py")
+        expected = open(
+            os.path.join(os.path.dirname(__file__), "__init__.py"), 'rb'
+        ).read()
 
         @app.route("/static/", branch=True)
         def root(request):
@@ -568,10 +578,7 @@ class KleinResourceTests(TestCase):
         d = _render(self.kr, request)
 
         self.assertFired(d)
-        self.assertEqual(request.getWrittenData(),
-            open(
-                os.path.join(
-                    os.path.dirname(__file__), "__init__.py"), 'rb').read())
+        self.assertEqual(request.getWrittenData(), expected)
         self.assertEqual(request.writeCount, 1)
         self.assertEqual(request.finishCount, 1)
 
@@ -603,10 +610,11 @@ class KleinResourceTests(TestCase):
 
         self.assertFired(d)
         self.assertEqual(request.setHeader.call_count, 3)
-        request.setHeader.assert_has_calls(
-            [call(b'Content-Type', b'text/html; charset=utf-8'),
-             call(b'Content-Length', b'259'),
-             call(b'Location', b'http://localhost:8080/foo/')])
+        request.setHeader.assert_has_calls([
+            call(b'Content-Type', b'text/html; charset=utf-8'),
+            call(b'Content-Length', b'259'),
+            call(b'Location', b'http://localhost:8080/foo/')
+        ])
 
     def test_methodNotAllowed(self):
         app = self.app
@@ -665,8 +673,7 @@ class KleinResourceTests(TestCase):
         d = _render(self.kr, request)
 
         self.assertFired(d)
-        self.assertEqual(str(request_url[0]),
-            "http://localhost:8080/foo/bar")
+        self.assertEqual(str(request_url[0]), "http://localhost:8080/foo/bar")
         self.assertEqual(request.getWrittenData(), b'foo')
         self.assertEqual(request.code, 200)
 
@@ -684,8 +691,9 @@ class KleinResourceTests(TestCase):
         d = _render(self.kr, request)
 
         self.assertFired(d)
-        self.assertEqual(str(request_url[0]),
-            'http://localhost:8080/egg/chicken')
+        self.assertEqual(
+            str(request_url[0]), 'http://localhost:8080/egg/chicken'
+        )
 
     def test_URLPath_root(self):
         app = self.app
@@ -722,8 +730,9 @@ class KleinResourceTests(TestCase):
         d = _render(self.kr, request)
 
         self.assertFired(d)
-        self.assertEqual(str(request_url[0]),
-            'http://localhost:8080/resource/foo')
+        self.assertEqual(
+            str(request_url[0]), 'http://localhost:8080/resource/foo'
+        )
 
     def test_handlerRaises(self):
         app = self.app
@@ -978,8 +987,9 @@ class KleinResourceTests(TestCase):
         @app.route("/foo/<int:bar>")
         def foo(request, bar):
             krequest = IKleinRequest(request)
-            relative_url[0] = krequest.url_for('foo', {'bar': bar + 1},
-                force_external=True)
+            relative_url[0] = krequest.url_for(
+                'foo', {'bar': bar + 1}, force_external=True
+            )
 
         d = _render(self.kr, request)
 
@@ -1163,7 +1173,9 @@ class ExtractURLpartsTests(TestCase):
         server_mock = Mock(Server)
         server_mock.getRequestHostname = u'/var/run/twisted.socket'
         request.host = server_mock
-        url_scheme, server_name, server_port, path_info, script_name = _extractURLparts(request)
+        (
+            url_scheme, server_name, server_port, path_info, script_name
+        ) = _extractURLparts(request)
 
         self.assertIsInstance(url_scheme, unicode)
         self.assertIsInstance(server_name, unicode)

--- a/src/klein/test/util.py
+++ b/src/klein/test/util.py
@@ -15,42 +15,58 @@ if twisted.version < Version('twisted', 13, 1, 0):
         def successResultOf(self, deferred):
             result = []
             deferred.addBoth(result.append)
+
             if not result:
                 self.fail(
-                    "Success result expected on %r, found no result instead" % (
-                        deferred,))
-            elif isinstance(result[0], failure.Failure):
+                    "Success result expected on {!r}, found no result instead"
+                    .format(deferred)
+                )
+
+            if isinstance(result[0], failure.Failure):
                 self.fail(
-                    "Success result expected on %r, "
-                    "found failure result instead:\n%s" % (
-                        deferred, result[0].getTraceback()))
-            else:
-                return result[0]
+                    "Success result expected on {!r}, "
+                    "found failure result instead:\n{}"
+                    .format(deferred, result[0].getTraceback())
+                )
+
+            return result[0]
 
         def failureResultOf(self, deferred, *expectedExceptionTypes):
             result = []
             deferred.addBoth(result.append)
+
             if not result:
                 self.fail(
-                    "Failure result expected on %r, found no result instead" % (
-                        deferred,))
-            elif not isinstance(result[0], failure.Failure):
+                    "Failure result expected on {!r}, found no result instead"
+                    .format(deferred)
+                )
+
+            if not isinstance(result[0], failure.Failure):
                 self.fail(
-                    "Failure result expected on %r, "
-                    "found success result (%r) instead" % (deferred, result[0]))
-            elif (expectedExceptionTypes and
-                  not result[0].check(*expectedExceptionTypes)):
+                    "Failure result expected on {!r}, "
+                    "found success result ({!r}) instead"
+                    .format(deferred, result[0])
+                )
+
+            if (
+                expectedExceptionTypes and
+                not result[0].check(*expectedExceptionTypes)
+            ):
                 expectedString = " or ".join([
-                    '.'.join((t.__module__, t.__name__)) for t in
-                    expectedExceptionTypes])
+                    '.'.join((t.__module__, t.__name__))
+                    for t in expectedExceptionTypes
+                ])
 
                 self.fail(
-                    "Failure of type (%s) expected on %r, "
-                    "found type %r instead: %s" % (
+                    "Failure of type ({}) expected on {!r}, "
+                    "found type {!r} instead: {}"
+                    .format(
                         expectedString, deferred, result[0].type,
-                        result[0].getTraceback()))
-            else:
-                return result[0]
+                        result[0].getTraceback()
+                    )
+                )
+
+            return result[0]
 
 
 

--- a/src/klein/test/util.py
+++ b/src/klein/test/util.py
@@ -3,10 +3,9 @@ Shared tools for Klein's test suite.
 """
 
 import twisted
-
-from twisted.trial.unittest import TestCase
 from twisted.python import failure
 from twisted.python.versions import Version
+from twisted.trial.unittest import TestCase
 
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -79,7 +79,7 @@ ignore =
 # flake8-import-order: local module name space
 application-import-names = sample_klein_app
 
-select = E,F,W,C,N
+select = C,E,F,N,S,W
 
 ##
 # Run twistedchecker

--- a/tox.ini
+++ b/tox.ini
@@ -50,6 +50,7 @@ skip_install = True
 
 deps =
     flake8
+    flake8_docstrings
 
 basepython = python3.5
 

--- a/tox.ini
+++ b/tox.ini
@@ -52,6 +52,7 @@ deps =
     flake8
     flake8_docstrings
     flake8-pep3101
+    pep8-naming
 
 basepython = python3.5
 

--- a/tox.ini
+++ b/tox.ini
@@ -68,6 +68,10 @@ commands =
 
 select = B,C,E,F,I,N,S,W
 
+disable-noqa = True
+show-source  = True
+doctests     = True
+
 # Codes: http://flake8.pycqa.org/en/latest/user/error-codes.html
 ignore =
     # too many blank lines

--- a/tox.ini
+++ b/tox.ini
@@ -51,6 +51,7 @@ skip_install = True
 deps =
     flake8
     flake8_docstrings
+    flake8-pep3101
 
 basepython = python3.5
 

--- a/tox.ini
+++ b/tox.ini
@@ -53,6 +53,7 @@ deps =
     flake8_docstrings
     flake8-pep3101
     pep8-naming
+    flake8-import-order
 
 basepython = python3.5
 
@@ -77,9 +78,9 @@ ignore =
     N806,
 
 # flake8-import-order: local module name space
-application-import-names = sample_klein_app
+application-import-names = klein
 
-select = C,E,F,N,S,W
+select = C,E,F,I,N,S,W
 
 ##
 # Run twistedchecker

--- a/tox.ini
+++ b/tox.ini
@@ -65,9 +65,21 @@ commands =
 
 # Codes: http://flake8.pycqa.org/en/latest/user/error-codes.html
 ignore =
+    # too many blank lines
     E302,
+    # too many blank lines
     E303,
+    # function name should be lowercase
+    N802,
+    # argument name should be lowercase
+    N803,
+    # variable in function should be lowercase
+    N806,
 
+# flake8-import-order: local module name space
+application-import-names = sample_klein_app
+
+select = E,F,W,C,N
 
 ##
 # Run twistedchecker

--- a/tox.ini
+++ b/tox.ini
@@ -50,6 +50,7 @@ skip_install = True
 
 deps =
     flake8
+    flake8-bugbear
     flake8_docstrings
     flake8-import-order
     flake8-pep3101
@@ -65,7 +66,7 @@ commands =
 
 [flake8]
 
-select = C,E,F,I,N,S,W
+select = B,C,E,F,I,N,S,W
 
 # Codes: http://flake8.pycqa.org/en/latest/user/error-codes.html
 ignore =

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 
 envlist =
-    pyflakes, twistedchecker-diff
+    flake8, twistedchecker-diff
     trial-py{27,py,33,34,35,36}-tw{132,140,150,155,166,current,trunk}
     docs, docs-linkcheck
 
@@ -41,24 +41,33 @@ commands =
 
 
 ##
-# Run pyflakes
+# Run flake8
 ##
 
-[testenv:pyflakes]
+[testenv:flake8]
 
 skip_install = True
 
-deps = pyflakes
+deps =
+    flake8
 
 basepython = python3.5
 
 commands =
     {toxinidir}/.travis/environment
-    pyflakes src/klein
+    flake8 {posargs:src/klein}
+
+
+[flake8]
+
+# Codes: http://flake8.pycqa.org/en/latest/user/error-codes.html
+ignore =
+    E302,
+    E303,
 
 
 ##
-# Run twistedchecker on full project
+# Run twistedchecker
 ##
 
 [testenv:twistedchecker]
@@ -69,7 +78,7 @@ basepython = python2.7
 
 commands =
     {toxinidir}/.travis/environment
-    twistedchecker klein
+    twistedchecker {posargs:klein}
 
 
 ##
@@ -86,7 +95,7 @@ basepython = python2.7
 
 commands =
     {toxinidir}/.travis/environment
-    {toxinidir}/.travis/twistedchecker-diff klein
+    {toxinidir}/.travis/twistedchecker-diff {posargs:klein}
 
 
 ##

--- a/tox.ini
+++ b/tox.ini
@@ -51,9 +51,10 @@ skip_install = True
 deps =
     flake8
     flake8_docstrings
+    flake8-import-order
     flake8-pep3101
     pep8-naming
-    flake8-import-order
+    mccabe
 
 basepython = python3.5
 
@@ -63,6 +64,8 @@ commands =
 
 
 [flake8]
+
+select = C,E,F,I,N,S,W
 
 # Codes: http://flake8.pycqa.org/en/latest/user/error-codes.html
 ignore =
@@ -80,7 +83,9 @@ ignore =
 # flake8-import-order: local module name space
 application-import-names = klein
 
-select = C,E,F,I,N,S,W
+# McCabe complexity checker
+max-complexity = 21
+
 
 ##
 # Run twistedchecker


### PR DESCRIPTION
This PR is for replacing our usage of `pyflakes` with `flake8` (which includes `pyflakes`), which will allow for more linting options long term, and since we can't easily make good use `twistedchecker` right now, it's a way to dial in some checks now.