### PR TITLE
trial invocation tweaks

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -52,9 +52,9 @@ setenv =
 commands =
     "{toxinidir}/.travis/environment"
 
-    trial: "{envbindir}/trial" {posargs:klein}
+    trial: trial --random=0 --logfile="{envlogdir}/trial.log" --temp-directory="{envlogdir}/trial.d" {posargs:klein}
 
-    coverage: coverage run -p "{envbindir}/trial" {posargs:klein}
+    coverage: coverage run -p "{envbindir}/trial" --random=0 --logfile="{envlogdir}/trial.log" --temp-directory="{envlogdir}/trial.d" {posargs:klein}
 
 
 ##

--- a/tox.ini
+++ b/tox.ini
@@ -138,8 +138,8 @@ basepython = python2.7
 
 commands =
     "{toxinidir}/.travis/environment"
-    {toxinidir}/.travis/twistedchecker-diff {posargs:klein}
 
+    "{toxinidir}/.travis/twistedchecker-diff" {posargs:klein}
 
 ##
 # Build the documentation

--- a/tox.ini
+++ b/tox.ini
@@ -78,6 +78,7 @@ basepython = python3.5
 
 commands =
     "{toxinidir}/.travis/environment"
+
     flake8 {posargs:src/klein}
 
 
@@ -121,6 +122,7 @@ basepython = python2.7
 
 commands =
     "{toxinidir}/.travis/environment"
+
     twistedchecker {posargs:klein}
 
 
@@ -141,6 +143,7 @@ commands =
 
     "{toxinidir}/.travis/twistedchecker-diff" {posargs:klein}
 
+
 ##
 # Build the documentation
 ##
@@ -155,6 +158,7 @@ basepython = python2.7
 
 commands =
     "{toxinidir}/.travis/environment"
+
     sphinx-build -b html -d "{envtmpdir}/doctrees" docs docs/_build/html
 
 
@@ -170,5 +174,6 @@ basepython = python2.7
 
 commands =
     "{toxinidir}/.travis/environment"
+
     sphinx-build -b html -d "{envtmpdir}/doctrees" docs docs/_build/html
     sphinx-build -b linkcheck docs docs/_build/html


### PR DESCRIPTION
When invoking trial, add:
 * `--random=0` to randomize tests
 * `--logfile=X` to put logs in trial env tmp dri
 * `--temp-directory=X` to put trial tmp dir in trial env tmp dir

The first helps find certain bugs in tests.
The latter two keep Tox runs from dropping turds in the source tree and drops them into the current environment's temporary directory instead.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/twisted/klein/194)
<!-- Reviewable:end -->
