### PR TITLE
Pass through PATH and CI variables.

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -48,6 +48,8 @@ deps =
 setenv =
     PIP_DISABLE_PIP_VERSION_CHECK=1
     VIRTUALENV_NO_DOWNLOAD=1
+
+passenv=
     PATH
     TRAVIS TRAVIS_* _system_*
 

--- a/tox.ini
+++ b/tox.ini
@@ -48,7 +48,6 @@ deps =
 passenv =
     PATH
     TRAVIS TRAVIS_* _system_*
-    CODECOV_OPTIONS
 
 commands =
     "{toxinidir}/.travis/environment"

--- a/tox.ini
+++ b/tox.ini
@@ -45,6 +45,11 @@ deps =
     twcurrent: Twisted
     twtrunk: https://github.com/twisted/twisted/archive/trunk.zip
 
+passenv =
+    PATH
+    TRAVIS TRAVIS_* _system_*
+    CODECOV_OPTIONS
+
 commands =
     "{toxinidir}/.travis/environment"
     coverage run -p "{envdir}/bin/trial" {posargs:klein}


### PR DESCRIPTION
PATH lets the environment tell us where things like Python are.

`TRAVIS` `TRAVIS_*` and `_system_*` are useful for debugging the Travis environment.  (They are printed out during runs.)
