### PR TITLE
Write coverage data into .tox/coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,6 @@
 /_trial_temp/
 /build/
 htmlcov
-.coverage
 /src/*.egg-info
 /.tox/
 /docs/_build/

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ matrix:
     - env: TOXENV=coverage-pypy-twtrunk,codecov   PYPY_VERSION=5.7.1
 
     - python: 2.7
-      env: TOXENV=coverage-py27-tw155
+      env: TOXENV=coverage-py27-tw155,codecov
     - python: 2.7
       env: TOXENV=coverage-py27-tw160,codecov
     - python: 2.7

--- a/.travis/run
+++ b/.travis/run
@@ -4,6 +4,9 @@ set -e
 set -u
 
 case "${TOXENV}" in
+    *-py2*|*-pypy*)
+        COVERAGE_OMIT="py3_*";
+        # Fall through
     *-pypy*)
         PYENV_ROOT="${HOME}/.pyenv";
         pyenv="${PYENV_ROOT}/bin/pyenv";

--- a/.travis/run
+++ b/.travis/run
@@ -6,7 +6,10 @@ set -u
 case "${TOXENV}" in
     *-py2*|*-pypy*)
         COVERAGE_OMIT="py3_*";
-        # Fall through
+        ;;
+esac;
+
+case "${TOXENV}" in
     *-pypy*)
         PYENV_ROOT="${HOME}/.pyenv";
         pyenv="${PYENV_ROOT}/bin/pyenv";

--- a/.travis/run
+++ b/.travis/run
@@ -5,14 +5,14 @@ set -u
 
 case "${TOXENV}" in
     *-py2*|*-pypy*)
-        COVERAGE_OMIT="py3_*";
+        export COVERAGE_OMIT="py3_*";
         ;;
 esac;
 
 case "${TOXENV}" in
     *-pypy*)
-        PYENV_ROOT="${HOME}/.pyenv";
-        pyenv="${PYENV_ROOT}/bin/pyenv";
+        pyenv_root="${HOME}/.pyenv";
+        pyenv="${pyenv_root}/bin/pyenv";
         eval "$("${pyenv}" init -)";
         ;;
 esac;

--- a/tox.ini
+++ b/tox.ini
@@ -65,6 +65,9 @@ setenv =
 
     codecov: COVERAGE_XML={envlogdir}/coverage_report.xml
 
+    {py27,pypy}: COVERAGE_OMIT="py3_*"
+
+
 commands =
     "{toxinidir}/.travis/environment"
 
@@ -218,7 +221,7 @@ commands =
     "{toxinidir}/.travis/environment"
 
     coverage combine --append
-    coverage xml -o "{env:COVERAGE_XML}"
+    coverage xml -o "{env:COVERAGE_XML}" --omit="{env:COVERAGE_OMIT:}"
     codecov -e TOXENV --required --file="{env:COVERAGE_XML}"
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -56,14 +56,20 @@ setenv =
     PIP_DISABLE_PIP_VERSION_CHECK=1
     VIRTUALENV_NO_DOWNLOAD=1
 
+    coverage: COVERAGE_FILE={toxworkdir}/coverage/coverage.{envname}
+    codecov: COVERAGE_FILE={toxworkdir}/coverage/coverage
+
 commands =
     "{toxinidir}/.travis/environment"
 
     # Run trial without coverage
     trial: trial --random=0 --logfile="{envlogdir}/trial.log" --temp-directory="{envlogdir}/trial.d" {posargs:klein}
 
+    # Create a directory for coverage reports
+    coverage: python -c 'import os; d="{toxworkdir}/coverage"; os.makedirs(d) if not os.path.exists(d) else None'
+
     # Run trial with coverage
-    coverage: coverage run -p "{envbindir}/trial" --random=0 --logfile="{envlogdir}/trial.log" --temp-directory="{envlogdir}/trial.d" {posargs:klein}
+    coverage: coverage run "{envdir}/bin/trial" --random=0 --logfile="{envlogdir}/trial.log" --temp-directory="{envlogdir}/trial.d" {posargs:klein}
 
 
 ##

--- a/tox.ini
+++ b/tox.ini
@@ -167,7 +167,7 @@ commands =
 
 [testenv:codecov]
 
-basepython = python3.5
+basepython = python
 
 skip_install = True
 

--- a/tox.ini
+++ b/tox.ini
@@ -59,6 +59,8 @@ setenv =
     coverage: COVERAGE_FILE={toxworkdir}/coverage/coverage.{envname}
     codecov: COVERAGE_FILE={toxworkdir}/coverage/coverage
 
+    codecov: COVERAGE_XML={envlogdir}/coverage_report.xml
+
 commands =
     "{toxinidir}/.travis/environment"
 
@@ -175,8 +177,8 @@ commands =
     "{toxinidir}/.travis/environment"
 
     coverage combine --append
-
-    codecov -e TOXENV --required
+    coverage xml -o "{env:COVERAGE_XML}"
+    codecov -e TOXENV --required --file="{env:COVERAGE_XML}"
 
 
 ##

--- a/tox.ini
+++ b/tox.ini
@@ -51,6 +51,8 @@ deps =
     coverage: coverage
 
 passenv =
+    codecov: COVERAGE_OMIT
+
     # See https://github.com/codecov/codecov-python/blob/5b9d539a6a09bc84501b381b563956295478651a/README.md#using-tox
     codecov: TOXENV
     codecov: CI
@@ -64,8 +66,6 @@ setenv =
     codecov: COVERAGE_FILE={toxworkdir}/coverage/coverage
 
     codecov: COVERAGE_XML={envlogdir}/coverage_report.xml
-
-    {py27,pypy}: COVERAGE_OMIT="py3_*"
 
 
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -63,9 +63,10 @@ setenv =
     VIRTUALENV_NO_DOWNLOAD=1
 
     coverage: COVERAGE_FILE={toxworkdir}/coverage/coverage.{envname}
-    codecov: COVERAGE_FILE={toxworkdir}/coverage/coverage
+    coverage_report,codecov: COVERAGE_FILE={toxworkdir}/coverage/coverage
 
-    codecov: COVERAGE_XML={envlogdir}/coverage_report.xml
+    {coverage_report,codecov}: COVERAGE_XML={envlogdir}/coverage_report.xml
+    coverage_report: COVERAGE_HTML={toxworkdir}/coverage/html
 
 
 commands =
@@ -203,6 +204,29 @@ commands =
     "{toxinidir}/.travis/environment"
 
     "{toxinidir}/.travis/twistedchecker-diff" {posargs:klein}
+
+
+##
+# Combine coverage reports
+##
+
+[testenv:coverage_report]
+
+basepython = python3.6
+
+skip_install = True
+
+deps = coverage
+
+commands =
+    "{toxinidir}/.travis/environment"
+
+    coverage combine --append
+
+    coverage html -d "{env:COVERAGE_HTML}"
+    coverage xml -o "{env:COVERAGE_XML}"
+
+    coverage report --fail-under=100 --omit "*/test/*"
 
 
 ##


### PR DESCRIPTION
Write coverage data into `.tox/coverage` instead of writing lots of `.coverage.BLEARGHHUCKHUCKBARF` files in the top of the source directory.