### PR TITLE
Fixed usage of branch=True under subroute()

### DIFF
--- a/src/klein/app.py
+++ b/src/klein/app.py
@@ -79,6 +79,8 @@ class Klein(object):
 
     _bound_klein_instances = weakref.WeakKeyDictionary()
 
+    _subroute_segments = 0
+
     def __init__(self):
         self._url_map = Map()
         self._endpoints = {}
@@ -163,6 +165,14 @@ class Klein(object):
         return k
 
 
+    @staticmethod
+    def _segments_in_url(url):
+        segment_count = url.count('/')
+        if url.endswith('/'):
+            segment_count -= 1
+        return segment_count
+
+
     def route(self, url, *args, **kwargs):
         """
         Add a new handler for C{url} passing C{args} and C{kwargs} directly to
@@ -186,9 +196,7 @@ class Klein(object):
 
         @returns: decorated handler function.
         """
-        segment_count = url.count('/')
-        if url.endswith('/'):
-            segment_count -= 1
+        segment_count = self._segments_in_url(url) + self._subroute_segments
 
         def deco(f):
             kwargs.setdefault('endpoint', f.__name__)
@@ -248,17 +256,21 @@ class Klein(object):
 
         _map_before_submount = self._url_map
 
+        segments = self._segments_in_url(prefix)
+
         submount_map = namedtuple(
             'submount', ['rules', 'add'])(
                 [], lambda r: submount_map.rules.append(r))
 
         try:
             self._url_map = submount_map
+            self._subroute_segments += segments
             yield self
             _map_before_submount.add(
                 Submount(prefix, submount_map.rules))
         finally:
             self._url_map = _map_before_submount
+            self._subroute_segments -= segments
 
 
     def handle_errors(self, f_or_exception, *additional_exceptions):

--- a/src/klein/test/test_resource.py
+++ b/src/klein/test/test_resource.py
@@ -1083,6 +1083,26 @@ class KleinResourceTests(TestCase):
     else:
         test_urlDecodeErrorReprPy3.skip = "Only works on Py3"
 
+
+    def test_subroutedBranch(self):
+        subapp = Klein()
+        @subapp.route('/foo')
+        def foo(request):
+            return b'foo'
+
+        app = self.app
+        with app.subroute('/sub') as app:
+            @app.route('/app', branch=True)
+            def subapp_endpoint(request):
+                return subapp.resource()
+
+        request = requestMock(b'/sub/app/foo')
+        d = _render(self.kr, request)
+
+        self.assertFired(d)
+        self.assertEqual(request.getWrittenData(), b'foo')
+
+
 class ExtractURLpartsTests(TestCase):
     """
     Tests for L{klein.resource._extractURLparts}.


### PR DESCRIPTION
Endpoint's `segment_count` attribute gets wrong value when route is created under `subroute()` context. Sub-apps or other routes with `branch=True` are failing to dispatch due to this.

Quick demo:
```python
class SubApp:
    router = Klein()
    @router.route('/hello')
    def hello(self, request):
        return b'hello world'

app = Klein()
with app.subroute('/sub'):
    @app.route('/app', branch=True)
    def sub_app(request):
        return SubApp().router.resource()
```

Request to `/sub/app/hello` fails with 404 because sub-apps' router is getting `/app/hello` url for handling instead of `/hello`.

This PR is fixing this by increasing `endpoint.segment_count` inside `subroute()` context by the amount of segments in subroute prefix.