### PR TITLE
Set COVERAGE_FILE into Tox env tmp dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,6 @@
 _trial_temp
 build
 htmlcov
-.coverage
 *.egg-info
 .tox/
 docs/_build/

--- a/tox.ini
+++ b/tox.ini
@@ -49,11 +49,16 @@ setenv =
     PIP_DISABLE_PIP_VERSION_CHECK=1
     VIRTUALENV_NO_DOWNLOAD=1
 
+    coverage: COVERAGE_FILE={toxworkdir}/coverage/coverage.{envname}
+
 commands =
     "{toxinidir}/.travis/environment"
 
+    # Run trial without coverage
     trial: trial --random=0 --logfile="{envlogdir}/trial.log" --temp-directory="{envlogdir}/trial.d" {posargs:klein}
 
+    # Run trial with coverage
+    coverage: python -c 'import os; d="{toxworkdir}/coverage"; os.makedirs(d) if not os.path.exists(d) else None'
     coverage: coverage run -p "{envbindir}/trial" --random=0 --logfile="{envlogdir}/trial.log" --temp-directory="{envlogdir}/trial.d" {posargs:klein}
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -57,8 +57,10 @@ commands =
     # Run trial without coverage
     trial: trial --random=0 --logfile="{envlogdir}/trial.log" --temp-directory="{envlogdir}/trial.d" {posargs:klein}
 
-    # Run trial with coverage
+    # Create a directory for coverage reports
     coverage: python -c 'import os; d="{toxworkdir}/coverage"; os.makedirs(d) if not os.path.exists(d) else None'
+
+    # Run trial with coverage
     coverage: coverage run -p "{envbindir}/trial" --random=0 --logfile="{envlogdir}/trial.log" --temp-directory="{envlogdir}/trial.d" {posargs:klein}
 
 


### PR DESCRIPTION
Set `COVERAGE_FILE` such that instead of dropping a million `.coverage.*` turds into the source tree, they go into the Tox environment's temporary directory.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/twisted/klein/195)
<!-- Reviewable:end -->
