### PR TITLE
Add new request and response API

### DIFF
--- a/.travis/mypy
+++ b/.travis/mypy
@@ -33,21 +33,26 @@ tmp="$(mktemp -t mypy.XXXX)";
 
 mypy "$@"      \
     | grep -v  \
-        -e ': note: .* defined here'                                                                               \
         -e ': error: "Callable\[\[[^]]*\], [^]]*\]" has no attribute "skip"'                                       \
         -e ': error: "Callable\[\[[^]]*\], [^]]*\]" has no attribute "todo"'                                       \
-        -e ': error: Unexpected keyword argument "[^"]*" for "[^"]*" of "IHTTPHeaders"'                            \
-        -e ': error: Unexpected keyword argument "[^"]*" for "[^"]*" of "IMutableHTTPHeaders"'                     \
-        -e ': error: Unexpected keyword argument "[^"]*" for "FrozenHTTPHeaders"'                                  \
-        -e ': error: Unexpected keyword argument "[^"]*" for "MutableHTTPHeaders"'                                 \
         -e ': error: Argument 2 to "[^"]*" of "IMutableHTTPHeaders" has incompatible type'                         \
         -e ': error: Incompatible return value type (got "[^"]*", expected "IMutableHTTPHeaders")'                 \
-        -e '^src/klein/_decorators.py:.[0-9:]*: error: Function is missing a type annotation'                      \
-        -e '^src/klein/_plating.py:.[0-9:]*: error: Function is missing a type annotation'                         \
+        -e ': error: Incompatible return value type (got "[^"]*HTTPRequest", expected "IHTTPMessage")'             \
+        -e ': error: Incompatible return value type (got "[^"]*HTTPResponse", expected "IHTTPMessage")'            \
+        -e ': error: Method must have at least one argument'                                                       \
+        -e ': error: Unexpected keyword argument "[^"]*" for "FrozenHTTPHeaders"'                                  \
+        -e ': error: Unexpected keyword argument "[^"]*" for "FrozenHTTPRequest"'                                  \
+        -e ': error: Unexpected keyword argument "[^"]*" for "FrozenHTTPResponse"'                                 \
+        -e ': error: Unexpected keyword argument "[^"]*" for "MutableHTTPHeaders"'                                 \
+        -e ': error: Unexpected keyword argument "[^"]*" for "[^"]*" of "IHTTPHeaders"'                            \
+        -e ': error: Unexpected keyword argument "[^"]*" for "[^"]*" of "IMutableHTTPHeaders"'                     \
+        -e ': note: .* defined here'                                                                               \
         -e '^src/klein/_app.py:.[0-9:]*: error: All conditional function variants must have identical signatures'  \
         -e '^src/klein/_app.py:.[0-9:]*: error: Function is missing a type annotation'                             \
         -e '^src/klein/_app.py:.[0-9:]*: error: Need type annotation for variable'                                 \
+        -e '^src/klein/_decorators.py:.[0-9:]*: error: Function is missing a type annotation'                      \
         -e '^src/klein/_interfaces.py:.[0-9:]*: error: Function is missing a type annotation'                      \
+        -e '^src/klein/_plating.py:.[0-9:]*: error: Function is missing a type annotation'                         \
         -e '^src/klein/_resource.py:.[0-9:]*: error: Function is missing a type annotation'                        \
         -e '^src/klein/test/_trial.py:.[0-9:]*: error: Function is missing a type annotation'                      \
         -e '^src/klein/test/py3_test_resource.py:.[0-9:]*: error: Function is missing a type annotation'           \

--- a/.travis/mypy
+++ b/.travis/mypy
@@ -33,19 +33,12 @@ tmp="$(mktemp -t mypy.XXXX)";
 
 mypy "$@"      \
     | grep -v  \
-        -e ': error: "Callable\[\[[^]]*\], [^]]*\]" has no attribute "skip"'                                       \
-        -e ': error: "Callable\[\[[^]]*\], [^]]*\]" has no attribute "todo"'                                       \
+        -e ': error: "Callable\[\[[^]]*\], [^]]*\]" has no attribute "\(skip\|todo\)"'                             \
         -e ': error: Argument 2 to "[^"]*" of "IMutableHTTPHeaders" has incompatible type'                         \
