### PR TITLE
Fix inconsistent Content-Length for redirect responses generated by Werkzeug

### DIFF
--- a/src/klein/resource.py
+++ b/src/klein/resource.py
@@ -245,7 +245,7 @@ class KleinResource(Resource):
                     for header, value in resp.headers:
                         request.setHeader(ensure_utf8_bytes(header), ensure_utf8_bytes(value))
 
-                    return ensure_utf8_bytes(he.get_body({}))
+                    return ensure_utf8_bytes(b''.join(resp.iter_encoded()))
                 else:
                     request.processingFailed(failure)
                     return

--- a/src/klein/test/test_resource.py
+++ b/src/klein/test/test_resource.py
@@ -1103,6 +1103,23 @@ class KleinResourceTests(TestCase):
         self.assertEqual(request.getWrittenData(), b'foo')
 
 
+    def test_correctContentLengthForRequestRedirect(self):
+        app = self.app
+
+        @app.route('/alias', alias=True)
+        @app.route('/real')
+        def real(req): return 'real'
+
+        request = requestMock(b'/alias')
+        d = _render(self.kr, request)
+        self.assertFired(d)
+        request.setResponseCode.assert_called_with(301)
+
+        actual_length = len(request.getWrittenData())
+        reported_length = int(request.responseHeaders.getRawHeaders(b'content-length')[0])
+        self.assertEqual(reported_length, actual_length)
+
+
 class ExtractURLpartsTests(TestCase):
     """
     Tests for L{klein.resource._extractURLparts}.

--- a/src/klein/test/test_resource.py
+++ b/src/klein/test/test_resource.py
@@ -1108,7 +1108,12 @@ class KleinResourceTests(TestCase):
 
         @app.route('/alias', alias=True)
         @app.route('/real')
-        def real(req): return 'real'
+        def real(req): return b'42'
+
+        request = requestMock(b'/real')
+        d = _render(self.kr, request)
+        self.assertFired(d)
+        self.assertEqual(request.getWrittenData(), b'42')
 
         request = requestMock(b'/alias')
         d = _render(self.kr, request)


### PR DESCRIPTION
When `KleinResource` encounters Werkzeug's `HTTPException`, it takes response headers from `HTTPException.get_response({}).headers` and body from `HTTPException.get_body({})`. It is fine for most `HTTPException`s, but not for [`RequestRedirect`](https://github.com/pallets/werkzeug/blob/master/werkzeug/routing.py#L223) which overrides `get_response()` without overriding `get_body()`. This results with response whose body has different length than in `Content-Length` header.

This can be noticed when using `route(..., alias=True)` or when Werkzeug makes redirect to append trailing slash to the URL because `route()` was specified with trailing slash.