### PR TITLE
Remove [paths] section in .coveragerc

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,11 +1,3 @@
 [run]
-source =
-       klein
 branch = True
-
-
-[paths]
-source =
-   src/
-   .tox/*/lib/python*/site-packages/
-   .tox/pypy*/site-packages/
+source = klein


### PR DESCRIPTION
It's not needed, and having Tox paths hard coded in there is odd.