-        -e ': error: Incompatible return value type (got "[^"]*", expected "IMutableHTTPHeaders")'                 \
-        -e ': error: Incompatible return value type (got "[^"]*HTTPRequest", expected "IHTTPMessage")'             \
-        -e ': error: Incompatible return value type (got "[^"]*HTTPResponse", expected "IHTTPMessage")'            \
+        -e ': error: Incompatible return value type (got "[^"]*HTTP[^"]*", expected "I[^"]*HTTP[^"]*")'            \
         -e ': error: Method must have at least one argument'                                                       \
-        -e ': error: Unexpected keyword argument "[^"]*" for "FrozenHTTPHeaders"'                                  \
-        -e ': error: Unexpected keyword argument "[^"]*" for "FrozenHTTPRequest"'                                  \
-        -e ': error: Unexpected keyword argument "[^"]*" for "FrozenHTTPResponse"'                                 \
-        -e ': error: Unexpected keyword argument "[^"]*" for "MutableHTTPHeaders"'                                 \
-        -e ': error: Unexpected keyword argument "[^"]*" for "[^"]*" of "IHTTPHeaders"'                            \
-        -e ': error: Unexpected keyword argument "[^"]*" for "[^"]*" of "IMutableHTTPHeaders"'                     \
+        -e ': error: Unexpected keyword argument "[^"]*" for "IOFount"'                                            \
+        -e ': error: Unexpected keyword argument.* for .*"[^"]*HTTP\(Headers\|Request\|Response\)"'                \
         -e ': note: .* defined here'                                                                               \
         -e '^src/klein/_app.py:.[0-9:]*: error: All conditional function variants must have identical signatures'  \
         -e '^src/klein/_app.py:.[0-9:]*: error: Function is missing a type annotation'                             \

--- a/src/klein/_message.py
+++ b/src/klein/_message.py
@@ -1,0 +1,160 @@
+# -*- test-case-name: klein.test.test_message -*-
+# Copyright (c) 2017-2018. See LICENSE for details.
+
+"""
+HTTP message API.
+"""
+
+from typing import Any, Optional, Union
+
+from attr import attrib, attrs
+from attr.validators import instance_of, optional
+
+from tubes.itube import IFount
+
+from twisted.internet.defer import Deferred, succeed
+
+from zope.interface import Attribute, Interface
+
+from ._headers import IHTTPHeaders
+from ._tubes import bytesToFount, fountToBytes
+
+Any, Deferred, IFount, IHTTPHeaders, Optional  # Silence linter
+
+
+__all__ = ()
+
+
+
+# Interfaces
+
+class NoFountError(Exception):
+    """
+    Request has no fount.
+    This implies someone already accessed the body fount.
+    """
+
+
+
+class IHTTPMessage(Interface):
+    """
+    HTTP entity.
+    """
+
+    headers = Attribute("Entity headers.")  # type: IHTTPHeaders
+
+
+    def bodyAsFount():
+        # type: () -> IFount
+        """
+        The entity body, as a fount.
+
+        @note: The fount may only be accessed once.
+            It provides a mechanism for accessing the body as a stream of data,
+            potentially as it is read from the network, without having to cache
+            the entire body, which may be large.
+            Because there is no caching, it is not possible to "start over" by
+            accessing the fount a second time.
+            Attempting to do so will raise L{NoFountError}.
+
+        @raise NoFountError: If the fount has previously been accessed.
+        """
+
+
+    def bodyAsBytes():
+        # type: () -> Deferred[bytes]
+        """
+        The entity body, as bytes.
+
+        @note: This necessarily reads the entire entity body into memory,
+            which may be a problem if the body is large.
+
+        @note: This method caches the body, which means that unlike
+            C{self.bodyAsFount}, calling it repeatedly will return the same
+            data.
+
+        @note: This method accesses the fount (via C{self.bodyAsFount}), which
+            means the fount will not be available afterwards, and that if
+            C{self.bodyAsFount} has previously been called directly, this
+            method will raise L{NoFountError}.
+
+        @raise NoFountError: If the fount has previously been accessed.
+        """
+
+
+
+# Code shared by internal implementations of IHTTPMessage
+
+InternalBody = Union[bytes, IFount]
+
+
+
+@attrs(frozen=False)
+class MessageState(object):
+    """
+    Internal mutable state for HTTP message implementations in L{klein}.
+    """
+
+    cachedBody = attrib(
+        validator=optional(instance_of(bytes)), default=None, init=False
+    )  # type: Optional[bytes]
+
+    fountExhausted = attrib(
+        validator=instance_of(bool), default=False, init=False
+    )  # type: bool
+
+
+
+def validateBody(instance, attribute, body):
+    # type: (Any, Any, InternalBody) -> None
+    """
+    Validator for L{InternalBody}.
+    """
+
+    if (
+        not isinstance(body, bytes) and
+        not IFount.providedBy(body)
+    ):
+        raise TypeError("body must be bytes or IFount")
+
+
+def bodyAsFount(body, state):
+    # type: (InternalBody, MessageState) -> IFount
+    """
+    Return a fount for a given L{InternalBody}.
+    """
+
+    if state.fountExhausted:
+        raise NoFountError()
+    state.fountExhausted = True
+
+    if isinstance(body, bytes):
+        return bytesToFount(body)
+
+    # assuming: IFount.providedBy(body)
+
+    return body
+
+
+def bodyAsBytes(body, state):
+    # type: (InternalBody, MessageState) -> Deferred[bytes]
+    """
+    Return bytes for a given L{InternalBody}.
+    """
+
+    if isinstance(body, bytes):
+        return succeed(body)
+
+    # assuming: IFount.providedBy(body)
+
+    if state.cachedBody is not None:
+        return succeed(state.cachedBody)
+
+    def cache(bodyBytes):
+        # type: (bytes) -> bytes
+        state.cachedBody = bodyBytes
+        return bodyBytes
+
+    d = fountToBytes(body)
+    d.addCallback(cache)
+    return d

