### PR TITLE
Remove hashability requirement for instances bound to Klein objects

### DIFF
--- a/src/klein/_app.py
+++ b/src/klein/_app.py
@@ -147,12 +147,14 @@ class Klein(object):
             return self
 
         if self._boundAs is None:
-            for name, obj in owner.__dict__.items():
+            for name in dir(owner):
+                obj = getattr(owner, name)
                 if obj is self:
                     self._boundAs = name
                     break
             else:
-                self._boundAs = 'UNKNOWN'
+                self._boundAs = 'unknown_' + str(id(self))
+
         boundName = "__klein_bound_{}__".format(self._boundAs)
         k = getattr(instance, boundName, lambda: None)()
 
@@ -162,8 +164,9 @@ class Klein(object):
             k._endpoints = self._endpoints
             k._error_handlers = self._error_handlers
             k._instance = instance
+            kref = ref(k)
             try:
-                setattr(instance, boundName, ref(k))
+                setattr(instance, boundName, kref)
             except AttributeError:
                 pass
 

--- a/src/klein/_app.py
+++ b/src/klein/_app.py
@@ -6,15 +6,14 @@ Applications are great.  Lets have more of them.
 from __future__ import absolute_import, division
 
 import sys
-from weakref import ref
 from collections import namedtuple
 from contextlib import contextmanager
-
 try:
     from inspect import iscoroutine
 except ImportError:
     def iscoroutine(*args, **kwargs):
         return False
+from weakref import ref
 
 from twisted.internet import endpoints, reactor
 from twisted.python import log

--- a/src/klein/test/test_app.py
+++ b/src/klein/test/test_app.py
@@ -132,7 +132,8 @@ class KleinTestCase(unittest.TestCase):
         Repeated accesses of the same L{Klein} attribute on the same instance
         should result in an identically bound instance, when possible.
         "Possible" is defined by a writable instance-level attribute named
-        C{__klein_bound_<the name of the Klein attribute on the class>__}.
+        C{__klein_bound_<the name of the Klein attribute on the class>__}, and
+        something is maintaining a strong reference to the L{Klein} instance.
         """
         # This is the desirable property.
         class DuplicateHasherWithWritableAttribute(DuplicateHasher):

--- a/src/klein/test/test_app.py
+++ b/src/klein/test/test_app.py
@@ -163,7 +163,7 @@ class KleinTestCase(unittest.TestCase):
                 self._wrapped = wrapped
 
             def __get__(self, instance, owner):
-                if owner is not None:
+                if owner is None:
                     return self
                 return self._wrapped.__get__(instance, owner)
 

--- a/src/klein/test/test_app.py
+++ b/src/klein/test/test_app.py
@@ -132,12 +132,12 @@ class KleinTestCase(unittest.TestCase):
         class DuplicateHasherWithWritableAttribute(DuplicateHasher):
             __slots__ = ('__klein_bound_myRouter__',)
         a = DuplicateHasherWithWritableAttribute("a")
-        self.assertIdentical(a.myRouter, a.myRouter)
+        self.assertIs(a.myRouter, a.myRouter)
 
         # The latter is an unfortunate consequence of the implementation choice
         # here, and could be changed.
         b = DuplicateHasher("b")
-        self.assertNotIdentical(b.myRouter, b.myRouter)
+        self.assertIsNot(b.myRouter, b.myRouter)
 
 
     def test_submountedRoute(self):

--- a/src/klein/test/test_app.py
+++ b/src/klein/test/test_app.py
@@ -163,7 +163,7 @@ class KleinTestCase(unittest.TestCase):
                 self._wrapped = wrapped
 
             def __get__(self, instance, owner):
-                if owner is None:
+                if instance is None:
                     return self
                 return self._wrapped.__get__(instance, owner)
 

--- a/src/klein/test/test_app.py
+++ b/src/klein/test/test_app.py
@@ -156,6 +156,7 @@ class KleinTestCase(unittest.TestCase):
         class Wrap(object):
             def __init__(self, wrapped):
                 self._wrapped = wrapped
+
             def __get__(self, instance, owner):
                 if owner is not None:
                     return self

--- a/src/klein/test/test_app.py
+++ b/src/klein/test/test_app.py
@@ -115,6 +115,12 @@ class KleinTestCase(unittest.TestCase):
         """
         a = DuplicateHasher("a")
         b = DuplicateHasher("b")
+
+        # Sanity check
+        d = {}
+        d[a] = "test"
+        self.assertEqual(d.get(b), "test")
+
         self.assertEqual(a.myRouter.execute_endpoint("root", DummyRequest(1)),
                          "a")
         self.assertEqual(b.myRouter.execute_endpoint("root", DummyRequest(1)),
@@ -138,6 +144,31 @@ class KleinTestCase(unittest.TestCase):
         # here, and could be changed.
         b = DuplicateHasher("b")
         self.assertIsNot(b.myRouter, b.myRouter)
+
+
+    def test_kleinNotFoundOnClass(self):
+        """
+        When the Klein object can't find itself on the class it still preserves
+        identity.
+        """
+
+        class Wrap(object):
+            def __init__(self, wrapped):
+                self._wrapped = wrapped
+            def __get__(self, instance, owner):
+                if owner is not None:
+                    return self
+                return self._wrapped.__get__(instance, owner)
+
+        class TwoRouters(object):
+
+            app1 = Wrap(Klein())
+            app2 = Wrap(Klein())
+
+        tr = TwoRouters()
+
+        self.assertIs(tr.app1, tr.app1)
+        self.assertIs(tr.app2, tr.app2)
 
 
     def test_submountedRoute(self):

--- a/src/klein/test/test_app.py
+++ b/src/klein/test/test_app.py
@@ -141,9 +141,14 @@ class KleinTestCase(unittest.TestCase):
         a = DuplicateHasherWithWritableAttribute("a")
         self.assertIs(a.myRouter, a.myRouter)
 
-        # The latter is an unfortunate consequence of the implementation choice
-        # here, and could be changed.
         b = DuplicateHasher("b")
+        # The following is simply an unfortunate consequence of the
+        # implementation choice here (i.e.: to insist on a specific writable
+        # attribute), and could be changed (for example, by doing something
+        # more elaborate with the identity of the object containing the
+        # router).  However, checking this also sets a sort of bounded "worst
+        # case" scenario"; it still works, nobody raises an exception, it's
+        # just not identical.
         self.assertIsNot(b.myRouter, b.myRouter)
 
 


### PR DESCRIPTION
Instead, just tack a special-named attribute on the object to point to its
cached router.

- "has an instance dictionary" is a much less esoteric property than "is
  hashable and comparable by identity"
- given the increased popularity of attrs, and its defaults, the hashability
  requirement is a practical problem in a surprising number of circumstances
- Identity preservation of the Klein object is simply not always necessary, so
  it's OK to just fail if it can't be met