### PR TITLE
Update mypy

### DIFF
--- a/.travis/mypy
+++ b/.travis/mypy
@@ -28,23 +28,24 @@ tmp="$(mktemp -t mypy.XXXX)";
 
 mypy "$@"      \
     | grep -v  \
-        -e ': error: "Callable\[\[[^]]*\], [^]]*\]" has no attribute "\(skip\|todo\)"'                             \
-        -e ': note: .* defined here'                                                                               \
-        -e '^src/klein/_app.py:.[0-9:]*: error: All conditional function variants must have identical signatures'  \
-        -e '^src/klein/_app.py:.[0-9:]*: error: Function is missing a type annotation'                             \
-        -e '^src/klein/_decorators.py:.[0-9:]*: error: Function is missing a type annotation'                      \
-        -e '^src/klein/_iapp.py:.[0-9:]*: error: Function is missing a type annotation'                            \
-        -e '^src/klein/_plating.py:.* error: Function is missing a type annotation'                                \
-        -e '^src/klein/_plating.py:.[0-9:]*: error: Need type annotation for '                                     \
-        -e '^src/klein/_resource.py:.[0-9:]*: error: Function is missing a type annotation'                        \
-        -e '^src/klein/test/_trial.py:.[0-9:]*: error: Function is missing a type annotation'                      \
-        -e '^src/klein/test/py3_test_resource.py:.[0-9:]*: error: Function is missing a type annotation'           \
-        -e '^src/klein/test/test_app.py:.[0-9:]*: error: Function is missing a type annotation'                    \
-        -e '^src/klein/test/test_plating.py:.[0-9:]*: error: Function is missing a type annotation'                \
-        -e '^src/klein/test/test_plating.py:.[0-9:]*: error: Need type annotation for '                            \
-        -e '^src/klein/test/test_resource.py:.[0-9:]*: error: Function is missing a type annotation'               \
-        -e '^src/klein/test/util.py:.[0-9:]*: error: Function is missing a type annotation'                        \
-        -e '^src/klein/test/util.py:.[0-9:]*: error: Name .* already defined'                                      \
+        -e ': error: "Callable\[\[[^]]*\], [^]]*\]" has no attribute "\(skip\|todo\)"'                            \
+        -e ': note: .* defined here'                                                                              \
+        -e '^src/klein/_app.py:[0-9:]*: error: All conditional function variants must have identical signatures'  \
+        -e '^src/klein/_app.py:[0-9:]*: error: Function is missing a type annotation'                             \
+        -e '^src/klein/_decorators.py:[0-9:]*: error: Function is missing a type annotation'                      \
+        -e '^src/klein/_iapp.py:[0-9:]*: error: Function is missing a type annotation'                            \
+        -e '^src/klein/_message.py:[0-9:]*: error: "attrib" does not return a value'                              \
+        -e '^src/klein/_plating.py:.* error: Function is missing a type annotation'                               \
+        -e '^src/klein/_plating.py:[0-9:]*: error: Need type annotation for '                                     \
+        -e '^src/klein/_resource.py:[0-9:]*: error: Function is missing a type annotation'                        \
+        -e '^src/klein/test/_trial.py:[0-9:]*: error: Function is missing a type annotation'                      \
+        -e '^src/klein/test/py3_test_resource.py:[0-9:]*: error: Function is missing a type annotation'           \
+        -e '^src/klein/test/test_app.py:[0-9:]*: error: Function is missing a type annotation'                    \
+        -e '^src/klein/test/test_plating.py:[0-9:]*: error: Function is missing a type annotation'                \
+        -e '^src/klein/test/test_plating.py:[0-9:]*: error: Need type annotation for '                            \
+        -e '^src/klein/test/test_resource.py:[0-9:]*: error: Function is missing a type annotation'               \
+        -e '^src/klein/test/util.py:[0-9:]*: error: Function is missing a type annotation'                        \
+        -e '^src/klein/test/util.py:[0-9:]*: error: Name .* already defined'                                      \
         > "${tmp}" || true;
 
 sort < "${tmp}";

