### PR TITLE
Remove Py3.3 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,15 +45,6 @@ matrix:
     - python: 2.7
       env: TOXENV=trial-py27-twtrunk
 
-    - python: 3.3
-      env: TOXENV=trial-py33-tw155
-    - python: 3.3
-      env: TOXENV=trial-py33-tw160
-    - python: 3.3
-      env: TOXENV=trial-py33-twcurrent
-    - python: 3.3
-      env: TOXENV=trial-py33-twtrunk
-
     - python: 3.4
       env: TOXENV=trial-py34-tw155
     - python: 3.4

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,6 @@ if __name__ == "__main__":
             'Operating System :: OS Independent',
             'Programming Language :: Python',
             'Programming Language :: Python :: 2.7',
-            'Programming Language :: Python :: 3.3',
             'Programming Language :: Python :: 3.4',
             'Programming Language :: Python :: 3.5',
             'Programming Language :: Python :: Implementation :: CPython',

--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,7 @@ envlist =
     trial-py{27,py}-tw{130,140}
 
     # Twisted 15.5 is the first version to support Python 3 (3.3+)
-    trial-py{27,py,33,34,35,36}-tw{155,166,current,trunk}
+    trial-py{27,py,34,35,36}-tw{155,166,current,trunk}
 
     docs, docs-linkcheck
 
@@ -23,7 +23,6 @@ skip_missing_interpreters = True
 basepython =
     pypy: pypy
     py27: python2.7
-    py33: python3.3
     py34: python3.4
     py35: python3.5
     py36: python3.6


### PR DESCRIPTION
We don't have much usage from Python 3.3:

<img width="278" alt="klein-downloads" src="https://user-images.githubusercontent.com/50002/26988840-b64fa122-4d05-11e7-9916-862ca28c9cc3.png">

I'd like to drop it from the support matrix.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/twisted/klein/184)
<!-- Reviewable:end -->
