### PR TITLE
Klein.url_for() for reverse URL mapping

### DIFF
--- a/src/klein/__init__.py
+++ b/src/klein/__init__.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import, division
 
-from klein.app import Klein, run, route, resource
+from klein.app import Klein, run, route, resource, url_for
 from klein._plating import Plating
 
 from ._version import __version__ as _incremental_version
@@ -22,4 +22,5 @@ __all__ = [
     'resource',
     'route',
     'run',
+    'url_for'
 ]

--- a/src/klein/__init__.py
+++ b/src/klein/__init__.py
@@ -1,7 +1,8 @@
 from __future__ import absolute_import, division
 
 from klein._plating import Plating
-from klein.app import Klein, handle_errors, resource, route, run, url_for
+from klein.app import Klein, handle_errors, resource, route, run, urlFor, \
+    url_for
 
 from ._version import __version__ as _incremental_version
 
@@ -17,6 +18,7 @@ __all__ = (
     "route",
     "run",
     "handle_errors",
+    "urlFor",
     "url_for",
 )
 

--- a/src/klein/app.py
+++ b/src/klein/app.py
@@ -356,6 +356,9 @@ class Klein(object):
                 force_external=False, append_unknown=True):
         host = request.getHeader(b'host')
         if host is None:
+            if force_external:
+                raise ValueError("Cannot build external URL if request"
+                                 " doesn't contain Host header")
             host = b''
         return self.url_map.bind(host).build(endpoint, values, method,
                                              force_external, append_unknown)

--- a/src/klein/app.py
+++ b/src/klein/app.py
@@ -345,7 +345,7 @@ class Klein(object):
 
     def url_for(self, request, endpoint, values = None, method = None, force_external = False, append_unknown = True):
         host = request.getHeader(b'host')
-        if not host:
+        if host is None:
             host = b''
         return self.url_map.bind(host).build(endpoint, values, method, force_external, append_unknown)
 

--- a/src/klein/app.py
+++ b/src/klein/app.py
@@ -352,8 +352,8 @@ class Klein(object):
         return deco
 
 
-    def url_for(self, request, endpoint, values=None, method=None,
-                force_external=False, append_unknown=True):
+    def urlFor(self, request, endpoint, values=None, method=None,
+               force_external=False, append_unknown=True):
         host = request.getHeader(b'host')
         if host is None:
             if force_external:
@@ -362,6 +362,8 @@ class Klein(object):
             host = b''
         return self.url_map.bind(host).build(endpoint, values, method,
                                              force_external, append_unknown)
