### PR TITLE
Pin all dependencies in tox.ini

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,12 +26,6 @@ branches:
 #
 matrix:
   include:
-    # PyPy (Python 2.7)
-    - env: TOXENV=coverage-pypy2-tw160,codecov     PYPY_VERSION=5.9.0
-    - env: TOXENV=coverage-pypy2-tw171,codecov     PYPY_VERSION=5.9.0
-    - env: TOXENV=coverage-pypy2-twcurrent,codecov PYPY_VERSION=5.9.0
-    - env: TOXENV=coverage-pypy2-twtrunk,codecov   PYPY_VERSION=5.9.0
-
     - python: 2.7
       env: TOXENV=coverage-py27-tw160,codecov
     - python: 2.7
@@ -79,9 +73,23 @@ matrix:
     - python: 2.7
       env: TOXENV=docs-linkcheck
 
+    - python: pypy
+      env: TOXENV=coverage-pypy2-tw160,codecov
+    - python: pypy
+      env: TOXENV=coverage-pypy2-tw171,codecov
+    - python: pypy
+      env: TOXENV=coverage-pypy2-twcurrent,codecov
+
+    - python: pypy3
+      env: TOXENV=coverage-pypy3-tw160,codecov
+    - python: pypy3
+      env: TOXENV=coverage-pypy3-tw171,codecov
+    - python: pypy3
+      env: TOXENV=coverage-pypy3-twcurrent,codecov
+
+
   allow_failures:
     # Tests against Twisted trunk are allow to fail, as they are not supported.
-    - env: TOXENV=coverage-pypy2-twtrunk
     - env: TOXENV=coverage-py27-twtrunk
     - env: TOXENV=coverage-py34-twtrunk
     - env: TOXENV=coverage-py35-twtrunk

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,11 +27,11 @@ branches:
 matrix:
   include:
     # PyPy (Python 2.7)
-    - env: TOXENV=coverage-pypy-tw155,codecov     PYPY_VERSION=5.7.1
-    - env: TOXENV=coverage-pypy-tw160,codecov     PYPY_VERSION=5.7.1
-    - env: TOXENV=coverage-pypy-tw171,codecov     PYPY_VERSION=5.7.1
-    - env: TOXENV=coverage-pypy-twcurrent,codecov PYPY_VERSION=5.7.1
-    - env: TOXENV=coverage-pypy-twtrunk,codecov   PYPY_VERSION=5.7.1
+    - env: TOXENV=coverage-pypy2-tw155,codecov     PYPY_VERSION=5.7.1
+    - env: TOXENV=coverage-pypy2-tw160,codecov     PYPY_VERSION=5.7.1
+    - env: TOXENV=coverage-pypy2-tw171,codecov     PYPY_VERSION=5.7.1
+    - env: TOXENV=coverage-pypy2-twcurrent,codecov PYPY_VERSION=5.7.1
+    - env: TOXENV=coverage-pypy2-twtrunk,codecov   PYPY_VERSION=5.7.1
 
     - python: 2.7
       env: TOXENV=coverage-py27-tw155,codecov
@@ -90,11 +90,11 @@ matrix:
 
   allow_failures:
     # Tests against Twisted trunk are allow to fail, as they are not supported.
+    - env: TOXENV=coverage-pypy2-twtrunk
     - env: TOXENV=coverage-py27-twtrunk
     - env: TOXENV=coverage-py34-twtrunk
     - env: TOXENV=coverage-py35-twtrunk
     - env: TOXENV=coverage-py36-twtrunk
-    - env: TOXENV=coverage-pypy-twtrunk
 
     # This is not yet required.
     - env: TOXENV=twistedchecker-diff

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,14 +27,11 @@ branches:
 matrix:
   include:
     # PyPy (Python 2.7)
-    - env: TOXENV=coverage-pypy2-tw155,codecov     PYPY_VERSION=5.9.0
     - env: TOXENV=coverage-pypy2-tw160,codecov     PYPY_VERSION=5.9.0
     - env: TOXENV=coverage-pypy2-tw171,codecov     PYPY_VERSION=5.9.0
     - env: TOXENV=coverage-pypy2-twcurrent,codecov PYPY_VERSION=5.9.0
     - env: TOXENV=coverage-pypy2-twtrunk,codecov   PYPY_VERSION=5.9.0
 
-    - python: 2.7
-      env: TOXENV=coverage-py27-tw155,codecov
     - python: 2.7
       env: TOXENV=coverage-py27-tw160,codecov
     - python: 2.7
