### PR TITLE
Don't include mock and coverage when they aren't needed.

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -25,9 +25,6 @@ basepython =
     py36: python3.6
 
 deps =
-    coverage
-    mock
-
     tw150: Twisted==15.0
     tw151: Twisted==15.1
     tw152: Twisted==15.2
@@ -44,6 +41,10 @@ deps =
     tw171: Twisted==17.1
     twcurrent: Twisted
     twtrunk: https://github.com/twisted/twisted/archive/trunk.zip
+
+    {trial,coverage}: mock
+
+    coverage: coverage
 
 setenv =
     PIP_DISABLE_PIP_VERSION_CHECK=1


### PR DESCRIPTION
`mock` and `coverage` are being included in all Tox environments, and are only required in some.

For example: `flake8` and `docs` do not need either.

Scope them into the environments where they are needed.