+
+    url_for = urlFor
 
 
     def run(self, host=None, port=None, logFile=None,
@@ -411,4 +413,4 @@ route = _globalKleinApp.route
 run = _globalKleinApp.run
 resource = _globalKleinApp.resource
 handle_errors = _globalKleinApp.handle_errors
-url_for = _globalKleinApp.url_for
+urlFor = url_for = _globalKleinApp.urlFor

--- a/src/klein/app.py
+++ b/src/klein/app.py
@@ -352,11 +352,13 @@ class Klein(object):
         return deco
 
 
-    def url_for(self, request, endpoint, values = None, method = None, force_external = False, append_unknown = True):
+    def url_for(self, request, endpoint, values=None, method=None,
+                force_external=False, append_unknown=True):
         host = request.getHeader(b'host')
         if host is None:
             host = b''
-        return self.url_map.bind(host).build(endpoint, values, method, force_external, append_unknown)
+        return self.url_map.bind(host).build(endpoint, values, method,
+                                             force_external, append_unknown)
 
 
     def run(self, host=None, port=None, logFile=None,

--- a/src/klein/app.py
+++ b/src/klein/app.py
@@ -343,6 +343,13 @@ class Klein(object):
         return deco
 
 
+    def url_for(self, request, endpoint, values = None, method = None, force_external = False, append_unknown = True):
+        host = request.getHeader(b'host')
+        if not host:
+            host = b''
+        return self.url_map.bind(host).build(endpoint, values, method, force_external, append_unknown)
+
+
     def run(self, host=None, port=None, logFile=None,
             endpoint_description=None):
         """
@@ -388,3 +395,4 @@ _globalKleinApp = Klein()
 route = _globalKleinApp.route
 run = _globalKleinApp.run
 resource = _globalKleinApp.resource
+url_for = _globalKleinApp.url_for

--- a/src/klein/test/test_app.py
+++ b/src/klein/test/test_app.py
@@ -416,11 +416,21 @@ class KleinTestCase(unittest.TestCase):
 
         @app.route('/user/<name>')
         def userpage(req, name):
-            pass
+            return name
 
         @app.route('/post/<int:postid>', endpoint='bar')
         def foo(req, postid):
-            pass
+            return str(postid)
+
+        request = requestMock(b'/user/john')
+        self.assertEqual(
+            app.execute_endpoint('userpage', request, 'john'),
+            'john'
+        )
+        self.assertEqual(
+            app.execute_endpoint('bar', requestMock(b'/post/123'), 123),
+            '123'
+        )
 
         request = requestMock(b'/addr')
         self.assertEqual(app.url_for(request, 'userpage', {'name': 'john'}),

--- a/src/klein/test/test_app.py
+++ b/src/klein/test/test_app.py
@@ -416,11 +416,11 @@ class KleinTestCase(unittest.TestCase):
 
         @app.route('/user/<name>')
         def userpage(req, name):
-            return name
+            pass
 
         @app.route('/post/<int:postid>', endpoint='bar')
         def foo(req, postid):
-            return str(postid)
+            pass
 
         request = requestMock(b'/addr')
         self.assertEqual(app.url_for(request, 'userpage', {'name': 'john'}),
@@ -444,3 +444,13 @@ class KleinTestCase(unittest.TestCase):
         request = requestMock(b'/addr')
         self.assertEqual(app.url_for(request, 'bar', {'postid': 123}),
                          '/post/123')
+
+        request = requestMock(b'/addr')
+        request.requestHeaders.removeHeader(b'host')
+        self.assertEqual(app.url_for(request, 'bar', {'postid': 123}),
+                         '/post/123')
+
+        request = requestMock(b'/addr')
+        request.requestHeaders.removeHeader(b'host')
+        with self.assertRaises(ValueError):
+            app.url_for(request, 'bar', {'postid': 123}, force_external=True)

--- a/src/klein/test/test_app.py
+++ b/src/klein/test/test_app.py
@@ -410,7 +410,7 @@ class KleinTestCase(unittest.TestCase):
         self.assertEqual(mock_kr.return_value, resource)
 
     def test_urlFor(self):
-        """L{Klein.url_for} builds an URL for an endpoint with parameters"""
+        """L{Klein.urlFor} builds an URL for an endpoint with parameters"""
 
         app = Klein()
 
@@ -433,34 +433,34 @@ class KleinTestCase(unittest.TestCase):
         )
 
         request = requestMock(b'/addr')
-        self.assertEqual(app.url_for(request, 'userpage', {'name': 'john'}),
+        self.assertEqual(app.urlFor(request, 'userpage', {'name': 'john'}),
                          '/user/john')
 
         request = requestMock(b'/addr')
-        self.assertEqual(app.url_for(request, 'userpage', {'name': 'john'},
-                                     force_external=True),
+        self.assertEqual(app.urlFor(request, 'userpage', {'name': 'john'},
+                                    force_external=True),
                          'http://localhost:8080/user/john')
 
         request = requestMock(b'/addr', host=b'example.com', port=4321)
-        self.assertEqual(app.url_for(request, 'userpage', {'name': 'john'},
-                                     force_external=True),
+        self.assertEqual(app.urlFor(request, 'userpage', {'name': 'john'},
+                                    force_external=True),
                          'http://example.com:4321/user/john')
 
         request = requestMock(b'/addr')
-        url = app.url_for(request, 'userpage', {'name': 'john', 'age': 29},
-                          append_unknown=True)
+        url = app.urlFor(request, 'userpage', {'name': 'john', 'age': 29},
+                         append_unknown=True)
         self.assertEqual(url, '/user/john?age=29')
 
         request = requestMock(b'/addr')
-        self.assertEqual(app.url_for(request, 'bar', {'postid': 123}),
+        self.assertEqual(app.urlFor(request, 'bar', {'postid': 123}),
                          '/post/123')
 
         request = requestMock(b'/addr')
         request.requestHeaders.removeHeader(b'host')
-        self.assertEqual(app.url_for(request, 'bar', {'postid': 123}),
+        self.assertEqual(app.urlFor(request, 'bar', {'postid': 123}),
                          '/post/123')
 
         request = requestMock(b'/addr')
         request.requestHeaders.removeHeader(b'host')
         with self.assertRaises(ValueError):
-            app.url_for(request, 'bar', {'postid': 123}, force_external=True)
+            app.urlFor(request, 'bar', {'postid': 123}, force_external=True)

--- a/src/klein/test/test_app.py
+++ b/src/klein/test/test_app.py
@@ -11,8 +11,8 @@ from klein import Klein
 from klein._decorators import bindable, modified, originalName
 from klein.app import KleinRequest
 from klein.interfaces import IKleinRequest
-from klein.test.util import EqualityTestsMixin
 from klein.test.test_resource import requestMock
+from klein.test.util import EqualityTestsMixin
 
 
 

--- a/src/klein/test/test_app.py
+++ b/src/klein/test/test_app.py
@@ -423,19 +423,24 @@ class KleinTestCase(unittest.TestCase):
             return str(postid)
 
         request = requestMock(b'/addr')
-        self.assertEqual(app.url_for(request, 'userpage', {'name': 'john'}), '/user/john')
+        self.assertEqual(app.url_for(request, 'userpage', {'name': 'john'}),
+                         '/user/john')
 
         request = requestMock(b'/addr')
-        self.assertEqual(app.url_for(request, 'userpage', {'name': 'john'}, force_external=True),
+        self.assertEqual(app.url_for(request, 'userpage', {'name': 'john'},
+                                     force_external=True),
                          'http://localhost:8080/user/john')
 
         request = requestMock(b'/addr', host=b'example.com', port=4321)
-        self.assertEqual(app.url_for(request, 'userpage', {'name': 'john'}, force_external=True),
+        self.assertEqual(app.url_for(request, 'userpage', {'name': 'john'},
+                                     force_external=True),
                          'http://example.com:4321/user/john')
 
         request = requestMock(b'/addr')
-        self.assertEqual(app.url_for(request, 'userpage', {'name': 'john', 'age': 29}, append_unknown=True),
-                         '/user/john?age=29')
+        url = app.url_for(request, 'userpage', {'name': 'john', 'age': 29},
+                          append_unknown=True)
+        self.assertEqual(url, '/user/john?age=29')
 
         request = requestMock(b'/addr')
-        self.assertEqual(app.url_for(request, 'bar', {'postid': 123}), '/post/123')
+        self.assertEqual(app.url_for(request, 'bar', {'postid': 123}),
+                         '/post/123')


### PR DESCRIPTION
I'd like to propose `Klein.url_for()` method for reverse URL mapping.

```python
def url_for(self, request, endpoint, values = None, method = None, force_external = False, append_unknown = True)
```
`request` is the `Request` object. It is used to obtain correct hostname for external links. Other arguments are just like in Werkzeug's [`MapAdapter.build()`](http://werkzeug.pocoo.org/docs/0.11/routing/#werkzeug.routing.MapAdapter.build).

It can be used like this:
```python
from klein import route, run, url_for

@route('/user/<username>')
def user_page(request, username):
    return "Welcome to {}'s homepage".format(username)

@route('/')
def homepage(request):
    users = ['Alice', 'Bob', 'Carl']
    return '<br/>'.join([
        '<a href="{link}">{username}</a>'.format(
            link=url_for(request, 'user_page', {'username': username}),
            username=username)
        for username in users
    ])

run('localhost', 8080)
```

Actually, Klein already has `url_for()` method on `IKleinRequest` that is assumed to be used like this:
```python
@app.route("/")
def homepage(request):
    krequest = IKleinRequest(request)
    url = krequest.url_for('user_page', {'username': username})
```
But this looks like a piece of confusing magic. How does request know about url-mapping? Why are we asking the request to do url mapping, not the app? And this is working by exploiting the fact that `Request` is `Componentized` that can be problematic as described in #31. Having `url_for()` method on `app` seems more reasonable.

Questions:
- `request` argument to `url_for` is needed only if `force_external=True`. Most of the links are internal, so it might be more convenient to make `request` arg optional. May be have two methods: `url_for(endpoint, ...)` that always returns internal link and `external_url_for(request, endpoint, ...)` for external ones?

If overall concept will be accepted I will add a docstring and example in docs.