@@ -45,8 +42,6 @@ matrix:
       env: TOXENV=coverage-py27-twtrunk,codecov
 
     - python: 3.4
-      env: TOXENV=coverage-py34-tw155,codecov
-    - python: 3.4
       env: TOXENV=coverage-py34-tw160,codecov
     - python: 3.4
       env: TOXENV=coverage-py34-tw171,codecov
@@ -56,8 +51,6 @@ matrix:
       env: TOXENV=coverage-py34-twtrunk,codecov
 
     - python: 3.5
-      env: TOXENV=coverage-py35-tw155,codecov
-    - python: 3.5
       env: TOXENV=coverage-py35-tw160,codecov
     - python: 3.5
       env: TOXENV=coverage-py35-tw171,codecov
@@ -66,8 +59,6 @@ matrix:
     - python: 3.5
       env: TOXENV=coverage-py35-twtrunk,codecov
 
-    - python: 3.6
-      env: TOXENV=coverage-py36-tw155,codecov
     - python: 3.6
       env: TOXENV=coverage-py36-tw160,codecov
     - python: 3.6

--- a/.travis.yml
+++ b/.travis.yml
@@ -70,7 +70,9 @@ matrix:
       env: TOXENV=coverage-pypy3-twcurrent,codecov
 
     # Test against Twisted trunk in case something in development breaks us.
-    # This test is allowed to fail below, since the bug may be in Twisted.
+    # This is allowed to fail below, since the bug may be in Twisted.
+    - python: 2.7
+      env: TOXENV=coverage-py27-twtrunk,codecov
     - python: 3.6
       env: TOXENV=coverage-py36-twtrunk,codecov
 
@@ -83,6 +85,7 @@ matrix:
 
   allow_failures:
     # Tests against Twisted trunk are allow to fail, as they are not supported.
+    - env: TOXENV=coverage-py27-twtrunk,codecov
     - env: TOXENV=coverage-py36-twtrunk,codecov
 
     # This is not yet required.

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,11 +27,11 @@ branches:
 matrix:
   include:
     # PyPy (Python 2.7)
-    - env: TOXENV=coverage-pypy2-tw155,codecov     PYPY_VERSION=5.7.1
-    - env: TOXENV=coverage-pypy2-tw160,codecov     PYPY_VERSION=5.7.1
-    - env: TOXENV=coverage-pypy2-tw171,codecov     PYPY_VERSION=5.7.1
-    - env: TOXENV=coverage-pypy2-twcurrent,codecov PYPY_VERSION=5.7.1
-    - env: TOXENV=coverage-pypy2-twtrunk,codecov   PYPY_VERSION=5.7.1
+    - env: TOXENV=coverage-pypy2-tw155,codecov     PYPY_VERSION=5.9.0
+    - env: TOXENV=coverage-pypy2-tw160,codecov     PYPY_VERSION=5.9.0
+    - env: TOXENV=coverage-pypy2-tw171,codecov     PYPY_VERSION=5.9.0
+    - env: TOXENV=coverage-pypy2-twcurrent,codecov PYPY_VERSION=5.9.0
+    - env: TOXENV=coverage-pypy2-twtrunk,codecov   PYPY_VERSION=5.9.0
 
     - python: 2.7
       env: TOXENV=coverage-py27-tw155,codecov

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,10 +20,6 @@ branches:
 #
 #  * The current release of Twisted.
 #
-#  * Twisted trunk, at the time of the build.
-#    This is allowed to fail, as a failure in only this case indicates a likely
-#    compatibility bug in Twisted trunk.
-#
 matrix:
   include:
     - python: 3.6
@@ -37,8 +33,6 @@ matrix:
       env: TOXENV=coverage-py27-tw171,codecov
     - python: 2.7
       env: TOXENV=coverage-py27-twcurrent,codecov
-    - python: 2.7
-      env: TOXENV=coverage-py27-twtrunk,codecov
 
     - python: 3.4
       env: TOXENV=coverage-py34-tw160,codecov
@@ -46,8 +40,6 @@ matrix:
       env: TOXENV=coverage-py34-tw171,codecov
     - python: 3.4
       env: TOXENV=coverage-py34-twcurrent,codecov
-    - python: 3.4
-      env: TOXENV=coverage-py34-twtrunk,codecov
 
     - python: 3.5
       env: TOXENV=coverage-py35-tw160,codecov
@@ -55,8 +47,6 @@ matrix:
       env: TOXENV=coverage-py35-tw171,codecov
     - python: 3.5
       env: TOXENV=coverage-py35-twcurrent,codecov
