### PR TITLE
new: doc: Show how to get the content of a request.

### DIFF
--- a/docs/examples/handlingpost.rst
+++ b/docs/examples/handlingpost.rst
@@ -37,3 +37,27 @@ So the ``POST`` handler must be defined before the handler with no ``methods``.
 The following curl command can be used to test this behaviour::
 
     curl -v -L -d name='bob' http://localhost:8080/
+
+
+Accessing the request content
+=============================
+
+To read the content of the request use ``request.content.read()``
+
+.. code-block:: python
+
+    from klein import run, route
+    import json
+    
+    @route('/', methods=['POST'])
+    def do_post(request):
+        content = json.loads(request.content.read())
+        response = json.dumps(dict(the_data=content), indent=4)
+        return response
+    
+     run("localhost", 8080)
+ 
+ 
+The following curl command can be used to test this behaviour::
+ 
+	 curl -XPOST -v -H 'Content-Type: appliction/json' -d '{"name":"bob"}'  http://localhost:8080/


### PR DESCRIPTION
It took me a while to figure this out so I am adding it to the docs for future reference.