### PR TITLE
Un-pin Hypothesis and fix performance issue in test_headers data generation.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 htmlcov
 /.coverage
 /.coverage.*
+/.mypy_cache
 /src/*.egg-info
 /.tox/
 /docs/_build/

--- a/src/klein/_headers.py
+++ b/src/klein/_headers.py
@@ -1,4 +1,4 @@
-# -*- test-case-name: txrequest.test.test_request -*-
+# -*- test-case-name: klein.test.test_request -*-
 # Copyright (c) 2017-2018. See LICENSE for details.
 
 """

--- a/src/klein/test/test_headers.py
+++ b/src/klein/test/test_headers.py
@@ -44,14 +44,6 @@ def decodeName(name):
     return name.decode(HEADER_NAME_ENCODING)
 
 
-def encodeValue(name):
-    # type: (Text) -> Optional[bytes]
-    try:
-        return name.encode(HEADER_VALUE_ENCODING)
-    except UnicodeEncodeError:
-        return None
-
-
 def decodeValue(name):
     # type: (bytes) -> Text
     return name.decode(HEADER_VALUE_ENCODING)

--- a/src/klein/test/test_headers.py
+++ b/src/klein/test/test_headers.py
@@ -1,8 +1,8 @@
-# -*- test-case-name: txrequest.test.test_headers -*-
+# -*- test-case-name: klein.test.test_headers -*-
 # Copyright (c) 2017-2018. See LICENSE for details.
 
 """
-Tests for L{txrequest._headers}.
+Tests for L{klein._headers}.
 """
 
 from collections import defaultdict
@@ -34,6 +34,11 @@ __all__ = ()
 def encodeName(name):
     # type: (Text) -> Optional[bytes]
     return name.encode(HEADER_NAME_ENCODING)
+
+
+def encodeValue(name):
+    # type: (Text) -> Optional[bytes]
+    return name.encode(HEADER_VALUE_ENCODING)
 
 
 def decodeName(name):
@@ -104,7 +109,7 @@ class EncodingTests(TestCase):
         """
         L{headerValueAsBytes} encodes L{Text} using L{HEADER_VALUE_ENCODING}.
         """
-        rawValue = encodeName(value)
+        rawValue = encodeValue(value)
         self.assertEqual(headerValueAsBytes(value), rawValue)
 
 

--- a/src/klein/test/test_headers.py
+++ b/src/klein/test/test_headers.py
@@ -8,7 +8,7 @@ Tests for L{txrequest._headers}.
 from collections import defaultdict
 from typing import AnyStr, Dict, Iterable, List, Optional, Text, Tuple, cast
 
-from hypothesis import assume, given
+from hypothesis import given
 from hypothesis.strategies import binary, iterables, text, tuples
 
 from ._strategies import ascii_text, latin1_text
@@ -33,10 +33,7 @@ __all__ = ()
 
 def encodeName(name):
     # type: (Text) -> Optional[bytes]
-    try:
-        return name.encode(HEADER_NAME_ENCODING)
-    except UnicodeEncodeError:
-        return None
+    return name.encode(HEADER_NAME_ENCODING)
 
 
 def decodeName(name):
@@ -64,14 +61,13 @@ class EncodingTests(TestCase):
         self.assertIdentical(headerNameAsBytes(name), name)
 
 
-    @given(text(min_size=1))
+    @given(latin1_text(min_size=1))
     def test_headerNameAsBytesWithText(self, name):
         # type: (Text) -> None
         """
         L{headerNameAsBytes} encodes L{Text} using L{HEADER_NAME_ENCODING}.
         """
         rawName = encodeName(name)
-        assume(rawName is not None)
         self.assertEqual(headerNameAsBytes(name), rawName)
 
 
@@ -102,14 +98,13 @@ class EncodingTests(TestCase):
         self.assertIdentical(headerValueAsBytes(value), value)
 
 
-    @given(text(min_size=1))
+    @given(latin1_text(min_size=1))
     def test_headerValueAsBytesWithText(self, value):
         # type: (Text) -> None
         """
         L{headerValueAsBytes} encodes L{Text} using L{HEADER_VALUE_ENCODING}.
         """
         rawValue = encodeName(value)
-        assume(rawValue is not None)
         self.assertEqual(headerValueAsBytes(value), rawValue)
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -47,9 +47,7 @@ deps =
     twtrunk: https://github.com/twisted/twisted/archive/trunk.zip
 
     {trial,coverage}: idna
-    # Pin hypothesis to 3.30 do to coverage issue
-    # See https://github.com/HypothesisWorks/hypothesis-python/issues/997
-    {trial,coverage}: hypothesis==3.30.0
+    {trial,coverage}: hypothesis>=3.44.1
     {trial,coverage}: mock
 
     coverage: coverage


### PR DESCRIPTION
This PR does three things:
 • In `tox.ini`, don't pin hypothesis now that [coverage tracking is fixed](https://github.com/HypothesisWorks/hypothesis-python/issues/997#event-1391243850).
 • In `test_headers.py`, don't generate text only to filter out text that doesn't encode to Latin-1 when we can easily just generate Latin-1-encodable text.
 • Remove `encodeValue`, which is unused and is therefore un-covered.