-    - python: 3.5
-      env: TOXENV=coverage-py35-twtrunk,codecov
 
     - python: 3.6
       env: TOXENV=coverage-py36-tw160,codecov
@@ -64,8 +54,6 @@ matrix:
       env: TOXENV=coverage-py36-tw171,codecov
     - python: 3.6
       env: TOXENV=coverage-py36-twcurrent,codecov
-    - python: 3.6
-      env: TOXENV=coverage-py36-twtrunk,codecov
 
     - python: pypy
       env: TOXENV=coverage-pypy2-tw160,codecov
@@ -81,6 +69,11 @@ matrix:
     - python: pypy3
       env: TOXENV=coverage-pypy3-twcurrent,codecov
 
+    # Test against Twisted trunk in case something in development breaks us.
+    # This test is allowed to fail below, since the bug may be in Twisted.
+    - python: 3.6
+      env: TOXENV=coverage-py36-twtrunk,codecov
+
     - python: 2.7
       env: TOXENV=twistedchecker-diff
     - python: 2.7
@@ -90,10 +83,7 @@ matrix:
 
   allow_failures:
     # Tests against Twisted trunk are allow to fail, as they are not supported.
-    - env: TOXENV=coverage-py27-twtrunk
-    - env: TOXENV=coverage-py34-twtrunk
-    - env: TOXENV=coverage-py35-twtrunk
-    - env: TOXENV=coverage-py36-twtrunk
+    - env: TOXENV=coverage-py36-twtrunk,codecov
 
     # This is not yet required.
     - env: TOXENV=twistedchecker-diff

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,11 @@ branches:
 #
 matrix:
   include:
+    - python: 3.6
+      env: TOXENV=flake8
+    - python: 3.6
+      env: TOXENV=mypy
+
     - python: 2.7
       env: TOXENV=coverage-py27-tw160,codecov
     - python: 2.7
@@ -62,17 +67,6 @@ matrix:
     - python: 3.6
       env: TOXENV=coverage-py36-twtrunk,codecov
 
-    - python: 3.6
-      env: TOXENV=flake8
-    - python: 3.6
-      env: TOXENV=mypy
-    - python: 2.7
-      env: TOXENV=twistedchecker-diff
-    - python: 2.7
-      env: TOXENV=docs
-    - python: 2.7
-      env: TOXENV=docs-linkcheck
-
     - python: pypy
       env: TOXENV=coverage-pypy2-tw160,codecov
     - python: pypy
@@ -87,6 +81,12 @@ matrix:
     - python: pypy3
       env: TOXENV=coverage-pypy3-twcurrent,codecov
 
+    - python: 2.7
+      env: TOXENV=twistedchecker-diff
+    - python: 2.7
+      env: TOXENV=docs
+    - python: 2.7
+      env: TOXENV=docs-linkcheck
 
   allow_failures:
     # Tests against Twisted trunk are allow to fail, as they are not supported.

--- a/.travis/install
+++ b/.travis/install
@@ -3,28 +3,4 @@
 set -e
 set -u
 
-case "${TOXENV}" in
-    *-pypy*)
-        echo "Installing pyenv..."
-
-        PYENV_ROOT="${HOME}/.pyenv";
-        rm -rf "${PYENV_ROOT}";
-        git clone "https://github.com/pyenv/pyenv" "${PYENV_ROOT}";
-
-        pyenv="${PYENV_ROOT}/bin/pyenv";
-
-        # Temporarily unset -e and -u because pyenv isn't clean
-        set +e
-        set +u
-        eval "$("${pyenv}" init -)";
-        set -e
-        set -u
-
-        echo "Installing PyPy..."
-
-        "${pyenv}" install "pypy-${PYPY_VERSION}";
-        "${pyenv}" global "pypy-${PYPY_VERSION}";
-        ;;
-esac;
-
 pip install tox;

--- a/.travis/run
+++ b/.travis/run
@@ -3,6 +3,8 @@
 set -e
 set -u
 
+export TOX_SKIP_MISSING_INTERPRETERS="False";
+
 case "${TOXENV}" in
     *-pypy*)
         PYENV_ROOT="${HOME}/.pyenv";

--- a/.travis/run
+++ b/.travis/run
@@ -5,12 +5,4 @@ set -u
 
 export TOX_SKIP_MISSING_INTERPRETERS="False";
 
-case "${TOXENV}" in
-    *-pypy*)
-        PYENV_ROOT="${HOME}/.pyenv";
-        pyenv="${PYENV_ROOT}/bin/pyenv";
-        eval "$("${pyenv}" init -)";
-        ;;
-esac;
-
 exec "$@";

