### PR TITLE
Add HTTPHeadersWrappingHeaders

### DIFF
--- a/.travis/mypy
+++ b/.travis/mypy
@@ -28,7 +28,7 @@ tmp="$(mktemp -t mypy.XXXX)";
 # * These are related to mypy not knowing about zope.interface:
 #   - Incompatible return value type
 #   - Method must have at least one argument
-#   - Unexpected keyword argument
+#   - Unexpected keyword argument (also effects attrs classes' __init__)
 #
 
 mypy "$@"      \
@@ -36,6 +36,7 @@ mypy "$@"      \
         -e ': note: .* defined here'                                                                               \
         -e ': error: "Callable\[\[[^]]*\], [^]]*\]" has no attribute "skip"'                                       \
         -e ': error: "Callable\[\[[^]]*\], [^]]*\]" has no attribute "todo"'                                       \
+        -e ': error: Unexpected keyword argument "[^"]*" for "HTTPHeadersWrappingHeaders"'                         \
         -e ': error: Unexpected keyword argument "[^"]*" for "[^"]*" of "IHTTPHeaders"'                            \
         -e ': error: Unexpected keyword argument "[^"]*" for "[^"]*" of "IMutableHTTPHeaders"'                     \
         -e ': error: Unexpected keyword argument "[^"]*" for "FrozenHTTPHeaders"'                                  \

--- a/src/klein/_headers_compat.py
+++ b/src/klein/_headers_compat.py
@@ -70,7 +70,7 @@ class HTTPHeadersWrappingHeaders(object):
         else:
             raise TypeError("name {!r} must be text or bytes".format(name))
 
-        return tuple(values)
+        return values
 
 
     def remove(self, name):

--- a/src/klein/_headers_compat.py
+++ b/src/klein/_headers_compat.py
@@ -1,0 +1,86 @@
+# -*- test-case-name: klein.test.test_headers -*-
+# Copyright (c) 2017-2018. See LICENSE for details.
+
+"""
+Support for interoperability with L{twisted.web.http_headers.Headers}.
+"""
+
+from typing import AnyStr, Iterable, Text, Tuple
+
+from attr import attrib, attrs
+from attr.validators import instance_of
+
+from twisted.web.http_headers import Headers
+
+from zope.interface import implementer
+
+from ._headers import (
+    IMutableHTTPHeaders, RawHeaders, String, headerNameAsBytes,
+    headerValueAsText, normalizeHeaderName, rawHeaderName,
+    rawHeaderNameAndValue,
+)
+
+AnyStr, Iterable, RawHeaders, String, Tuple  # Silence linter
+
+
+__all__ = ()
+
+
+
+@implementer(IMutableHTTPHeaders)
+@attrs(frozen=True)
+class HTTPHeadersWrappingHeaders(object):
+    """
+    HTTP entity headers.
+
+    This is an L{IMutableHTTPHeaders} implementation that wraps a L{Headers}
+    object.
+    """
+
+    _headers = attrib(validator=instance_of(Headers))  # type: Headers
+
+
+    @property
+    def rawHeaders(self):
+        # type: () -> RawHeaders
+        def pairs():
+            # type: () -> Iterable[Tuple[bytes, bytes]]
+            for name, values in self._headers.getAllRawHeaders():
+                name = normalizeHeaderName(name)
+                for value in values:
+                    yield (name, value)
+
+        return tuple(pairs())
+
+
+    def getValues(self, name):
+        # type: (AnyStr) -> Iterable[AnyStr]
+        if isinstance(name, bytes):
+            values = self._headers.getRawHeaders(name, default=())
+        elif isinstance(name, Text):
+            values = (
+                headerValueAsText(value)
+                for value in self._headers.getRawHeaders(
+                    headerNameAsBytes(name), default=()
+                )
+            )
+        else:
+            raise TypeError("name {!r} must be text or bytes".format(name))
+
+        return tuple(values)
+
+
+    # NOTE: In case Headers has different ideas about encoding text than we do,
+    # always interact with it using bytes.
+
+
+    def remove(self, name):
+        # type: (String) -> None
+        self._headers.removeHeader(rawHeaderName(name))
+
+
+    def addValue(self, name, value):
+        # type: (AnyStr, AnyStr) -> None
+        rawName, rawValue = rawHeaderNameAndValue(name, value)
+
+        self._headers.addRawHeader(rawName, rawValue)

