### PR TITLE
Remove twistedchecker-diff from default envlist

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 
 envlist =
-    flake8, twistedchecker-diff
+    flake8
 
     # Twisted 15.5 is the first version to support Python 3 (3.3+)
     coverage-py{27,py,34,35,36}-tw{155,166,current,trunk}


### PR DESCRIPTION
Remove twistedchecker-diff from default envlist, as it doesn't work outside of CI builds.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/twisted/klein/193)
<!-- Reviewable:end -->