--- a/README.rst
+++ b/README.rst
@@ -8,6 +8,9 @@ Klein, a Web Micro-Framework
 .. image:: https://codecov.io/github/twisted/klein/coverage.svg?branch=master
     :target: https://codecov.io/github/twisted/klein?branch=master
     :alt: Code Coverage
+.. image:: https://requires.io/github/twisted/klein/requirements.svg?branch=master
+    :target: https://requires.io/github/twisted/klein/requirements/?branch=master
+    :alt: Requirements Status
 .. image:: https://img.shields.io/pypi/pyversions/klein.svg
     :target: https://pypi.python.org/pypi/klein
     :alt: Python Version Compatibility

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,0 @@
-mock ; python_version <= '3.3'

--- a/tox.ini
+++ b/tox.ini
@@ -92,13 +92,13 @@ commands =
 skip_install = True
 
 deps =
-    flake8
-    flake8-bugbear
-    flake8_docstrings
-    flake8-import-order
-    flake8-pep3101
-    pep8-naming
-    mccabe
+    flake8==3.5.9
+    flake8-bugbear==17.12.0
+    flake8-docstrings==1.1.0
+    flake8-import-order==0.16
+    flake8-pep3101==1.2
+    pep8-naming==0.4.1
+    mccabe==0.6.1
 
 basepython = python3.6
 
@@ -163,7 +163,7 @@ basepython = python3.6
 skip_install = True
 
 deps =
-    mypy
+    mypy==0.560
 
 commands =
     "{toxinidir}/.travis/environment"
@@ -195,7 +195,8 @@ ignore_missing_imports = True
 
 [testenv:twistedchecker]
 
-deps = twistedchecker
+deps =
+    twistedchecker==0.7.2
 
 basepython = python2.7
 
@@ -213,7 +214,7 @@ commands =
 
 deps =
     {[testenv:twistedchecker]deps}
-    diff_cover
+    diff_cover==1.0.1
 
 basepython = python2.7
 
@@ -233,7 +234,8 @@ basepython = python
 
 skip_install = True
 
-deps = codecov
+deps =
+    codecov==2.0.10
 
 commands =
     "{toxinidir}/.travis/environment"
@@ -250,8 +252,8 @@ commands =
 [testenv:docs]
 
 deps =
-    sphinx
-    sphinx_rtd_theme
+    sphinx==1.6.5
+    sphinx_rtd_theme==0.2.4
 
 basepython = python2.7
 

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,7 @@ envlist =
     mypy
 
     # Twisted 15.5 is the first version to support Python 3 (3.3+)
-    coverage-py{27,34,35,36,py2,py3}-tw{155,166,171,current,trunk}
+    coverage-py{27,34,35,36,py2,py3}-tw{166,171,current,trunk}
 
     docs, docs-linkcheck
 
@@ -29,12 +29,6 @@ basepython =
     pypy3: pypy3
 
 deps =
-    tw150: Twisted==15.0.0
-    tw151: Twisted==15.1.0
-    tw152: Twisted==15.2.1
-    tw153: Twisted==15.3.0
-    tw154: Twisted==15.4.0
-    tw155: Twisted==15.5.0
     tw160: Twisted==16.0.0
     tw161: Twisted==16.1.1
     tw162: Twisted==16.2.0

--- a/tox.ini
+++ b/tox.ini
@@ -27,22 +27,22 @@ basepython =
     py37: python3.7
 
 deps =
-    tw150: Twisted==15.0
-    tw151: Twisted==15.1
-    tw152: Twisted==15.2
-    tw153: Twisted==15.3
-    tw154: Twisted==15.4
-    tw155: Twisted==15.5
-    tw160: Twisted==16.0
-    tw161: Twisted==16.1
-    tw162: Twisted==16.2
-    tw163: Twisted==16.3
-    tw164: Twisted==16.4
-    tw165: Twisted==16.5
-    tw166: Twisted==16.6
-    tw171: Twisted==17.1
-    tw175: Twisted==17.5
-    tw179: Twisted==17.9
+    tw150: Twisted==15.0.0
+    tw151: Twisted==15.1.0
+    tw152: Twisted==15.2.1
+    tw153: Twisted==15.3.0
+    tw154: Twisted==15.4.0
+    tw155: Twisted==15.5.0
+    tw160: Twisted==16.0.0
+    tw161: Twisted==16.1.1
+    tw162: Twisted==16.2.0
+    tw163: Twisted==16.3.2
+    tw164: Twisted==16.4.1
+    tw165: Twisted==16.5.0
+    tw166: Twisted==16.6.0
+    tw171: Twisted==17.1.0
+    tw175: Twisted==17.5.0
+    tw179: Twisted==17.9.0
     twcurrent: Twisted
     twtrunk: https://github.com/twisted/twisted/archive/trunk.zip
 

