### PR TITLE
Prefer unittest.mock but require mock for python < 3.3.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+mock ; python_version <= '3.3'

--- a/src/klein/test/test_app.py
+++ b/src/klein/test/test_app.py
@@ -2,7 +2,10 @@ from __future__ import absolute_import, division
 
 import sys
 
-from mock import Mock, patch
+try:
+    from unittest.mock import Mock, patch
+except Exception:
+    from mock import Mock, patch  # type:ignore
 
 from twisted.python.components import registerAdapter
 from twisted.trial import unittest

--- a/src/klein/test/test_resource.py
+++ b/src/klein/test/test_resource.py
@@ -3,7 +3,10 @@ from __future__ import absolute_import, division
 import os
 from io import BytesIO
 
-from mock import Mock, call
+try:
+    from unittest.mock import Mock, call
+except Exception:
+    from mock import Mock, call  # type:ignore
 
 from six.moves.urllib.parse import parse_qs
 


### PR DESCRIPTION
The unit tests require mock but don't specify it, which causes
problems for any usages outside tox (e.g. testing that changes to
twisted don't break klein).  Use PEP508 to specify environment markers
and only install mock when required.  Tests can then conditionally
import unittest.mock and fall back to mock.

The conditional imports do raise a mypy error, discussed here:
    https://github.com/python/mypy/issues/1153

So an annotation is required to silence this specific warning.