### PR TITLE
Set PIP_DISABLE_PIP_VERSION_CHECK=1

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -45,6 +45,9 @@ deps =
     twcurrent: Twisted
     twtrunk: https://github.com/twisted/twisted/archive/trunk.zip
 
+setenv =
+    PIP_DISABLE_PIP_VERSION_CHECK=1
+
 commands =
     "{toxinidir}/.travis/environment"
     coverage run -p "{envdir}/bin/trial" {posargs:klein}

--- a/tox.ini
+++ b/tox.ini
@@ -47,6 +47,7 @@ deps =
 
 setenv =
     PIP_DISABLE_PIP_VERSION_CHECK=1
+    VIRTUALENV_NO_DOWNLOAD=1
 
 commands =
     "{toxinidir}/.travis/environment"


### PR DESCRIPTION
This prevents pip from hitting PyPI unnecessarily.

[Travis sets this by default now](https://github.com/travis-ci/travis-ci/issues/5499), so another way to do it is to pass it through, but this makes sense locally also.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/twisted/klein/191)
<!-- Reviewable:end -->
