### PR TITLE
Allow "from klein import handle_errors"

### DIFF
--- a/src/klein/__init__.py
+++ b/src/klein/__init__.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import, division
 
 from klein._plating import Plating
-from klein.app import Klein, resource, route, run
+from klein.app import Klein, resource, route, run, handle_errors
 
 from ._version import __version__ as _incremental_version
 
@@ -16,6 +16,7 @@ __all__ = (
     "resource",
     "route",
     "run",
+    "handle_errors",
 )
 
 

--- a/src/klein/__init__.py
+++ b/src/klein/__init__.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import, division
 
 from klein._plating import Plating
-from klein.app import Klein, resource, route, run, handle_errors
+from klein.app import Klein, handle_errors, resource, route, run
 
 from ._version import __version__ as _incremental_version
 

--- a/src/klein/app.py
+++ b/src/klein/app.py
@@ -403,3 +403,4 @@ _globalKleinApp = Klein()
 route = _globalKleinApp.route
 run = _globalKleinApp.run
 resource = _globalKleinApp.resource
+handle_errors = _globalKleinApp.handle_errors

--- a/src/klein/test/test_resource.py
+++ b/src/klein/test/test_resource.py
@@ -1231,6 +1231,33 @@ class ExtractURLpartsTests(TestCase):
         self.assertIsInstance(script_name, unicode)
 
 
+class GlobalAppTests(TestCase):
+    """
+    Tests for the global app object
+    """
+
+    def test_global_app(self):
+        from klein import run, route, resource, handle_errors
+
+        global_app = run.__self__
+
+        self.assertIs(route.__self__, global_app)
+        self.assertIs(resource.__self__, global_app)
+        self.assertIs(handle_errors.__self__, global_app)
+
+        @route('/')
+        def index(request):
+            1 // 0
+        @handle_errors(ZeroDivisionError)
+        def on_zero(request, failure):
+            return b'alive'
+
+        request = requestMock(b'/')
+        d = _render(resource(), request)
+        self.assertIsNone(self.successResultOf(d))
+        self.assertEqual(request.getWrittenData(), b'alive')
+
+
 if _PY3:
     import sys
     if sys.version_info >= (3, 5):

--- a/src/klein/test/test_resource.py
+++ b/src/klein/test/test_resource.py
@@ -1239,11 +1239,11 @@ class GlobalAppTests(TestCase):
     def test_global_app(self):
         from klein import run, route, resource, handle_errors
 
-        global_app = run.__self__
+        globalApp = run.__self__
 
-        self.assertIs(route.__self__, global_app)
-        self.assertIs(resource.__self__, global_app)
-        self.assertIs(handle_errors.__self__, global_app)
+        self.assertIs(route.__self__, globalApp)
+        self.assertIs(resource.__self__, globalApp)
+        self.assertIs(handle_errors.__self__, globalApp)
 
         @route('/')
         def index(request):

--- a/src/klein/test/test_resource.py
+++ b/src/klein/test/test_resource.py
@@ -1248,6 +1248,7 @@ class GlobalAppTests(TestCase):
         @route('/')
         def index(request):
             1 // 0
+
         @handle_errors(ZeroDivisionError)
         def on_zero(request, failure):
             return b'alive'


### PR DESCRIPTION
Makes it possible to `from klein import handle_errors` just like `route`, `run` and `resource`. Useful for writing quick tests and examples.