--- a/.travis/mypy
+++ b/.travis/mypy
@@ -34,25 +34,23 @@ tmp="$(mktemp -t mypy.XXXX)";
 mypy "$@"      \
     | grep -v  \
         -e ': error: "Callable\[\[[^]]*\], [^]]*\]" has no attribute "\(skip\|todo\)"'                             \
-        -e ': error: Argument 2 to "[^"]*" of "IMutableHTTPHeaders" has incompatible type'                         \
         -e ': error: Incompatible return value type (got "[^"]*HTTP[^"]*", expected "I[^"]*HTTP[^"]*")'            \
         -e ': error: Method must have at least one argument'                                                       \
-        -e ': error: Unexpected keyword argument "[^"]*" for "HTTPHeadersWrappingHeaders"'                         \
-        -e ': error: Unexpected keyword argument "[^"]*" for "HTTPRequestWrappingIRequest"'                        \
-        -e ': error: Unexpected keyword argument "[^"]*" for "IOFount"'                                            \
         -e ': error: Unexpected keyword argument.* for .*"[^"]*HTTP\(Headers\|Request\|Response\)"'                \
+        -e ': error: Argument .* has incompatible type "[^"]*HTTPHeaders"; expected "IHTTPHeaders"'                \
         -e ': note: .* defined here'                                                                               \
         -e '^src/klein/_app.py:.[0-9:]*: error: All conditional function variants must have identical signatures'  \
         -e '^src/klein/_app.py:.[0-9:]*: error: Function is missing a type annotation'                             \
-        -e '^src/klein/_app.py:.[0-9:]*: error: Need type annotation for variable'                                 \
         -e '^src/klein/_decorators.py:.[0-9:]*: error: Function is missing a type annotation'                      \
         -e '^src/klein/_interfaces.py:.[0-9:]*: error: Function is missing a type annotation'                      \
-        -e '^src/klein/_plating.py:.[0-9:]*: error: Function is missing a type annotation'                         \
+        -e '^src/klein/_plating.py:.* error: Function is missing a type annotation'                                \
+        -e '^src/klein/_plating.py:.[0-9:]*: error: Need type annotation for '                                     \
         -e '^src/klein/_resource.py:.[0-9:]*: error: Function is missing a type annotation'                        \
         -e '^src/klein/test/_trial.py:.[0-9:]*: error: Function is missing a type annotation'                      \
         -e '^src/klein/test/py3_test_resource.py:.[0-9:]*: error: Function is missing a type annotation'           \
         -e '^src/klein/test/test_app.py:.[0-9:]*: error: Function is missing a type annotation'                    \
         -e '^src/klein/test/test_plating.py:.[0-9:]*: error: Function is missing a type annotation'                \
+        -e '^src/klein/test/test_plating.py:.[0-9:]*: error: Need type annotation for '                            \
         -e '^src/klein/test/test_resource.py:.[0-9:]*: error: Function is missing a type annotation'               \
         -e '^src/klein/test/util.py:.[0-9:]*: error: Function is missing a type annotation'                        \
         -e '^src/klein/test/util.py:.[0-9:]*: error: Name .* already defined'                                      \

--- a/.travis/mypy
+++ b/.travis/mypy
@@ -25,24 +25,15 @@ tmp="$(mktemp -t mypy.XXXX)";
 #   annotations are used, but we ignore the errors for files that are not yet
 #   participating.
 #
-# * These are related to mypy not knowing about zope.interface:
-#   - Incompatible return value type
-#   - Method must have at least one argument
-#   - Unexpected keyword argument (also effects attrs classes' __init__)
-#
 
 mypy "$@"      \
     | grep -v  \
         -e ': error: "Callable\[\[[^]]*\], [^]]*\]" has no attribute "\(skip\|todo\)"'                             \