--- a/src/klein/_message.py
+++ b/src/klein/_message.py
@@ -28,10 +28,10 @@ __all__ = ()
 
 # Interfaces
 
-class NoFountError(Exception):
+class FountAlreadyAccessedError(Exception):
     """
-    Request has no fount.
-    This implies someone already accessed the body fount.
+    The HTTP message's fount has already been accessed and is no longer
+    available.
     """
 
 
@@ -55,9 +55,10 @@ class IHTTPMessage(Interface):
             the entire body, which may be large.
             Because there is no caching, it is not possible to "start over" by
             accessing the fount a second time.
-            Attempting to do so will raise L{NoFountError}.
+            Attempting to do so will raise L{FountAlreadyAccessedError}.
 
-        @raise NoFountError: If the fount has previously been accessed.
+        @raise FountAlreadyAccessedError: If the fount has previously been
+            accessed.
         """
 
 
@@ -76,9 +77,10 @@ class IHTTPMessage(Interface):
         @note: This method accesses the fount (via C{self.bodyAsFount}), which
             means the fount will not be available afterwards, and that if
             C{self.bodyAsFount} has previously been called directly, this
-            method will raise L{NoFountError}.
+            method will raise L{FountAlreadyAccessedError}.
 
-        @raise NoFountError: If the fount has previously been accessed.
+        @raise FountAlreadyAccessedError: If the fount has previously been
+            accessed.
         """
 
 
