### PR TITLE
Allow returning Resource from handle_errors

### DIFF
--- a/src/klein/app.py
+++ b/src/klein/app.py
@@ -333,8 +333,6 @@ class Klein(object):
             @wraps(f)
             def _f(instance, request, failure):
                 r = _call(instance, f, request, failure)
-                if IRenderable.providedBy(r):
-                    return renderElement(request, r)
                 return r
 
             self._error_handlers.append(([f_or_exception] + list(additional_exceptions), _f))

--- a/src/klein/app.py
+++ b/src/klein/app.py
@@ -19,9 +19,7 @@ except ImportError:
 from twisted.internet import endpoints, reactor
 from twisted.python import log
 from twisted.python.components import registerAdapter
-from twisted.web.iweb import IRenderable
 from twisted.web.server import Request, Site
-from twisted.web.template import renderElement
 
 try:
     from twisted.internet.defer import ensureDeferred
@@ -344,8 +342,7 @@ class Klein(object):
         def deco(f):
             @modified("error handling wrapper", f)
             def _f(instance, request, failure):
-                r = _call(instance, f, request, failure)
-                return r
+                return _call(instance, f, request, failure)
 
             self._error_handlers.append(
                 ([f_or_exception] + list(additional_exceptions), _f)

--- a/src/klein/resource.py
+++ b/src/klein/resource.py
@@ -259,6 +259,8 @@ class KleinResource(Resource):
                                         request,
                                         failure)
 
+                d.addCallback(process)
+
                 return d.addErrback(processing_failed, error_handlers[1:])
 
             return processing_failed(failure, error_handlers[1:])

--- a/src/klein/test/test_resource.py
+++ b/src/klein/test/test_resource.py
@@ -860,6 +860,29 @@ class KleinResourceTests(TestCase):
         self.assertEqual(request.processingFailed.called, False)
         self.assertEqual(request.getWrittenData(), rendered)
 
+    def test_errorHandlerReturnsResource(self):
+        """
+        Resources returned by L{handle_errors} are rendered
+        """
+        app = self.app
+        request = requestMock(b"/")
+
+        class NotFoundResource(Resource):
+            isLeaf = True
+            def render(self, request):
+                request.setResponseCode(404)
+                return b'Nothing found'
+
+        @app.handle_errors(NotFound)
+        def handle_not_found(request, failure):
+            return NotFoundResource()
+
+        d = _render(self.kr, request)
+
+        self.assertFired(d)
+        self.assertEqual(request.code, 404)
+        self.assertEqual(request.getWrittenData(), b'Nothing found')
+
     def test_requestWriteAfterFinish(self):
         app = self.app
         request = requestMock(b"/")

--- a/src/klein/test/test_resource.py
+++ b/src/klein/test/test_resource.py
@@ -878,6 +878,7 @@ class KleinResourceTests(TestCase):
 
         class NotFoundResource(Resource):
             isLeaf = True
+
             def render(self, request):
                 request.setResponseCode(404)
                 return b'Nothing found'


### PR DESCRIPTION
Currently it is not permitted to return `Resource` instances from `Klein.handle_errors()` which seems inconsistent.

This PR replaces duplicated handling of `IRenderable` in `handle_errors` with calling the same `process()` in `KleinResource` as for returned value from non-error route functions.