-        -e ': error: Argument .* has incompatible type "[^"]*"; expected "I[^"]*HTTPHeaders"'                      \
-        -e ': error: Incompatible return value type (got "[^"]*HTTP[^"]*", expected "I[^"]*HTTP[^"]*")'            \
-        -e ': error: Method must have at least one argument'                                                       \
-        -e ': error: Unexpected keyword argument.* for .*"[^"]*HTTP\(Headers\|Request\|Response\)"'                \
         -e ': note: .* defined here'                                                                               \
         -e '^src/klein/_app.py:.[0-9:]*: error: All conditional function variants must have identical signatures'  \
         -e '^src/klein/_app.py:.[0-9:]*: error: Function is missing a type annotation'                             \
         -e '^src/klein/_decorators.py:.[0-9:]*: error: Function is missing a type annotation'                      \
-        -e '^src/klein/_interfaces.py:.[0-9:]*: error: Function is missing a type annotation'                      \
+        -e '^src/klein/_iapp.py:.[0-9:]*: error: Function is missing a type annotation'                            \
         -e '^src/klein/_plating.py:.* error: Function is missing a type annotation'                                \
         -e '^src/klein/_plating.py:.[0-9:]*: error: Need type annotation for '                                     \
         -e '^src/klein/_resource.py:.[0-9:]*: error: Function is missing a type annotation'                        \

--- a/.travis/mypy
+++ b/.travis/mypy
@@ -34,10 +34,10 @@ tmp="$(mktemp -t mypy.XXXX)";
 mypy "$@"      \
     | grep -v  \
         -e ': error: "Callable\[\[[^]]*\], [^]]*\]" has no attribute "\(skip\|todo\)"'                             \
+        -e ': error: Argument .* has incompatible type "[^"]*"; expected "I[^"]*HTTPHeaders"'                      \
         -e ': error: Incompatible return value type (got "[^"]*HTTP[^"]*", expected "I[^"]*HTTP[^"]*")'            \
         -e ': error: Method must have at least one argument'                                                       \
         -e ': error: Unexpected keyword argument.* for .*"[^"]*HTTP\(Headers\|Request\|Response\)"'                \
-        -e ': error: Argument .* has incompatible type "[^"]*HTTPHeaders"; expected "IHTTPHeaders"'                \
         -e ': note: .* defined here'                                                                               \
         -e '^src/klein/_app.py:.[0-9:]*: error: All conditional function variants must have identical signatures'  \
         -e '^src/klein/_app.py:.[0-9:]*: error: Function is missing a type annotation'                             \

--- a/src/klein/_headers.py
+++ b/src/klein/_headers.py
@@ -9,7 +9,7 @@ from typing import (
     AnyStr, Iterable, List, MutableSequence, Sequence, Text, Tuple, Union
 )
 
-from attr import attrib, attrs
+from attr import Factory, attrib, attrs
 
 from zope.interface import Attribute, Interface, implementer
 
@@ -263,7 +263,7 @@ class FrozenHTTPHeaders(object):
     """
 
     rawHeaders = attrib(
-        convert=normalizeRawHeadersFrozen,
+        converter=normalizeRawHeadersFrozen,
         default=(),
     )  # type: RawHeaders
 
@@ -282,8 +282,8 @@ class MutableHTTPHeaders(object):
     """
 
     _rawHeaders = attrib(
-        convert=normalizeRawHeadersMutable,
-        default=(),
+        converter=normalizeRawHeadersMutable,
+        default=Factory(list),
     )  # type: MutableRawHeaders
 
 

