### PR TITLE
Concurrent JSON

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ if __name__ == "__main__":
         use_incremental=True,
         install_requires=[
             "attrs",
-            "constantly",
+            'enum34 ; python_version<"3.4"',
             "hyperlink",
             "incremental",
             "six",

--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,7 @@ if __name__ == "__main__":
         use_incremental=True,
         install_requires=[
             "attrs",
+            "constantly",
             "hyperlink",
             "incremental",
             "six",

--- a/src/klein/_plating.py
+++ b/src/klein/_plating.py
@@ -55,6 +55,9 @@ def resolveDeferredObjects(root):
 
     while stack:
         mightBeDeferred, setter = stack.pop()
+        # inlineCallbacks pauses the generator only on yielded
+        # Deferreds. It's resumed immediately with any other object.
+        # Consequently coroutines must be wrapped in ensureDeferred.
         obj = yield mightBeDeferred
         if isinstance(obj, ATOM_TYPES):
             setter(obj)

--- a/src/klein/_plating.py
+++ b/src/klein/_plating.py
@@ -40,9 +40,9 @@ def resolveDeferredObjects(root):
     Wait on possibly nested L{Deferred}s that represent a JSON
     serializable object.
 
-    @param root: A JSON-serializable object that may contain
-        L{Deferred}s, or a Deferred that will resolve to a
-        JSON-serializable object
+    @param root: JSON-serializable object that may contain
+        L{Deferred}s that resolve to JSON-serializable objects, or a
+        L{Deferred} that resolves to one.
 
     @return: A L{Deferred} that fires with a L{Deferred}-free version
         of C{root}, or that fails with the first exception

--- a/src/klein/_plating.py
+++ b/src/klein/_plating.py
@@ -4,29 +4,34 @@
 Templating wrapper support for Klein.
 """
 
+from functools import partial
 from json import JSONEncoder
+from operator import setitem
+from typing import Any, Tuple, cast
 
 import attr
-from functools import partial
-from operator import setitem
 
 from six import integer_types, string_types, text_type
 
 from twisted.internet.defer import inlineCallbacks, returnValue
 from twisted.internet.interfaces import IPushProducer
 from twisted.internet.task import cooperate
-from twisted.web.server import NOT_DONE_YET
 from twisted.web.error import MissingRenderMethod
+from twisted.web.server import NOT_DONE_YET
 from twisted.web.template import Element, TagLoader
+
+from zope.interface import implementer
 
 from ._app import _call
 from ._decorators import bindable, modified
 
-from zope.interface import implementer
 
-
-ATOM_TYPES = integer_types + string_types + (float, None.__class__)
-
+# https://github.com/python/mypy/issues/224
+ATOM_TYPES = (
+    cast(Tuple[Any, ...], integer_types) +
+    cast(Tuple[Any, ...], string_types) +
+    cast(Tuple[Any, ...], (float, None.__class__))
+)
 
 def _should_return_json(request):
     """

--- a/src/klein/_plating.py
+++ b/src/klein/_plating.py
@@ -100,8 +100,10 @@ def resolveDeferredObjects(root):
         elif isinstance(obj, PlatedElement):
             stack.append((obj._asJSON(), setter))
         else:
-            raise TypeError("{input} not JSON serializable"
-                            .format(input=obj))
+            raise TypeError(
+                obj,
+                "{input} not JSON serializable".format(input=obj),
+            )
 
     returnValue(result[0])
 

--- a/src/klein/test/test_plating.py
+++ b/src/klein/test/test_plating.py
@@ -304,11 +304,19 @@ class ResolveDeferredObjectsTests(unittest.SynchronousTestCase):
         fail with an informative L{TypeError}.
 
         """
+
+        @attr.s
+        class ConsistentRepr(object):
+            """
+            Objects with a predictable repr
+            """
+
         exception = self.failureResultOf(
-            resolveDeferredObjects(frozenset())
+            resolveDeferredObjects(ConsistentRepr())
         ).value
         self.assertIsInstance(exception, TypeError)
-        self.assertIn("frozenset([]) not JSON serializable", str(exception))
+        self.assertIn("ConsistentRepr() not JSON serializable",
+                      str(exception))
 
 
 class ProduceJSONTests(unittest.SynchronousTestCase):

--- a/src/klein/test/test_plating.py
+++ b/src/klein/test/test_plating.py
@@ -226,7 +226,7 @@ class TransformJSONObjectTests(unittest.SynchronousTestCase):
         """
         self.assertRaises(AssertionError,
                           transformJSONObject,
-                          set(), lambda: None)
+                          set(), list.append)
 
 
 class ResolveDeferredObjectsTests(unittest.SynchronousTestCase):

--- a/src/klein/test/test_plating.py
+++ b/src/klein/test/test_plating.py
@@ -12,7 +12,7 @@ from string import printable
 
 import attr
 
-from constantly import NamedConstant, Names
+import enum
 
 from hypothesis import given, settings, strategies as st
 
@@ -408,15 +408,12 @@ class ProduceJSONTests(unittest.SynchronousTestCase):
         self.assertIs(self.failureResultOf(done).type, TaskStopped)
 
 
-    class ACTIONS(Names):
-        PAUSE = NamedConstant()
-        RESUME = NamedConstant()
-        WRITE = NamedConstant()
+    ACTIONS = enum.Enum("ACTIONS", ["PAUSE", "RESUME", "WRITE"])
 
     @given(
         jsonObject=jsonObjectsWithoutTuples,
         actions=st.lists(
-            st.sampled_from(list(ACTIONS.iterconstants())),
+            st.sampled_from(list(ACTIONS)),
             min_size=32,
             max_size=128,
         ),

--- a/src/klein/test/test_plating.py
+++ b/src/klein/test/test_plating.py
@@ -1,18 +1,16 @@
 """
 Tests for L{klein.plating}.
 """
+from __future__ import (absolute_import, division, print_function,
+                        unicode_literals)
 
-from __future__ import (
-    absolute_import, division, print_function, unicode_literals
-)
-
+import enum
 import json
 from functools import partial
 from string import printable
+from typing import Any, cast
 
 import attr
-
-import enum
 
 from hypothesis import given, settings, strategies as st
 
@@ -26,12 +24,8 @@ from twisted.web.template import slot, tags
 from .test_resource import _render, requestMock
 from .util import TestCase
 from .. import Klein, Plating
-from .._plating import (
-    ATOM_TYPES,
-    PlatedElement,
-    ProduceJSON,
-    resolveDeferredObjects
-)
+from .._plating import (ATOM_TYPES, PlatedElement, ProduceJSON,
+                        resolveDeferredObjects)
 
 page = Plating(
     defaults={
@@ -407,8 +401,9 @@ class ProduceJSONTests(unittest.SynchronousTestCase):
         self.assertFalse(self.consumer.value())
         self.assertIs(self.failureResultOf(done).type, TaskStopped)
 
-
-    ACTIONS = enum.Enum("ACTIONS", ["PAUSE", "RESUME", "WRITE"])
+    # https://github.com/python/mypy/issues/2305
+    # Fixed but as-yet unreleased.
+    ACTIONS = cast(Any, enum.Enum("ACTIONS", ["PAUSE", "RESUME", "WRITE"]))
 
     @given(
         jsonObject=jsonObjectsWithoutTuples,

--- a/src/klein/test/test_plating.py
+++ b/src/klein/test/test_plating.py
@@ -8,6 +8,10 @@ from __future__ import (
 
 import attr
 
+from constantly import Names, NamedConstant
+
+from functools import partial
+
 import json
 
 from hypothesis import given, strategies as st, settings
@@ -15,13 +19,20 @@ from hypothesis import given, strategies as st, settings
 from string import printable
 
 from twisted.internet.defer import Deferred, succeed
+from twisted.internet.task import Clock, Cooperator, TaskStopped
 from twisted.web.error import FlattenerError, MissingRenderMethod
 from twisted.web.template import slot, tags
+from twisted.test.proto_helpers import StringTransport
 from twisted.trial import unittest
 
 from .test_resource import _render, requestMock
 from .util import TestCase
-from .._plating import ATOM_TYPES, PlatedElement, resolveDeferredObjects
+from .._plating import (
+    ATOM_TYPES,
+    PlatedElement,
+    ProduceJSON,
+    resolveDeferredObjects
+)
 from .. import Klein, Plating
 
 page = Plating(
@@ -112,7 +123,7 @@ jsonAtoms = (st.none() |
              st.text(printable))
 
 
-def jsonComposites(children):
+def jsonComposites(children, withTuples=True):
     """
     Creates a Hypothesis strategy that constructs composite
     JSON-serializable objects (e.g., lists).
@@ -122,12 +133,18 @@ def jsonComposites(children):
 
     @return: The composite objects strategy.
     """
-    return (st.lists(children) |
-            st.dictionaries(st.text(printable), children) |
-            st.tuples(children))
-
+    composites = (st.lists(children) |
+                  st.dictionaries(st.text(printable), children))
+    if withTuples:
+        return composites | st.tuples(children)
+    else:
+        return composites
 
 jsonObjects = st.recursive(jsonAtoms, jsonComposites, max_leaves=200)
+jsonObjectsWithoutTuples = st.recursive(
+    jsonAtoms,
+    partial(jsonComposites, withTuples=False),
+)
 
 
 def transformJSONObject(jsonObject, transformer):
@@ -293,6 +310,149 @@ class ResolveDeferredObjectsTests(unittest.SynchronousTestCase):
         self.assertIn("frozenset([]) not JSON serializable", str(exception))
 
 
+class ProduceJSONTests(unittest.SynchronousTestCase):
+    """
+    Tests for L{ProduceJSON}.
+    """
+
+    def setUp(self):
+        self.clock = Clock()
+        self.interval = 1
+        self.cooperate = Cooperator(
+            scheduler=partial(self.clock.callLater, self.interval),
+        ).cooperate
+        self.consumer = StringTransport()
+
+    def writeAllPending(self, maxTicks=16384):
+        """
+        Schedule all pending producer writes.
+        """
+        for _ in range(16384):
+            self.clock.advance(self.interval)
+        self.assertFalse(self.clock.getDelayedCalls())
+
+    @given(jsonObject=jsonObjectsWithoutTuples)
+    def test_writeValidJSON(self, jsonObject):
+        """
+        The producer writes valid JSON to its consumer, stopping and
+        unregistering itself on completion.
+        """
+        self.setUp()
+        producer = ProduceJSON(jsonObject, "utf-8", cooperate=self.cooperate)
+        done = producer.beginProducing(self.consumer)
+
+        self.writeAllPending()
+        self.successResultOf(done)
+
+        written = self.consumer.value()
+        self.assertEqual(json.loads(written.decode("utf-8")), jsonObject)
+        self.assertIsNone(self.consumer.producer)
+
+    def test_stopOnEncodingFailure(self):
+        """
+        An encoding failure stops and unregisters the producer.
+        """
+        unserializable = {"a": [1, 2, set()]}
+        producer = ProduceJSON(
+            unserializable, "utf-8", cooperate=self.cooperate
+        )
+        done = producer.beginProducing(self.consumer)
+
+        self.writeAllPending()
+
+        self.assertIsInstance(self.failureResultOf(done).value, TypeError)
+        self.assertIsNone(self.consumer.producer)
+
+
+    def test_pauseProducing(self):
+        """
+        A paused producer makes no progress but remains registered
+        with its consumer.
+        """
+        producer = ProduceJSON(
+            {"some": "data"}, "utf-8", cooperate=self.cooperate
+        )
+        done = producer.beginProducing(self.consumer)
+        producer.pauseProducing()
+
+        self.writeAllPending()
+
+        self.assertFalse(self.consumer.value())
+        self.assertNoResult(done)
+        self.assertIsNotNone(self.consumer.producer)
+
+
+    def test_stopProducing(self):
+        """
+        A stopped producer writes no data and terminates the
+        L{Deferred} returned by L{ProduceJSON.beginProducing}.
+        """
+        producer = ProduceJSON(
+            {"some": "data"}, "utf-8", cooperate=self.cooperate
+        )
+        done = producer.beginProducing(self.consumer)
+        producer.stopProducing()
+
+        self.writeAllPending()
+
+        self.assertFalse(self.consumer.value())
+        self.assertIs(self.failureResultOf(done).type, TaskStopped)
+
+
+    class ACTIONS(Names):
+        PAUSE = NamedConstant()
+        RESUME = NamedConstant()
+        WRITE = NamedConstant()
+
+    @given(
+        jsonObject=jsonObjectsWithoutTuples,
+        actions=st.lists(
+            st.sampled_from(list(ACTIONS.iterconstants())),
+            min_size=32,
+            max_size=128,
+        ),
+    )
+    def test_flowControl(self, jsonObject, actions):
+        """
+        The consumer can pause and resume the producer to control the
+        flow of data.
+        """
+        self.setUp()
+        producer = ProduceJSON(
+            jsonObject, "utf-8", cooperate=self.cooperate
+        )
+        done = producer.beginProducing(self.consumer)
+
+        def isExhausted():
+            # The iterator has been exhausted so the producer
+            # unregistered itself.
+            return self.consumer.producer is None
+
+        paused = False
+        for action in actions:
+            if isExhausted():
+                break
+            elif action is self.ACTIONS.PAUSE and not paused:
+                paused = True
+                producer.pauseProducing()
+            elif action is self.ACTIONS.RESUME and paused:
+                paused = False
+                producer.resumeProducing()
+            elif action is self.ACTIONS.WRITE:
+                self.clock.advance(self.interval)
+
+        if paused:
+            producer.resumeProducing()
+
+        if not isExhausted():
+            self.writeAllPending()
+
+        written = self.consumer.value()
+        self.assertEqual(json.loads(written.decode("utf-8")), jsonObject)
+        self.successResultOf(done)
+        self.assertIsNone(self.consumer.producer)
+
+
 class PlatingTests(TestCase):
     """
     Tests for L{Plating}.
@@ -305,6 +465,14 @@ class PlatingTests(TestCase):
         self.app = Klein()
         self.kr = self.app.resource()
 
+        self.clock = Clock()
+        self.interval = 1
+        self.cooperate = Cooperator(
+            scheduler=partial(self.clock.callLater, self.interval),
+        ).cooperate
+        self.patch(page, "_cooperate", self.cooperate)
+        self.patch(element, "_cooperate", self.cooperate)
+
     def get(self, uri):
         """
         Issue a virtual GET request to the given path that is expected to
@@ -313,6 +481,8 @@ class PlatingTests(TestCase):
         """
         request = requestMock(uri)
         d = _render(self.kr, request)
+        # Sufficient to write at least 16k of JSON.
+        self.clock.advance(self.interval * 16384)
         self.successResultOf(d)
         return request, request.getWrittenData()
 
@@ -546,6 +716,7 @@ class PlatingTests(TestCase):
             tags=tags.span(slot("title")),
             presentation_slots={"title"}
         )
+        plating._cooperate = self.cooperate
 
         @plating.routed(self.app.route("/"), tags.span(slot("data")))
         def justJson(request):

--- a/src/klein/test/test_plating.py
+++ b/src/klein/test/test_plating.py
@@ -6,13 +6,22 @@ from __future__ import (
     absolute_import, division, print_function, unicode_literals
 )
 
+import attr
+
 import json
 
+from hypothesis import given, strategies as st, settings
+
+from string import printable
+
+from twisted.internet.defer import Deferred, succeed
 from twisted.web.error import FlattenerError, MissingRenderMethod
 from twisted.web.template import slot, tags
+from twisted.trial import unittest
 
 from .test_resource import _render, requestMock
 from .util import TestCase
+from .._plating import ATOM_TYPES, PlatedElement, resolveDeferredObjects
 from .. import Klein, Plating
 
 page = Plating(
@@ -48,6 +57,14 @@ def enwidget(a, b):
     return {"a": a, "b": b}
 
 
+@element.widgeted
+def deferredEnwidget(a, b):
+    """
+    Provide some L{Deferred} values for the L{element} template.
+    """
+    return {"a": succeed(a), "b": succeed(b)}
+
+
 class InstanceWidget(object):
     """
     A class with a method that's a L{Plating.widget}.
@@ -60,6 +77,220 @@ class InstanceWidget(object):
         """
         return {"a": a, "b": b}
 
+    @element.widgeted
+    def deferredEnwidget(self, a, b):
+        """
+        Provide some L{Deferred} values for the L{element} template.
+        """
+        return {"a": succeed(a), "b": succeed(b)}
+
+
+@attr.s
+class DeferredValue(object):
+    """
+    A value within a JSON serializable object that is deferred.
+
+    @param value: The value.
+
+    @param deferred: The L{Deferred} representing the value.
+    """
+    value = attr.ib()
+    deferred = attr.ib(attr.Factory(Deferred))
+
+    def resolve(self):
+        """
+        Resolve the L{Deferred} that represents the value with the
+        value itself.
+        """
+        self.deferred.callback(self.value)
+
+
+jsonAtoms = (st.none() |
+             st.booleans() |
+             st.integers() |
+             st.floats(allow_nan=False) |
+             st.text(printable))
+
+
+def jsonComposites(children):
+    """
+    Creates a Hypothesis strategy that constructs composite
+    JSON-serializable objects (e.g., lists).
+
+    @param children: A strategy from which each composite object's
+        children will be drawn.
+
+    @return: The composite objects strategy.
+    """
+    return (st.lists(children) |
+            st.dictionaries(st.text(printable), children) |
+            st.tuples(children))
+
+
+jsonObjects = st.recursive(jsonAtoms, jsonComposites, max_leaves=200)
+
+
+def transformJSONObject(jsonObject, transformer):
+    """
+    Recursively apply a transforming function to a JSON serializable
+    object, returning a new, transformed object.
+
+    @param json_object: A JSON serializable object to transform.
+
+    @param transformer: A one-argument callable that will be applied
+        to each member of the object.
+
+    @return: A transformed copy of C{jsonObject}.
+    """
+
+    def visit(obj):
+        """
+        Recur through the object, sometimes replacing values with
+        L{Deferred}s
+        """
+        if isinstance(obj, ATOM_TYPES):
+            return transformer(obj)
+        elif isinstance(obj, tuple):
+            return tuple(transformer(child) for child in obj)
+        elif isinstance(obj, list):
+            return [transformer(child) for child in obj]
+        elif isinstance(obj, dict):
+            return {transformer(k): transformer(v) for k, v in obj.items()}
+        else:
+            assert False, "Object of unknown type {!r}".format(obj)
+
+    return visit(jsonObject)
+
+
+class TransformJSONObjectTests(unittest.SynchronousTestCase):
+    """
+    Tests for L{transform_json_object}.
+    """
+
+    def test_transform_atom(self):
+        """
+        L{transform_json_object} transforms a representative atomic
+        JSON data types.
+        """
+        def inc(value):
+            return value + 1
+
+        self.assertEqual(transformJSONObject(1, inc), 2)
+
+    def test_transform_tuple(self):
+        """
+        L{transformJSONObject} transforms L{tuple}s.
+        """
+        def inc(value):
+            return value + 1
+
+        self.assertEqual(transformJSONObject((1, 1), inc), (2, 2))
+
+    def test_transform_list(self):
+        """
+        L{transformJSONObject} transforms L{list}s.
+        """
+        def inc(value):
+            return value + 1
+
+        self.assertEqual(transformJSONObject([1, 1], inc), [2, 2])
+
+    def test_transform_dict(self):
+        """
+        L{transformJSONObject} transforms L{dict}s.
+        """
+        def inc(value):
+            return value + 1
+
+        self.assertEqual(transformJSONObject({2: 2}, inc), {3: 3})
+
+    def test_transform_unserializable(self):
+        """
+        L{transformJSONObject} will not transform objects that are
+        not JSON serializable.
+        """
+        self.assertRaises(AssertionError,
+                          transformJSONObject,
+                          set(), lambda: None)
+
+
+class ResolveDeferredObjectsTests(unittest.SynchronousTestCase):
+    """
+    Tests for L{resolve_deferred_objects}.
+    """
+
+    @settings(max_examples=500)
+    @given(
+        jsonObject=jsonObjects,
+        data=st.data(),
+    )
+    def test_resolveObjects(self, jsonObject, data):
+        """
+        A JSON serializable object that may contain L{Deferred}s or a
+        L{Deferred} that resolves to a JSON serializable object
+        resolves to an object that contains no L{Deferred}s.
+        """
+        deferredValues = []
+
+        def maybeWrapInDeferred(value, choose=st.booleans()):
+            if data.draw(choose):
+                deferredValues.append(DeferredValue(value))
+                return deferredValues[-1].deferred
+            else:
+                return value
+
+        deferredJSONObject = transformJSONObject(
+            jsonObject,
+            maybeWrapInDeferred,
+        )
+
+        resolved = resolveDeferredObjects(deferredJSONObject)
+
+        for value in deferredValues:
+            value.resolve()
+
+        self.assertEqual(self.successResultOf(resolved), jsonObject)
+
+
+    @given(
+        jsonObject=jsonObjects,
+        data=st.data(),
+    )
+    def test_elementSerialized(self, jsonObject, data):
+        """
+        A L{PlatedElement} within a JSON serializable object replaced
+        by its JSON representation.
+        """
+        def injectPlatingElements(value, choose=st.booleans()):
+            if data.draw(choose) and isinstance(value, dict):
+                return PlatedElement(slot_data=value,
+                                     preloaded=tags.html(),
+                                     boundInstance=None,
+                                     presentationSlots={})
+            else:
+                return value
+
+        withPlatingElements = transformJSONObject(
+            jsonObject,
+            injectPlatingElements,
+        )
+
+        resolved = resolveDeferredObjects(withPlatingElements)
+
+        self.assertEqual(self.successResultOf(resolved), jsonObject)
+
+
+    def test_unserializableObject(self):
+        """
+        An object that cannot be serialized causes the L{Deferred} to
+        fail with an informative L{TypeError}.
+
+        """
+        exception = self.failureResultOf(
+            resolveDeferredObjects(frozenset())
+        ).value
+        self.assertIsInstance(exception, TypeError)
+        self.assertIn("frozenset([]) not JSON serializable", str(exception))
 
 
 class PlatingTests(TestCase):
@@ -138,6 +369,27 @@ class PlatingTests(TestCase):
         self.assertEquals({"ok": "an-plating-test",
                            "title": "default title unchanged"},
                           json.loads(written.decode('utf-8')))
+
+
+    def test_template_json_contains_deferred(self):
+        """
+        Rendering a L{Plating.routed} decorated route with a query
+        parameter asking for JSON waits until the L{Deferred}s
+        returned by the route have fired.
+        """
+        @page.routed(self.app.route("/"), tags.span(slot("ok")))
+        def plateMe(request):
+            return {"ok": succeed("an-plating-test")}
+
+        request, written = self.get(b"/?json=true")
+        self.assertEqual(
+            request.responseHeaders.getRawHeaders(b'content-type')[0],
+            b'text/json; charset=utf-8'
+        )
+        self.assertEquals({"ok": "an-plating-test",
+                           "title": "default title unchanged"},
+                          json.loads(written.decode('utf-8')))
+
 
     def test_template_numbers(self):
         """
@@ -230,6 +482,27 @@ class PlatingTests(TestCase):
                           "instance-widget": {"a": 5, "b": 6},
                           "title": "default title unchanged"})
 
+    def test_widget_json_deferred(self):
+        """
+        When L{Plating.widgeted} is applied as a decorator, and the result is
+        serialized to JSON, it appears the same as the returned value despite
+        the HTML-friendly wrapping described above.
+        """
+
+        @page.routed(self.app.route("/"),
+                     tags.div(tags.div(slot("widget")),
+                              tags.div(slot("instance-widget"))))
+        def rsrc(request):
+            instance = InstanceWidget()
+            return {"widget": deferredEnwidget.widget(a=3, b=4),
+                    "instance-widget": instance.deferredEnwidget.widget(5, 6)}
+
+        request, written = self.get(b"/?json=1")
+        self.assertEqual(json.loads(written.decode('utf-8')),
+                         {"widget": {"a": 3, "b": 4},
+                          "instance-widget": {"a": 5, "b": 6},
+                          "title": "default title unchanged"})
+
     def test_prime_directive_return(self):
         """
         Nothing within these Articles Of Federation shall authorize the United
@@ -303,17 +576,3 @@ class PlatingTests(TestCase):
 
         test("garbage")
         test("garbage:missing")
-
-    def test_json_serialize_unknown_type(self):
-        """
-        The JSON serializer will raise a L{TypeError} when it can't find an
-        appropriate type.
-        """
-        from klein._plating import json_serialize
-
-        class Reprish(object):
-            def __repr__(self):
-                return '<blub>'
-
-        te = self.assertRaises(TypeError, json_serialize, {"an": Reprish()})
-        self.assertIn("<blub>", str(te))

--- a/src/klein/test/test_plating.py
+++ b/src/klein/test/test_plating.py
@@ -471,8 +471,8 @@ class PlatingTests(TestCase):
         self.cooperate = Cooperator(
             scheduler=partial(self.clock.callLater, self.interval),
         ).cooperate
-        self.patch(page, "_cooperate", self.cooperate)
-        self.patch(element, "_cooperate", self.cooperate)
+        self.patch(page, "cooperate", self.cooperate)
+        self.patch(element, "cooperate", self.cooperate)
 
     def get(self, uri):
         """
@@ -717,7 +717,7 @@ class PlatingTests(TestCase):
             tags=tags.span(slot("title")),
             presentation_slots={"title"}
         )
-        plating._cooperate = self.cooperate
+        plating.cooperate = self.cooperate
 
         @plating.routed(self.app.route("/"), tags.span(slot("data")))
         def justJson(request):

--- a/src/klein/test/test_resource.py
+++ b/src/klein/test/test_resource.py
@@ -65,6 +65,8 @@ def requestMock(path, method=b"GET", host=b"localhost", port=8080,
 
     def registerProducer(producer, streaming):
         request.producer = producer
+        if streaming:
+            return
         for _ in range(2):
             if request.producer:
                 request.producer.resumeProducing()

--- a/src/klein/test/test_resource.py
+++ b/src/klein/test/test_resource.py
@@ -65,8 +65,6 @@ def requestMock(path, method=b"GET", host=b"localhost", port=8080,
 
     def registerProducer(producer, streaming):
         request.producer = producer
-        if streaming:
-            return
         for _ in range(2):
             if request.producer:
                 request.producer.resumeProducing()


### PR DESCRIPTION
Plating is good but it has ~~two problems~~ a problem with JSON. (See below for strikethrough)

### Deferred slots can't be rendered to JSON.

Consider the following program:

```python
from klein import Klein, Plating
from twisted.internet import task, reactor
from twisted.web.template import tags, slot

app = Klein()
style = Plating(tags=tags.html(slot(Plating.CONTENT)))


@style.routed(
    app.route("/"),
    tags.div(
        tags.div(slot("immediate")),
        tags.div(slot("delayed")),
    )
)
def route(request):
    return {
        "immediate": "now",
        "delayed": task.deferLater(reactor, 1, lambda: "later")
    }

app.run("localhost", 8081)
```

The power of `twisted.web.template` and browsers (or at least Firefox) combine to render "now" a second before "later" appears.  Requesting the same page with `?json=1` fails with a [`TypeError: <Deferred at 0xabcdef> not JSON serializable`](https://github.com/twisted/klein/blob/4a504274dd5537b242ba58cfd74f4db1e4806e33/src/klein/_plating.py#L36-L37).

There are two ways to fix this: stream the JSON as values become available, or wait until the entire thing is ready before attempting to serialize it. @dreid and @glyph convinced me that streaming JSON is bad; a serialization error along the way would result in incomplete output, and unlike HTML, partial JSON cannot be deserialized.

This PR takes the latter approach.  A new function, `resolveDeferredObjects`, walks the object returned by a Plating route and iteratively waits on it or any Deferreds it contains, finally resolving to a complete object.  This means, unlike `twisted.web.template`, that no data is available to the client until all the slot Deferreds have fired, but it does make routes work with both HTML and JSON.

### ~~One big JSON string~~
~~[Klein currently blocks during JSON serialization](https://github.com/twisted/klein/blob/4a504274dd5537b242ba58cfd74f4db1e4806e33/src/klein/_plating.py#L38).  A big enough object will make Klein serialize requests that could be handled concurrently.~~

~~This PR borrows [a wrapper around `JSONEncoder.iterencode` from @exarkun](http://as.ynchrono.us/2010/06/asynchronous-json_18.html).  A request for JSON from a Plating route will yield back to the reactor instead of blocking it.~~

I still think Klein should iteratively encode JSON responses, but doing so will require a way for users to specify the reactor to use.  Expecting everybody to monkeypatch out `Plating.cooperator` isn't it.  After we figure out what that API should be I can revive iterative encoding.