### PR TITLE
Drop support for Twisted<15.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,28 +16,24 @@ branches:
 # For each supported version of Python, we will test with:
 #
 #  * The first minor version of Twisted for each major version that supports
-#    the tested version of Python, staring with Twisted 13.
+#    the tested version of Python, covering two years of releases.
 #
 #  * The current release of Twisted.
 #
 #  * Twisted trunk, at the time of the build.
+#    This is allowed to fail, as a failure in only this case indicates a likely
+#    compatibility bug in Twisted trunk.
 #
 matrix:
   include:
     # PyPy (Python 2.7)
-    - env: TOXENV=trial-pypy-tw130     PYPY_VERSION=5.7.1
-    - env: TOXENV=trial-pypy-tw140     PYPY_VERSION=5.7.1
-    - env: TOXENV=trial-pypy-tw150     PYPY_VERSION=5.7.1
+    - env: TOXENV=trial-pypy-tw155     PYPY_VERSION=5.7.1
     - env: TOXENV=trial-pypy-tw160     PYPY_VERSION=5.7.1
     - env: TOXENV=trial-pypy-twcurrent PYPY_VERSION=5.7.1
     - env: TOXENV=trial-pypy-twtrunk   PYPY_VERSION=5.7.1
 
     - python: 2.7
-      env: TOXENV=trial-py27-tw130
-    - python: 2.7
-      env: TOXENV=trial-py27-tw140
-    - python: 2.7
-      env: TOXENV=trial-py27-tw150
+      env: TOXENV=trial-py27-tw155
     - python: 2.7
       env: TOXENV=trial-py27-tw160
     - python: 2.7

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -13,14 +13,14 @@ Klein is an open source project that welcomes contributions of all kinds coming 
 Getting started
 ===============
 
-Here is a list of shell commands that will install the dependencies of Klein, run the test suite with Python 2.7 and the current version of Twisted, compile the documentation, and check for coding style issues with pyflakes.
+Here is a list of shell commands that will install the dependencies of Klein, run the test suite with Python 2.7 and the current version of Twisted, compile the documentation, and check for coding style issues with flake8.
 
 .. code-block:: shell
 
    pip install --user tox
    tox -e py27-twcurrent
    tox -e docs
-   tox -e pyflakes
+   tox -e flake8
 
 `Tox <https://tox.readthedocs.io/en/latest/>`_ makes a virtualenv, installs Klein's dependencies into the virtualenv, and then runs a set of commands based on the ``-e`` (environment) argument.
 This strategy allows one to make and test changes to Klein without needing to change system-level Python packages.
@@ -39,13 +39,13 @@ Code
   Similarly, if you change existing code, following the Twisted style guide is good, but is less important than not breaking public APIs.
 - Compatibility across versions is important: here are `Twisted's compatibility guidelines <https://twistedmatrix.com/trac/wiki/CompatibilityPolicy>`_, which Klein shares.
 - If you're adding a new feature, please add a file with an example and some explanation to the `examples directory <https://github.com/twisted/klein/tree/master/docs/examples>`_, then add your example to ``/docs/index.rst``.
-- Please run ``tox -e pyflakes`` to check for style issues in changed code.
-  PyFlakes and similar tools expose many small-but-common errors early enough that it's easy to remedy the problem.
+- Please run ``tox -e flake8`` to check for style issues in changed code.
+  Flake8 and similar tools expose many small-but-common errors early enough that it's easy to remedy the problem.
 - Code changes should have tests: untested code is buggy code.
   Klein uses `Twisted Trial <http://twistedmatrix.com/documents/current/api/twisted.trial.html>`_ and `tox <https://tox.readthedocs.io/en/latest/>`_ for its tests.
   The command to run the full test suite is ``tox`` with no arguments.
   This will run tests against several versions of Python and Twisted, which can be time-consuming.
-  To run tests against only one or a few versions, pass a ``-e`` argument with an environment from the envlist in ``tox.ini``: for example, ``tox -e py33-tw150`` will run tests with Python 3.3 and Twisted 15.0.
+  To run tests against only one or a few versions, pass a ``-e`` argument with an environment from the envlist in ``tox.ini``: for example, ``tox -e py35-twcurrent`` will run tests with Python 3.5 and the current released version of Twisted.
   To run only one or a few specific tests in the suite, add a filename or fully-qualified Python path to the end of the test invocation: for example, ``tox klein.test.test_app.KleinTestCase.test_foo`` will run only the ``test_foo()`` method of the ``KleinTestCase`` class in ``klein/test/test_app.py``.
   These two test shortcuts can be combined to give you a quick feedback cycle, but make sure to check on the full test suite from time to time to make sure changes haven't had unexpected side effects.
 - Show us your code changes through pull requests sent to `Klein's GitHub repo <https://github.com/twisted/klein>`_.

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ if __name__ == "__main__":
         use_incremental=True,
         install_requires=[
             "six",
-            "Twisted>=13.2",
+            "Twisted>=15.5",
             "werkzeug",
             "incremental",
         ],

--- a/tox.ini
+++ b/tox.ini
@@ -3,9 +3,6 @@
 envlist =
     flake8, twistedchecker-diff
 
-    # Twisted 13-14 require Python 2.
-    trial-py{27,py}-tw{130,140}
-
     # Twisted 15.5 is the first version to support Python 3 (3.3+)
     trial-py{27,py,34,35,36}-tw{155,166,current,trunk}
 
@@ -31,10 +28,6 @@ deps =
     coverage
     mock
 
-    tw130: Twisted==13.0
-    tw131: Twisted==13.1
-    tw132: Twisted==13.2
-    tw140: Twisted==14.0.2
     tw150: Twisted==15.0
     tw151: Twisted==15.1
     tw152: Twisted==15.2
@@ -48,6 +41,7 @@ deps =
     tw164: Twisted==16.4
     tw165: Twisted==16.5
     tw166: Twisted==16.6
+    tw171: Twisted==17.1
     twcurrent: Twisted
     twtrunk: https://github.com/twisted/twisted/archive/trunk.zip
 


### PR DESCRIPTION
Drop support for `Twisted<15.5`.

PyPI data by Twisted version:

<img width="196" alt="twisted-versions" src="https://user-images.githubusercontent.com/50002/26990927-53293074-4d0d-11e7-986f-1e85b7b4dcd6.png">

PyPI data by Twisted major version:

<img width="232" alt="twisted-major-versions" src="https://user-images.githubusercontent.com/50002/26990932-5e05606c-4d0d-11e7-88ad-4df94b9c6081.png">

I sum up 356883 downloads.  59% use Twisted 17.  77% use Twisted>=16.  82% use Twisted >=15.

@glyph says if you use Twisted 14, you must suffer for it, so dropping that is a no-brainer, as we want to minimize suffering, or at least discourage it.

I'm going with a floor of 15.5 because (a) that's still two years ago, which I think is a good minimum, and (b) it's the first to support Python 3.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/twisted/klein/185)
<!-- Reviewable:end -->
