### PR TITLE
Free widgets

### DIFF
--- a/src/klein/_plating.py
+++ b/src/klein/_plating.py
@@ -181,11 +181,11 @@ class Plating(object):
         def __call__(self, *args, **kwargs):
             return self._function(*args, **kwargs)
 
-        def __get__(self, obj, type_=None):
+        def __get__(self, instance, owner=None):
             return self.__class__(
                 self._plating,
-                self._function.__get__(obj, type_),
-                instance=obj,
+                self._function.__get__(instance, owner),
+                instance=instance,
             )
 
         def widget(self, *args, **kwargs):
@@ -195,8 +195,10 @@ class Plating(object):
             data = self._function(*args, **kwargs)
             return self._plating._elementify(self._instance, data)
 
+
         def __getattr__(self, attr):
             return getattr(self._function, attr)
+
 
     def widgeted(self, function):
         """

--- a/src/klein/_plating.py
+++ b/src/klein/_plating.py
@@ -4,9 +4,9 @@
 Templating wrapper support for Klein.
 """
 
-import attr
-
 from json import dumps
+
+import attr
 
 from six import integer_types, text_type
 

--- a/src/klein/test/test_plating.py
+++ b/src/klein/test/test_plating.py
@@ -182,6 +182,14 @@ class PlatingTests(TestCase):
         self.assertIn(b'<ul><li>1</li><li>2</li><li>3</li></ul>', written)
         self.assertIn(b'<title>default title unchanged</title>', written)
 
+    def test_widget_function(self):
+        """
+        A function decorated with L{Plating.wigeted} can be directly
+        invoked.
+        """
+        self.assertEqual(enwidget(5, 6), {"a": 5, "b": 6})
+        self.assertEqual(InstanceWidget().enwidget(7, 8), {"a": 7, "b": 8})
+
     def test_widget_html(self):
         """
         When L{Plating.widgeted} is applied as a decorator, it gives the

--- a/src/klein/test/test_plating.py
+++ b/src/klein/test/test_plating.py
@@ -43,9 +43,23 @@ element = Plating(
 @element.widgeted
 def enwidget(a, b):
     """
-    Provide some values for the L{widget} template.
+    Provide some values for the L{element} template.
     """
     return {"a": a, "b": b}
+
+
+class InstanceWidget(object):
+    """
+    A class with a method that's a L{Plating.widget}.
+    """
+
+    @element.widgeted
+    def enwidget(self, a, b):
+        """
+        Provide some values for the L{element} template.
+        """
+        return {"a": a, "b": b}
+
 
 
 class PlatingTests(TestCase):
@@ -175,14 +189,19 @@ class PlatingTests(TestCase):
         function with a modified return type that turns it into a renderable
         HTML sub-element that may fill a slot.
         """
-        @page.routed(self.app.route("/"), tags.div(slot("widget")))
+        @page.routed(self.app.route("/"),
+                     tags.div(tags.div(slot("widget")),
+                              tags.div(slot("instance-widget"))))
         def rsrc(request):
-            return {"widget": enwidget.widget(3, 4)}
+            return {"widget": enwidget.widget(a=3, b=4),
+                    "instance-widget": InstanceWidget().enwidget.widget(5, 6)}
 
         request, written = self.get(b"/")
 
         self.assertIn(b"<span>a: 3</span>", written)
         self.assertIn(b"<span>b: 4</span>", written)
+        self.assertIn(b"<span>a: 5</span>", written)
+        self.assertIn(b"<span>b: 6</span>", written)
 
     def test_widget_json(self):
         """
@@ -190,13 +209,17 @@ class PlatingTests(TestCase):
         serialized to JSON, it appears the same as the returned value despite
         the HTML-friendly wrapping described above.
         """
-        @page.routed(self.app.route("/"), tags.div(slot("widget")))
+        @page.routed(self.app.route("/"),
+                     tags.div(tags.div(slot("widget")),
+                              tags.div(slot("instance-widget"))))
         def rsrc(request):
-            return {"widget": enwidget.widget(3, 4)}
+            return {"widget": enwidget.widget(a=3, b=4),
+                    "instance-widget": InstanceWidget().enwidget.widget(5, 6)}
 
         request, written = self.get(b"/?json=1")
         self.assertEqual(json.loads(written.decode('utf-8')),
                          {"widget": {"a": 3, "b": 4},
+                          "instance-widget": {"a": 5, "b": 6},
                           "title": "default title unchanged"})
 
     def test_prime_directive_return(self):


### PR DESCRIPTION
Widgets don't work with free functions that don't have a first positional argument, or with instance methods.

A first positional argument is required because the returned `wrapper` has `instance` as its first argument:

https://github.com/twisted/klein/blob/67580644a53201332ac48a0fa18769d19fad6338/src/klein/_plating.py#L167

Instance methods don't work because the `wrapper` can't forward the bound `self` to its invocation of `function`:

https://github.com/twisted/klein/blob/67580644a53201332ac48a0fa18769d19fad6338/src/klein/_plating.py#L168

because it's assigned as an attribute on the function:

https://github.com/twisted/klein/blob/67580644a53201332ac48a0fa18769d19fad6338/src/klein/_plating.py#L170

This PR introduces a descriptor that addresses both by binding the function it wraps on attribute access.