--- a/tox.ini
+++ b/tox.ini
@@ -19,7 +19,7 @@ skip_missing_interpreters = True
 [testenv]
 
 basepython =
-    pypy: pypy
+    pypy2: pypy
     py27: python2.7
     py34: python3.4
     py35: python3.5
@@ -46,11 +46,20 @@ deps =
     twcurrent: Twisted
     twtrunk: https://github.com/twisted/twisted/archive/trunk.zip
 
-    {trial,coverage}: idna
-    {trial,coverage}: hypothesis>=3.44.1
-    {trial,coverage}: mock
+    attrs==17.3.0
+    hyperlink==17.3.1
+    incremental==17.5.0
+    six==1.11.0
+    Tubes==0.2.0
+    Werkzeug==0.13
+    zope.interface==4.4.3
 
-    coverage: coverage
+    {trial,coverage}: hypothesis==3.44.1
+    {trial,coverage}: idna==2.6
+    {trial,coverage}-py{27,py2}: mock==2.0.0
+    {trial,coverage}-py{27,py2}: typing==3.6.2
+
+    coverage: coverage==4.4.2
 
 passenv =
     # See https://github.com/codecov/codecov-python/blob/5b9d539a6a09bc84501b381b563956295478651a/README.md#using-tox

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,7 @@ envlist =
     mypy
 
     # Twisted 15.5 is the first version to support Python 3 (3.3+)
-    coverage-py{27,py2,34,35,36}-tw{155,166,171,current,trunk}
+    coverage-py{27,34,35,36,py2,py3}-tw{155,166,171,current,trunk}
 
     docs, docs-linkcheck
 
@@ -19,12 +19,14 @@ skip_missing_interpreters = {env:TOX_SKIP_MISSING_INTERPRETERS:True}
 [testenv]
 
 basepython =
-    pypy2: pypy
     py27: python2.7
     py34: python3.4
     py35: python3.5
     py36: python3.6
     py37: python3.7
+
+    pypy2: pypy
+    pypy3: pypy3
 
 deps =
     tw150: Twisted==15.0.0

--- a/tox.ini
+++ b/tox.ini
@@ -86,7 +86,7 @@ commands =
 skip_install = True
 
 deps =
-    flake8==3.5.9
+    flake8==3.5.0
     flake8-bugbear==17.12.0
     flake8-docstrings==1.1.0
     flake8-import-order==0.16

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,7 @@ envlist =
     mypy
 
     # Twisted 15.5 is the first version to support Python 3 (3.3+)
-    coverage-py{27,py,34,35,36}-tw{155,166,171,current,trunk}
+    coverage-py{27,py2,34,35,36}-tw{155,166,171,current,trunk}
 
     docs, docs-linkcheck
 

--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,7 @@ envlist =
 
     docs, docs-linkcheck
 
-skip_missing_interpreters = True
+skip_missing_interpreters = {env:TOX_SKIP_MISSING_INTERPRETERS:True}
 
 
 ##


### PR DESCRIPTION
Things here:

 * Add all dependencies into `tox.ini` with pinned versions, so that updates to dependencies (including flake8 and mypy) don't add unexpected curveballs into new PRs.
 * Add Requires.io to `README.rst` so that we have an indicator when dependencies are outdated.
 * Make it so that `skip_missing_intrepreters` is set to `False` for Travis builds, and that should be a failure mode there.  It's still defaults to `True`, as local dev test machines may not install every Python.
 * Remove Twisted 15.5 from the test matrix, because it is now 17.12, and 17.12 - 15.5 = 2.7 (in base calendar), and that is > 2.
 * Start using Travis CI's PyPy instead of installing it, now that Travis has a non-ancient PyPy (they have 5.8.0, which is newer than the 5.7.1 we've been installing).
 * Add PyPy3 to the test matrix because Travis supports it and it works.
 * Run `twtrunk` tests with Python 3.6 only instead of which every Python version, to manage the size of the test matrix but still have a canary for Twisted trunk.
 * `twtrunk` tests were supposed to be allowed to fail but weren't due to an out-of-sync part of the Travis config; that's fixed.
 * Run `flake8` and `mypy` early since they are a bit faster and catch low-hanging fruit.
 * Run PyPy late because it's generally slowest.  Keep optional bits last.