--- a/src/klein/_headers.py
+++ b/src/klein/_headers.py
@@ -5,116 +5,23 @@
 HTTP headers API.
 """
 
-from typing import (
-    AnyStr, Iterable, List, MutableSequence, Sequence, Text, Tuple, Union
-)
+from typing import AnyStr, Iterable, Text, Tuple, Union
 
 from attr import Factory, attrib, attrs
 
-from zope.interface import Attribute, Interface, implementer
+from zope.interface import implementer
 
-AnyStr, Iterable, List  # Silence linter
+from ._imessage import MutableRawHeaders, RawHeader, RawHeaders
+from ._interfaces import IHTTPHeaders, IMutableHTTPHeaders
+
+# Silence linter
+AnyStr, Iterable, Tuple, MutableRawHeaders, RawHeader, RawHeaders
 
 
 __all__ = ()
 
 
-# Interfaces
-
 String = Union[bytes, Text]
-
-RawHeader = Tuple[bytes, bytes]
-RawHeaders = Sequence[RawHeader]
-MutableRawHeaders = MutableSequence[RawHeader]
-
-
-class IHTTPHeaders(Interface):
-    """
-    HTTP entity headers.
-
-    HTTP headers names and values are sort-of-but-not-quite-specifically
-    expected to be text.
-
-    Because the specifications are somewhat vague, and implementations vary in
-    fidelity, both header names and values must be made available as the
-    original bytes received from the network.
-    This interface also makes them available as an ordered sequence of name and
-    value pairs so that they can be iterated in the same order as they were
-    received on the network.
-
-    As such, the C{rawHeaders} attribute provides the header data as a sequence
-    of C{(name, value)} L{tuple}s.
-
-    A dictionary-like interface that maps text names to an ordered sequence of
-    text values.
-    This interface assumes that both header name bytes and header value bytes
-    are encoded as ISO-8859-1.
-
-    Note that header name bytes should be strictly encoded as ASCII; this
-    interface uses ISO-8859-1 to provide interoperability with (naughty) HTTP
-    implementations that send non-ASCII data.
-    Because ISO-8859-1 is a superset of ASCII, this will still work for
-    well-behaved implementations.
-    """
-
-    rawHeaders = Attribute(
-        """
-        Raw header data as a tuple in the from: C{((name, value), ...)}.
-        C{name} and C{value} are bytes.
-        Headers are provided in the order that they were received.
-        Headers with multiple values are provided as separate name and value
-        pairs.
-        """
-    )  # type: RawHeaders
-
-
-    def getValues(name):
-        # type: (AnyStr) -> Iterable[AnyStr]
-        """
-        Get the values associated with the given header name.
-
-        If the given name is L{bytes}, the value will be returned as the raw
-        header L{bytes}.
-
-        If the given name is L{Text}, the name will be encoded as ISO-8859-1
-        and the value will be returned as text, by decoding the raw header
-        value bytes with ISO-8859-1.
-
-        @param name: The name of the header to look for.
-
-        @return: The values of the header with the given name.
-        """
-
-
-
-class IMutableHTTPHeaders(IHTTPHeaders):
-    """
-    Mutable HTTP entity headers.
-    """
-
-    def remove(name):
-        # type: (AnyStr) -> None
-        """
-        Remove all header name/value pairs for the given header name.
-
-        If the given name is L{Text}, it will be encoded as ISO-8859-1 before
-        comparing to the (L{bytes}) header names.
-
-        @param name: The name of the header to remove.
-        """
-
-
-    def addValue(name, value):
-        # type: (AnyStr, AnyStr) -> None
-        """
-        Add the given header name/value pair.
-
-        If the given name is L{bytes}, the value must also be L{bytes}.
-
-        If the given name is L{Text}, it will be encoded as ISO-8859-1, and the
-        value, which must also be L{Text}, will be encoded as ISO-8859-1.
-        """
-
 
 
 # Encoding/decoding header data

--- a/src/klein/_iapp.py
+++ b/src/klein/_iapp.py
@@ -1,0 +1,18 @@
+from zope.interface import Attribute, Interface
+
+from ._typing import ifmethod
+
+
+
+class IKleinRequest(Interface):
+    branch_segments = Attribute("Segments consumed by a branch route.")
+    mapper = Attribute("L{werkzeug.routing.MapAdapter}")
+
+    @ifmethod
+    def url_for(
+        self, endpoint, values=None, method=None,
+        force_external=False, append_unknown=True,
+    ):
+        """
+        L{werkzeug.routing.MapAdapter.build}
+        """

--- a/src/klein/_imessage.py
+++ b/src/klein/_imessage.py
@@ -1,0 +1,204 @@
+# Copyright (c) 2017-2018. See LICENSE for details.
+
+"""
+Interfaces related to HTTP messages.
+
+Do not import directly from here, except:
+ * From _interfaces.py.
+ * From implementations of these interfaces, but even then, import the
+   zope.interface.Interface classes via _interfaces.py.
+
+This will ensure that type checking works.
+"""
+
+from typing import AnyStr, Iterable, MutableSequence, Sequence, Text, Tuple
+
+from hyperlink import URL
+
+from tubes.itube import IFount
+
+from twisted.internet.defer import Deferred
+
+from zope.interface import Attribute, Interface
+
+from ._typing import ifmethod
+
+AnyStr, Deferred, Iterable, IFount, Text, URL  # Silence linter
+
+
+__all__ = ()
+
+
+RawHeader = Tuple[bytes, bytes]
+RawHeaders = Sequence[RawHeader]
+MutableRawHeaders = MutableSequence[RawHeader]
+
+
+
+class FountAlreadyAccessedError(Exception):
+    """
+    The HTTP message's fount has already been accessed and is no longer
+    available.
+    """
+
+
+
+class IHTTPHeaders(Interface):
+    """
+    HTTP entity headers.
+
+    HTTP headers names and values are sort-of-but-not-quite-specifically
+    expected to be text.
+
+    Because the specifications are somewhat vague, and implementations vary in
+    fidelity, both header names and values must be made available as the
+    original bytes received from the network.
+    This interface also makes them available as an ordered sequence of name and
+    value pairs so that they can be iterated in the same order as they were
+    received on the network.
+
+    As such, the C{rawHeaders} attribute provides the header data as a sequence
+    of C{(name, value)} L{tuple}s.
+
+    A dictionary-like interface that maps text names to an ordered sequence of
+    text values.
+    This interface assumes that both header name bytes and header value bytes
+    are encoded as ISO-8859-1.
+
+    Note that header name bytes should be strictly encoded as ASCII; this
+    interface uses ISO-8859-1 to provide interoperability with (naughty) HTTP
+    implementations that send non-ASCII data.
+    Because ISO-8859-1 is a superset of ASCII, this will still work for
+    well-behaved implementations.
+    """
+
+    rawHeaders = Attribute(
+        """
+        Raw header data as a tuple in the from: C{((name, value), ...)}.
+        C{name} and C{value} are bytes.
+        Headers are provided in the order that they were received.
+        Headers with multiple values are provided as separate name and value
+        pairs.
+        """
+    )  # type: RawHeaders
+
+
+    @ifmethod
+    def getValues(name):
+        # type: (AnyStr) -> Iterable[AnyStr]
+        """
+        Get the values associated with the given header name.
+
+        If the given name is L{bytes}, the value will be returned as the raw
+        header L{bytes}.
+
+        If the given name is L{Text}, the name will be encoded as ISO-8859-1
+        and the value will be returned as text, by decoding the raw header
+        value bytes with ISO-8859-1.
+
+        @param name: The name of the header to look for.
+
+        @return: The values of the header with the given name.
+        """
+
+
+
+class IMutableHTTPHeaders(IHTTPHeaders):
+    """
+    Mutable HTTP entity headers.
+    """
+
+    @ifmethod
+    def remove(name):
+        # type: (AnyStr) -> None
+        """
+        Remove all header name/value pairs for the given header name.
+
+        If the given name is L{Text}, it will be encoded as ISO-8859-1 before
+        comparing to the (L{bytes}) header names.
+
+        @param name: The name of the header to remove.
+        """
+
+
+    @ifmethod
+    def addValue(name, value):
+        # type: (AnyStr, AnyStr) -> None
+        """
+        Add the given header name/value pair.
+
+        If the given name is L{bytes}, the value must also be L{bytes}.
+
+        If the given name is L{Text}, it will be encoded as ISO-8859-1, and the
+        value, which must also be L{Text}, will be encoded as ISO-8859-1.
+        """
+
+
+
+class IHTTPMessage(Interface):
+    """
+    HTTP entity.
+    """
+
+    headers = Attribute("Entity headers.")  # type: IHTTPHeaders
+
+
+    @ifmethod
+    def bodyAsFount():
+        # type: () -> IFount
+        """
+        The entity body, as a fount.
+
+        @note: The fount may only be accessed once.
+            It provides a mechanism for accessing the body as a stream of data,
+            potentially as it is read from the network, without having to cache
+            the entire body, which may be large.
+            Because there is no caching, it is not possible to "start over" by
+            accessing the fount a second time.
+            Attempting to do so will raise L{FountAlreadyAccessedError}.
+
+        @raise FountAlreadyAccessedError: If the fount has previously been
+            accessed.
+        """
+
+
+    @ifmethod
+    def bodyAsBytes():
+        # type: () -> Deferred[bytes]
+        """
+        The entity body, as bytes.
+
+        @note: This necessarily reads the entire entity body into memory,
+            which may be a problem if the body is large.
+
+        @note: This method caches the body, which means that unlike
+            C{self.bodyAsFount}, calling it repeatedly will return the same
+            data.
+
+        @note: This method accesses the fount (via C{self.bodyAsFount}), which
+            means the fount will not be available afterwards, and that if
+            C{self.bodyAsFount} has previously been called directly, this
+            method will raise L{FountAlreadyAccessedError}.
+
+        @raise FountAlreadyAccessedError: If the fount has previously been
+            accessed.
+        """
+
+
+
+class IHTTPRequest(IHTTPMessage):
+    """
+    HTTP request.
+    """
+
+    method = Attribute("Request method.")  # type: Text
+    uri    = Attribute("Request URI.")     # type: URL
+
+
+
+class IHTTPResponse(IHTTPMessage):
+    """
+    HTTP response.
+    """
+
+    status = Attribute("Response status code.")  # type: int

--- a/src/klein/_interfaces.py
+++ b/src/klein/_interfaces.py
@@ -1,16 +1,74 @@
-from __future__ import absolute_import, division
+# Copyright (c) 2018. See LICENSE for details.
 
-from zope.interface import Attribute, Interface
+"""
+Internal interface definitions.
+
+All Zope Interface classes should be imported from here so that type checking
+works, since mypy doesn't otherwise get along with Zope Interface.
+"""
+
+from typing import TYPE_CHECKING
+
+from ._iapp import IKleinRequest
+from ._imessage import (
+    IHTTPHeaders as _IHTTPHeaders,
+    IHTTPMessage as _IHTTPMessage,
+    IHTTPRequest as _IHTTPRequest,
+    IHTTPResponse as _IHTTPResponse,
+    IMutableHTTPHeaders as _IMutableHTTPHeaders,
+)
+
+IKleinRequest  # Silence linter
 
 
-class IKleinRequest(Interface):
-    branch_segments = Attribute("Segments consumed by a branch route.")
-    mapper = Attribute("L{werkzeug.routing.MapAdapter}")
+if TYPE_CHECKING:
+    from typing import Union
 
-    def url_for(
-        self, endpoint, values=None, method=None,
-        force_external=False, append_unknown=True,
-    ):
-        """
-        L{werkzeug.routing.MapAdapter.build}
-        """
+    from ._headers import FrozenHTTPHeaders, MutableHTTPHeaders
+    from ._headers_compat import HTTPHeadersWrappingHeaders
+    from ._request import FrozenHTTPRequest
+    from ._request_compat import HTTPRequestWrappingIRequest
+    from ._response import FrozenHTTPResponse
+
+    IHTTPHeaders = Union[
+        _IHTTPHeaders,
+        _IMutableHTTPHeaders,
+        FrozenHTTPHeaders,
+        HTTPHeadersWrappingHeaders,
+        MutableHTTPHeaders,
+    ]
+
+    IMutableHTTPHeaders = Union[
+        _IMutableHTTPHeaders,
+        HTTPHeadersWrappingHeaders,
+        MutableHTTPHeaders,
+    ]
+
+    IHTTPMessage = Union[
+        _IHTTPMessage,
+        _IHTTPRequest,
+        _IHTTPResponse,
+        FrozenHTTPRequest,
+        FrozenHTTPResponse,
+    ]
+
+    IHTTPRequest = Union[
+        _IHTTPRequest,
+        FrozenHTTPRequest,
+        HTTPRequestWrappingIRequest,
+    ]
+
+    IHTTPResponse = Union[
+        _IHTTPResponse,
+        FrozenHTTPResponse,
+    ]
+
+else:
+    IHTTPHeaders        = _IHTTPHeaders
+    IMutableHTTPHeaders = _IMutableHTTPHeaders
+    IHTTPMessage        = _IHTTPMessage
+    IHTTPRequest        = _IHTTPRequest
+    IHTTPResponse       = _IHTTPResponse
+
+
+__all__ = ()

--- a/src/klein/_message.py
+++ b/src/klein/_message.py
@@ -14,78 +14,15 @@ from tubes.itube import IFount
 
 from twisted.internet.defer import Deferred, succeed
 
-from zope.interface import Attribute, Interface
-
-from ._headers import IHTTPHeaders
+from ._imessage import FountAlreadyAccessedError
+from ._interfaces import IHTTPMessage
 from ._tubes import bytesToFount, fountToBytes
 
-Any, Deferred, IFount, IHTTPHeaders, Optional  # Silence linter
+Any, Deferred, IHTTPMessage, Optional  # Silence linter
 
 
 __all__ = ()
 
-
-
-# Interfaces
-
-class FountAlreadyAccessedError(Exception):
-    """
-    The HTTP message's fount has already been accessed and is no longer
-    available.
-    """
-
-
-
-class IHTTPMessage(Interface):
-    """
-    HTTP entity.
-    """
-
-    headers = Attribute("Entity headers.")  # type: IHTTPHeaders
-
-
-    def bodyAsFount():
-        # type: () -> IFount
-        """
-        The entity body, as a fount.
-
-        @note: The fount may only be accessed once.
-            It provides a mechanism for accessing the body as a stream of data,
-            potentially as it is read from the network, without having to cache
-            the entire body, which may be large.
-            Because there is no caching, it is not possible to "start over" by
-            accessing the fount a second time.
-            Attempting to do so will raise L{FountAlreadyAccessedError}.
-
-        @raise FountAlreadyAccessedError: If the fount has previously been
-            accessed.
-        """
-
-
-    def bodyAsBytes():
-        # type: () -> Deferred[bytes]
-        """
-        The entity body, as bytes.
-
-        @note: This necessarily reads the entire entity body into memory,
-            which may be a problem if the body is large.
-
-        @note: This method caches the body, which means that unlike
-            C{self.bodyAsFount}, calling it repeatedly will return the same
-            data.
-
-        @note: This method accesses the fount (via C{self.bodyAsFount}), which
-            means the fount will not be available afterwards, and that if
-            C{self.bodyAsFount} has previously been called directly, this
-            method will raise L{FountAlreadyAccessedError}.
-
-        @raise FountAlreadyAccessedError: If the fount has previously been
-            accessed.
-        """
-
-
-
-# Code shared by internal implementations of IHTTPMessage
 
 InternalBody = Union[bytes, IFount]
 

--- a/src/klein/_request.py
+++ b/src/klein/_request.py
@@ -16,12 +16,10 @@ from tubes.itube import IFount
 
 from twisted.internet.defer import Deferred
 
-from zope.interface import Attribute, implementer
+from zope.interface import implementer
 
-from ._headers import IHTTPHeaders
-from ._message import (
-    IHTTPMessage, MessageState, bodyAsBytes, bodyAsFount, validateBody
-)
+from ._interfaces import IHTTPHeaders, IHTTPRequest
+from ._message import MessageState, bodyAsBytes, bodyAsFount, validateBody
 
 # Silence linter
 Deferred, IFount, IHTTPHeaders, Text, Union
@@ -30,20 +28,6 @@ Deferred, IFount, IHTTPHeaders, Text, Union
 __all__ = ()
 
 
-
-# Interfaces
-
-class IHTTPRequest(IHTTPMessage):
-    """
-    HTTP request.
-    """
-
-    method = Attribute("Request method.")  # type: Text
-    uri    = Attribute("Request URI.")     # type: URL
-
-
-
-# Implementation
 
 @implementer(IHTTPRequest)
 @attrs(frozen=True)

--- a/src/klein/_response.py
+++ b/src/klein/_response.py
@@ -14,26 +14,15 @@ from tubes.itube import IFount
 
 from twisted.internet.defer import Deferred
 
-from zope.interface import Attribute, implementer
+from zope.interface import implementer
 
-from ._headers import IHTTPHeaders
-from ._message import (
-    IHTTPMessage, MessageState, bodyAsBytes, bodyAsFount, validateBody
-)
+from ._interfaces import IHTTPHeaders, IHTTPResponse
+from ._message import MessageState, bodyAsBytes, bodyAsFount, validateBody
 
 Deferred, IFount, Union  # Silence linter
 
 
 __all__ = ()
-
-
-
-class IHTTPResponse(IHTTPMessage):
-    """
-    HTTP response.
-    """
-
-    status = Attribute("Response status code.")  # type: int
 
 
 

--- a/src/klein/_typing.py
+++ b/src/klein/_typing.py
@@ -1,0 +1,11 @@
+from typing import TYPE_CHECKING
+
+
+__all__ = ()
+
+
+if TYPE_CHECKING:
+    ifmethod = staticmethod
+else:
+    def ifmethod(method):
+        return method

--- a/tox.ini
+++ b/tox.ini
@@ -157,7 +157,7 @@ basepython = python3.6
 skip_install = True
 
 deps =
-    mypy==0.560
+    mypy==0.570
 
 commands =
     "{toxinidir}/.travis/environment"


### PR DESCRIPTION
This PR:
 * updates `mypy` to the latest version
 * fixes a few new errors noticed by `mypy`
 * Moves shared Zope Interface classes, exceptions, and types from `_headers.py`, `_message.py`, `_request.py`, `_response.py` to `_imessage.py` so that interfaces are importable separately from implementations.
 * Moves `_interfaces.py` to `_iapp.py` to indicate it is related to `app.py`.
 * Adds a new `_interfaces.py` which imports the Zope Interface classes in `_iapp.py` and `_imessage.py` so and exposes them either directly or (when type checking) as `Union` types that works better with `mypy`.  This is a work-around for the fact that `mypy` doesn't play well with Zope Interface.
 * Reduces the number of filtered-out errors from `mypy` in the `.travis/mypy` wrapper script, partly due to fixes in `mypy` but more significantly due to the Zope Interface work-around above.

Note that the diff is large, but what's going on is moving code around; there's no new functionality, and the public API is un-altered.