@@ -125,7 +127,7 @@ def bodyAsFount(body, state):
     """
 
     if state.fountExhausted:
-        raise NoFountError()
+        raise FountAlreadyAccessedError()
     state.fountExhausted = True
 
     if isinstance(body, bytes):

--- a/src/klein/_request.py
+++ b/src/klein/_request.py
@@ -1,0 +1,73 @@
+# -*- test-case-name: klein.test.test_request -*-
+# Copyright (c) 2017-2018. See LICENSE for details.
+
+"""
+HTTP request API.
+"""
+
+from typing import Text, Union
+
+from attr import Factory, attrib, attrs
+from attr.validators import instance_of, provides
+
+from hyperlink import URL
+
+from tubes.itube import IFount
+
+from twisted.internet.defer import Deferred
+
+from zope.interface import Attribute, implementer
+
+from ._headers import IHTTPHeaders
+from ._message import (
+    IHTTPMessage, MessageState, bodyAsBytes, bodyAsFount, validateBody
+)
+
+# Silence linter
+Deferred, IFount, IHTTPHeaders, Text, Union
+
+
+__all__ = ()
+
+
+
+# Interfaces
+
+class IHTTPRequest(IHTTPMessage):
+    """
+    HTTP request.
+    """
+
+    method = Attribute("Request method.")  # type: Text
+    uri    = Attribute("Request URI.")     # type: URL
+
+
+
+# Implementation
+
+@implementer(IHTTPRequest)
+@attrs(frozen=True)
+class FrozenHTTPRequest(object):
+    """
+    Immutable HTTP request.
+    """
+
+    method  = attrib(validator=instance_of(Text))       # type: Text
+    uri     = attrib(validator=instance_of(URL))        # type: URL
+    headers = attrib(validator=provides(IHTTPHeaders))  # type: IHTTPHeaders
+
+    _body = attrib(validator=validateBody)  # type: Union[bytes, IFount]
+
+    _state = attrib(
+        default=Factory(MessageState), init=False
+    )  # type: MessageState
+
+
+    def bodyAsFount(self):
+        # type: () -> IFount
+        return bodyAsFount(self._body, self._state)
+
+
+    def bodyAsBytes(self):
+        # type: () -> Deferred[bytes]
+        return bodyAsBytes(self._body, self._state)

--- a/src/klein/_response.py
+++ b/src/klein/_response.py
@@ -1,0 +1,65 @@
+# -*- test-case-name: klein.test.test_response -*-
+# Copyright (c) 2017-2018. See LICENSE for details.
+
+"""
+HTTP response API.
+"""
+
+from typing import Union
+
+from attr import Factory, attrib, attrs
+from attr.validators import instance_of, provides
+
+from tubes.itube import IFount
+
+from twisted.internet.defer import Deferred
+
+from zope.interface import Attribute, implementer
+
+from ._headers import IHTTPHeaders
+from ._message import (
+    IHTTPMessage, MessageState, bodyAsBytes, bodyAsFount, validateBody
+)
+
+Deferred, IFount, Union  # Silence linter
+
+
+__all__ = ()
+
+
+
+class IHTTPResponse(IHTTPMessage):
+    """
+    HTTP response.
+    """
+
+    status = Attribute("Response status code.")  # type: int
+
+
+
+@implementer(IHTTPResponse)
+@attrs(frozen=True)
+class FrozenHTTPResponse(object):
+    """
+    Immutable HTTP response.
+    """
+
+    status = attrib(validator=instance_of(int))  # type: int
+
+    headers = attrib(validator=provides(IHTTPHeaders))  # type: IHTTPHeaders
+
+    _body = attrib(validator=validateBody)  # type: Union[bytes, IFount]
+
+    _state = attrib(
+        default=Factory(MessageState), init=False
+    )  # type: MessageState
+
+
+    def bodyAsFount(self):
+        # type: () -> IFount
+        return bodyAsFount(self._body, self._state)
+
+
+    def bodyAsBytes(self):
+        # type: () -> Deferred[bytes]
+        return bodyAsBytes(self._body, self._state)

--- a/src/klein/_tubes.py
+++ b/src/klein/_tubes.py
@@ -1,0 +1,105 @@
+# Copyright (c) 2017-2018. See LICENSE for details.
+
+"""
+Extensions to Tubes.
+"""
+
+from io import BytesIO
+from typing import Iterable
+from typing.io import BinaryIO
+
+from attr import attrib, attrs
+from attr.validators import instance_of, optional, provides
+
+from tubes.itube import IDrain, IFount, ISegment
+from tubes.kit import Pauser, beginFlowingTo
+from tubes.undefer import fountToDeferred
+
+from twisted.internet.defer import Deferred
+from twisted.python.failure import Failure
+
+from zope.interface import implementer
+
+BinaryIO, Deferred, Iterable  # Silence linter
+
+
+__all__ = ()
+
+
+# See https://github.com/twisted/tubes/issues/60
+def fountToBytes(fount):
+    # type: (IFount) -> Deferred[bytes]
+    def collect(chunks):
+        # type: (Iterable[bytes]) -> bytes
+        return b"".join(chunks)
+
+    d = fountToDeferred(fount)
+    d.addCallback(collect)
+    return d
+
+
+# See https://github.com/twisted/tubes/issues/60
+def bytesToFount(data):
+    # type: (bytes) -> IFount
+    return IOFount(source=BytesIO(data))
+
+
+
+# https://github.com/twisted/tubes/issues/61
+@implementer(IFount)
+@attrs(frozen=False)
+class IOFount(object):
+    """
+    Fount that reads from a file-like-object.
+    """
+
+    outputType = ISegment
+
+    _source = attrib()  # type: BinaryIO
+
+    drain = attrib(
+        validator=optional(provides(IDrain)), default=None, init=False
+    )  # type: IDrain
+    _paused = attrib(validator=instance_of(bool), default=False, init=False)
+
+
+    def __attrs_post_init__(self):
+        # type: () -> None
+        self._pauser = Pauser(self._pause, self._resume)
+
+
+    def _flowToDrain(self):
+        # type: () -> None
+        if self.drain is not None and not self._paused:
+            data = self._source.read()
+            if data:
+                self.drain.receive(data)
+            self.drain.flowStopped(Failure(StopIteration()))
+
+
+    def flowTo(self, drain):
+        # type: (IDrain) -> IFount
+        result = beginFlowingTo(self, drain)
+        self._flowToDrain()
+        return result
+
+
+    def pauseFlow(self):
+        # type: () -> None
+        return self._pauser.pause()
+
+
+    def stopFlow(self):
+        # type: () -> None
+        return self._pauser.resume()
+
+
+    def _pause(self):
+        # type: () -> None
+        self._paused = True
+
+
+    def _resume(self):
+        # type: () -> None
+        self._paused = False
+        self._flowToDrain()

--- a/src/klein/test/test_message.py
+++ b/src/klein/test/test_message.py
@@ -11,7 +11,9 @@ from hypothesis import given
 from hypothesis.strategies import binary
 
 from ._trial import TestCase
-from .._message import IHTTPMessage, NoFountError, bytesToFount, fountToBytes
+from .._message import (
+    FountAlreadyAccessedError, IHTTPMessage, bytesToFount, fountToBytes
+)
 
 
 __all__ = ()
@@ -72,12 +74,14 @@ class FrozenHTTPMessageTestsMixIn(object):
     def test_bodyAsFountFromBytesTwice(self, data):
         # type: (bytes) -> None
         """