--- a/src/klein/_headers_compat.py
+++ b/src/klein/_headers_compat.py
@@ -37,6 +37,9 @@ class HTTPHeadersWrappingHeaders(object):
     object.
     """
 
+    # NOTE: In case Headers has different ideas about encoding text than we do,
+    # always interact with it using bytes, not text.
+
     _headers = attrib(validator=instance_of(Headers))  # type: Headers
 
 
@@ -68,10 +71,6 @@ class HTTPHeadersWrappingHeaders(object):
             raise TypeError("name {!r} must be text or bytes".format(name))
 
         return tuple(values)
-
-
-    # NOTE: In case Headers has different ideas about encoding text than we do,
-    # always interact with it using bytes.
 
 
     def remove(self, name):

--- a/src/klein/test/test_headers_compat.py
+++ b/src/klein/test/test_headers_compat.py
@@ -1,0 +1,66 @@
+# -*- test-case-name: klein.test.test_headers -*-
+# Copyright (c) 2017-2018. See LICENSE for details.
+
+"""
+Tests for L{klein._headers}.
+"""
+
+from twisted.web.http_headers import Headers
+
+from ._trial import TestCase
+from .test_headers import MutableHTTPHeadersTestsMixIn
+from .._headers import (
+    IMutableHTTPHeaders, RawHeaders, normalizeRawHeadersFrozen
+)
+from .._headers_compat import HTTPHeadersWrappingHeaders
+
+# Silence linter
+IMutableHTTPHeaders, RawHeaders
+
+
+__all__ = ()
+
+
+
+class HTTPHeadersWrappingHeadersTests(MutableHTTPHeadersTestsMixIn, TestCase):
+    """
+    Tests for L{HTTPHeadersWrappingHeaders}.
+    """
+
+    def assertRawHeadersEqual(self, rawHeaders1, rawHeaders2):
+        # type: (RawHeaders, RawHeaders) -> None
+        super(HTTPHeadersWrappingHeadersTests, self).assertRawHeadersEqual(
+            sorted(rawHeaders1), sorted(rawHeaders2)
+        )
+
+
+    def headers(self, rawHeaders):
+        # type: (RawHeaders) -> IMutableHTTPHeaders
+        headers = Headers()
+        for rawName, rawValue in rawHeaders:
+            headers.addRawHeader(rawName, rawValue)
+
+        return HTTPHeadersWrappingHeaders(headers=headers)
+
+
+    def test_rawHeaders(self):
+        # type: () -> None
+        """
+        L{MutableHTTPHeaders.rawHeaders} equals raw headers matching the
+        L{Headers} given at init time.
+        """
+        rawHeaders = ((b"b", b"2a"), (b"a", b"1"), (b"B", b"2b"))
+        webHeaders = Headers()
+        for name, value in rawHeaders:
+            webHeaders.addRawHeader(name, value)
+        headers = HTTPHeadersWrappingHeaders(headers=webHeaders)
+
+        # Note that Headers does not give you back header names in network
+        # order, but it should give us back values in network order.
+        # So we need to normalize our way around.
+
+        normalizedRawHeaders = normalizeRawHeadersFrozen(rawHeaders)
+
+        self.assertEqual(
+            sorted(headers.rawHeaders), sorted(normalizedRawHeaders)
+        )


### PR DESCRIPTION
This class wraps `twisted.web.http_headers.Headers` object and exposes it as an `IHTTPHeaders` implementation.