### PR TITLE
Git ignore: use rooted paths for files that have a fixed location.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,11 +1,11 @@
 *.pyc
-_trial_temp
-build
+/_trial_temp/
+/build/
 htmlcov
 .coverage
 /src/*.egg-info
 /.tox/
 /docs/_build/
 .DS_Store
-dist/
+/dist/
 *~

--- a/.gitignore
+++ b/.gitignore
@@ -3,9 +3,9 @@ _trial_temp
 build
 htmlcov
 .coverage
-*.egg-info
-.tox/
-docs/_build/
+/src/*.egg-info
+/.tox/
+/docs/_build/
 .DS_Store
 dist/
 *~


### PR DESCRIPTION
Git ignore: use rooted paths for files that have a fixed location.

This is being a bit pedantic, but if there's a `.tox`, for example, in some other location, that's weird.