-        C{bodyAsFount} raises L{NoFountError} if called more than once, when
-        created from bytes.
+        C{bodyAsFount} raises L{FountAlreadyAccessedError} if called more than
+        once, when created from bytes.
         """
         message = self.messageFromBytes(data)
         message.bodyAsFount()
-        cast(TestCase, self).assertRaises(NoFountError, message.bodyAsFount)
+        cast(TestCase, self).assertRaises(
+            FountAlreadyAccessedError, message.bodyAsFount
+        )
 
 
     @given(binary())
@@ -97,12 +101,14 @@ class FrozenHTTPMessageTestsMixIn(object):
     def test_bodyAsFountFromFountTwice(self, data):
         # type: (bytes) -> None
         """
-        C{bodyAsFount} raises L{NoFountError} if called more than once, when
-        created from a fount.
+        C{bodyAsFount} raises L{FountAlreadyAccessedError} if called more than
+        once, when created from a fount.
         """
         message = self.messageFromFountFromBytes(data)
         message.bodyAsFount()
-        cast(TestCase, self).assertRaises(NoFountError, message.bodyAsFount)
+        cast(TestCase, self).assertRaises(
+            FountAlreadyAccessedError, message.bodyAsFount
+        )
 
 
     @given(binary())

--- a/src/klein/test/test_message.py
+++ b/src/klein/test/test_message.py
@@ -1,0 +1,156 @@
+# -*- test-case-name: klein.test.test_message -*-
+# Copyright (c) 2017-2018. See LICENSE for details.
+
+"""
+Tests for L{klein._message}.
+"""
+
+from typing import cast
+
+from hypothesis import given
+from hypothesis.strategies import binary
+
+from ._trial import TestCase
+from .._message import IHTTPMessage, NoFountError, bytesToFount, fountToBytes
+
+
+__all__ = ()
+
+
+
+class FrozenHTTPMessageTestsMixIn(object):
+    """
+    Mix-In class for implementations of IHTTPMessage.
+    """
+
+    @classmethod
+    def messageFromBytes(cls, data=b""):
+        # type: (bytes) -> IHTTPMessage
+        """
+        Return a new instance of an L{IHTTPMessage} implementation using the
+        given bytes as the message body.
+        """
+        raise NotImplementedError(
+            "{} must implement getValues()".format(cls)
+        )
+
+
+    @classmethod
+    def messageFromFountFromBytes(cls, data=b""):
+        # type: (bytes) -> IHTTPMessage
+        """
+        Return a new instance of an L{IHTTPMessage} implementation using a
+        fount containing the given bytes as the message body.
+        """
+        return cls.messageFromBytes(bytesToFount(data))
+
+
+    def test_interface_message(self):
+        # type: () -> None
+        """
+        Message instance implements L{IHTTPMessage}.
+        """
+        message = self.messageFromBytes()
+        cast(TestCase, self).assertProvides(IHTTPMessage, message)
+
+
+    @given(binary())
+    def test_bodyAsFountFromBytes(self, data):
+        # type: (bytes) -> None
+        """
+        C{bodyAsFount} returns a fount with the same bytes given to
+        C{__init__}.
+        """
+        message = self.messageFromBytes(data)
+        fount = message.bodyAsFount()
+        body = cast(TestCase, self).successResultOf(fountToBytes(fount))
+
+        cast(TestCase, self).assertEqual(body, data)
+
+
+    @given(binary())
+    def test_bodyAsFountFromBytesTwice(self, data):
+        # type: (bytes) -> None
+        """
+        C{bodyAsFount} raises L{NoFountError} if called more than once, when
+        created from bytes.
+        """
+        message = self.messageFromBytes(data)
+        message.bodyAsFount()
+        cast(TestCase, self).assertRaises(NoFountError, message.bodyAsFount)
+
+
+    @given(binary())
+    def test_bodyAsFountFromFount(self, data):
+        # type: (bytes) -> None
+        """
+        C{bodyAsBytes} returns the bytes from the fount given to C{__init__}.
+        """
+        message = self.messageFromFountFromBytes(data)
+        fount = message.bodyAsFount()
+        body = cast(TestCase, self).successResultOf(fountToBytes(fount))
+
+        cast(TestCase, self).assertEqual(body, data)
+
+
+    @given(binary())
+    def test_bodyAsFountFromFountTwice(self, data):
+        # type: (bytes) -> None
+        """
+        C{bodyAsFount} raises L{NoFountError} if called more than once, when
+        created from a fount.
+        """
+        message = self.messageFromFountFromBytes(data)
+        message.bodyAsFount()
+        cast(TestCase, self).assertRaises(NoFountError, message.bodyAsFount)
+
+
+    @given(binary())
+    def test_bodyAsBytesFromBytes(self, data):
+        # type: (bytes) -> None
+        """
+        C{bodyAsBytes} returns the same bytes given to C{__init__}.
+        """
+        message = self.messageFromBytes(data)
+        body = cast(TestCase, self).successResultOf(message.bodyAsBytes())
+
+        cast(TestCase, self).assertEqual(body, data)
+
+
+    @given(binary())
+    def test_bodyAsBytesFromBytesCached(self, data):
+        # type: (bytes) -> None
+        """
+        C{bodyAsBytes} called twice returns the same object both times, when
+        created from bytes.
+        """
+        message = self.messageFromBytes(data)
+        body1 = cast(TestCase, self).successResultOf(message.bodyAsBytes())
+        body2 = cast(TestCase, self).successResultOf(message.bodyAsBytes())
+
+        cast(TestCase, self).assertIdentical(body1, body2)
+
+
+    @given(binary())
+    def test_bodyAsBytesFromFount(self, data):
+        # type: (bytes) -> None
+        """
+        C{bodyAsBytes} returns the bytes from the fount given to C{__init__}.
+        """
+        message = self.messageFromFountFromBytes(data)
+        body = cast(TestCase, self).successResultOf(message.bodyAsBytes())
+        cast(TestCase, self).assertEqual(body, data)
+
+
+    @given(binary())
+    def test_bodyAsBytesFromFountCached(self, data):
+        # type: (bytes) -> None
+        """
+        C{bodyAsBytes} called twice returns the same object both times, when
+        created from a fount.
+        """
+        message = self.messageFromFountFromBytes(data)
+        body1 = cast(TestCase, self).successResultOf(message.bodyAsBytes())
+        body2 = cast(TestCase, self).successResultOf(message.bodyAsBytes())
+
+        cast(TestCase, self).assertIdentical(body1, body2)

--- a/src/klein/test/test_request.py
+++ b/src/klein/test/test_request.py
@@ -1,0 +1,68 @@
+# -*- test-case-name: klein.test.test_request -*-
+# Copyright (c) 2017-2018. See LICENSE for details.
+
+"""
+Tests for L{klein._request}.
+"""
+
+from hyperlink import URL
+
+from ._trial import TestCase
+from .test_message import FrozenHTTPMessageTestsMixIn
+from .._headers import FrozenHTTPHeaders
+from .._message import IHTTPMessage
+from .._request import FrozenHTTPRequest, IHTTPRequest
+
+IHTTPMessage  # Silence linter
+
+
+__all__ = ()
+
+
+
+class FrozenHTTPRequestTests(FrozenHTTPMessageTestsMixIn, TestCase):
+    """
+    Tests for L{FrozenHTTPRequest}.
+    """
+
+    @staticmethod
+    def requestFromBytes(data=b""):
+        # type: (bytes) -> FrozenHTTPRequest
+        return FrozenHTTPRequest(
+            method=u"GET",
+            uri=URL.fromText(u"https://twistedmatrix.com/"),
+            headers=FrozenHTTPHeaders(rawHeaders=()),
+            body=data,
+        )
+
+
+    @classmethod
+    def messageFromBytes(cls, data=b""):
+        # type: (bytes) -> IHTTPMessage
+        return cls.requestFromBytes(data)
+
+
+    def test_interface(self):
+        # type: () -> None
+        """
+        L{FrozenHTTPRequest} implements L{IHTTPRequest}.
+        """
+        request = self.requestFromBytes()
+        self.assertProvides(IHTTPRequest, request)
+
+
+    def test_initInvalidBodyType(self):
+        # type: () -> None
+        """
+        L{FrozenHTTPRequest} raises L{TypeError} when given a body of an
+        unknown type.
+        """
+        e = self.assertRaises(
+            TypeError,
+            FrozenHTTPRequest,
+            method=u"GET",
+            uri=URL.fromText(u"https://twistedmatrix.com/"),
+            headers=FrozenHTTPHeaders(rawHeaders=()),
+            body=object(),
+        )
+        self.assertEqual(str(e), "body must be bytes or IFount")

--- a/src/klein/test/test_response.py
+++ b/src/klein/test/test_response.py
@@ -1,0 +1,64 @@
+# -*- test-case-name: klein.test.test_response -*-
+# Copyright (c) 2017-2018. See LICENSE for details.
+
+"""
+Tests for L{klein._response}.
+"""
+
+from ._trial import TestCase
+from .test_message import FrozenHTTPMessageTestsMixIn
+from .._headers import FrozenHTTPHeaders
+from .._message import IHTTPMessage
+from .._response import FrozenHTTPResponse, IHTTPResponse
+
+IHTTPMessage  # Silence linter
+
+
+__all__ = ()
+
+
+
+class FrozenHTTPResponseTests(FrozenHTTPMessageTestsMixIn, TestCase):
+    """
+    Tests for L{FrozenHTTPResponse}.
+    """
+
+    @staticmethod
+    def responseFromBytes(data=b""):
+        # type: (bytes) -> FrozenHTTPResponse
+        return FrozenHTTPResponse(
+            status=200,
+            headers=FrozenHTTPHeaders(rawHeaders=()),
+            body=data,
+        )
+
+
+    @classmethod
+    def messageFromBytes(cls, data=b""):
+        # type: (bytes) -> IHTTPMessage
+        return cls.responseFromBytes(data)
+
+
+    def test_interface(self):
+        # type: () -> None
+        """
+        L{FrozenHTTPResponse} implements L{IHTTPResponse}.
+        """
+        response = self.responseFromBytes()
+        self.assertProvides(IHTTPResponse, response)
+
+
+    def test_initInvalidBodyType(self):
+        # type: () -> None
+        """
+        L{FrozenHTTPResponse} raises L{TypeError} when given a body of an
+        unknown type.
+        """
+        e = self.assertRaises(
+            TypeError,
+            FrozenHTTPResponse,
+            status=200,
+            headers=FrozenHTTPHeaders(rawHeaders=()),
+            body=object(),
+        )
+        self.assertEqual(str(e), "body must be bytes or IFount")


### PR DESCRIPTION
This adds:
 * `_message.py`: A new `IHTTPMessage` interface and some functions for use by implementations.
 * `_response.py`: A new `IHTTPResponse` interface, which is a superset of `IHTTPMessage` and `FrozenHTTPResponse` implementation.
 * _request.py`: A new `IHTTPRequest ` interface, which is a superset of `IHTTPMessage` and `FrozenHTTPRequest ` implementation.
 * `_tubes.py`: Implements to code that allows converting `bytes` to a fount and back, and an `IOFount` class that wraps an FLO as a fount.  This code should eventually live in Tubes.  Note that the implementation of `IOFount` is not optimal, as it doesn't stream IO.  That can be done later; the point here is to establish an API for streaming in `IHTTPMessage`.
