### PR TITLE
resolve weird klein.resource namespace conflict, gently as possible

### DIFF
--- a/src/klein/__init__.py
+++ b/src/klein/__init__.py
@@ -6,7 +6,7 @@ from ._app import Klein, handle_errors, route, run, urlFor, url_for
 from ._plating import Plating
 from ._version import __version__ as _incremental_version
 
-if TYPE_CHECKING:
+if TYPE_CHECKING:               # pragma: no cover
     # Inform mypy of import shenanigans.
     from .resource import _SpecialModuleObject
     resource = _SpecialModuleObject()

--- a/src/klein/__init__.py
+++ b/src/klein/__init__.py
@@ -1,9 +1,17 @@
 from __future__ import absolute_import, division
 
+from typing import TYPE_CHECKING
+
 from ._app import Klein, handle_errors, route, run, urlFor, url_for
 from ._plating import Plating
 from ._version import __version__ as _incremental_version
 
+if TYPE_CHECKING:
+    # Inform mypy of import shenanigans.
+    from .resource import _SpecialModuleObject
+    resource = _SpecialModuleObject()
+else:
+    from . import resource
 
 __all__ = (
     "Klein",
@@ -13,6 +21,7 @@ __all__ = (
     "__license__",
     "__version__",
     "handle_errors",
+    "resource",
     "route",
     "run",
     "urlFor",

--- a/src/klein/__init__.py
+++ b/src/klein/__init__.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import, division
 
-from ._app import Klein, handle_errors, resource, route, run, urlFor, url_for
+from ._app import Klein, handle_errors, route, run, urlFor, url_for
 from ._plating import Plating
 from ._version import __version__ as _incremental_version
 
@@ -13,7 +13,6 @@ __all__ = (
     "__license__",
     "__version__",
     "handle_errors",
-    "resource",
     "route",
     "run",
     "urlFor",

--- a/src/klein/resource.py
+++ b/src/klein/resource.py
@@ -14,7 +14,7 @@ from typing import TYPE_CHECKING
 from ._app import resource
 from ._resource import KleinResource as _KleinResource, ensure_utf8_bytes
 
-if TYPE_CHECKING:
+if TYPE_CHECKING:               # pragma: no cover
     from typing import AnyStr, Callable, Text
     AnyStr, Callable, Text
     KleinResource = _KleinResource

--- a/src/klein/resource.py
+++ b/src/klein/resource.py
@@ -18,7 +18,6 @@ if TYPE_CHECKING:
     from typing import AnyStr, Callable, Text
     AnyStr, Callable, Text
     KleinResource = _KleinResource
-    resource = resource
 
 class _SpecialModuleObject(object):
     """
@@ -59,4 +58,6 @@ class _SpecialModuleObject(object):
         return "<special bound method/module klein.resource>"
 
 
+preserve = modules[__name__]
 modules[__name__] = _SpecialModuleObject()
+modules[__name__].__preserve__ = preserve

--- a/src/klein/resource.py
+++ b/src/klein/resource.py
@@ -11,7 +11,7 @@ This module, L{klein.resource}, serves two purposes:
 from sys import modules
 from typing import TYPE_CHECKING
 
-from ._app import resource
+from ._app import resource as _globalResourceMethod
 from ._resource import KleinResource as _KleinResource, ensure_utf8_bytes
 
 if TYPE_CHECKING:               # pragma: no cover
@@ -47,7 +47,7 @@ class _SpecialModuleObject(object):
         """
         # Use the same docstring as the real implementation to reduce
         # confusion.
-        return resource()
+        return _globalResourceMethod()
 
 
     def __repr__(self):

--- a/src/klein/resource.py
+++ b/src/klein/resource.py
@@ -1,7 +1,52 @@
+# -*- test-case-name: klein.test.test_resource.GlobalAppTests.test_weird_resource_situation -*-
+
+"""
+This module, L{klein.resource}, serves two purposes:
+
+    - It's the global C{resource()} method on the global L{klein.Klein}
+      application.
+
+    - It's the module where L{KleinResource} is defined.
+"""
+
 from ._resource import KleinResource, ensure_utf8_bytes
+from ._app import resource
+from sys import modules
+
+class _SpecialModuleObject(object):
+    """
+    See the test in
+    L{klein.test.test_resource.GlobalAppTests.test_weird_resource_situation}
+    for an explanation.
+    """
+
+    __all__ = (
+        "KleinResource",
+        "ensure_utf8_bytes",
+    )
+
+    KleinResource = KleinResource
+
+    @property
+    def ensure_utf8_bytes(self):
+        return ensure_utf8_bytes
+
+    def __call__(self):
+        """
+        Return an L{IResource} which suitably wraps this app.
+
+        @returns: An L{IResource}
+        """
+        # Use the same docstring as the real implementation to reduce
+        # confusion.
+        return resource()
 
 
-__all__ = (
-    "KleinResource",
-    "ensure_utf8_bytes",
-)
+    def __repr__(self):
+        """
+        Give a special C{repr()} to make the dual purpose of this object clear.
+        """
+        return "<special bound method/module klein.resource>"
+
+
+modules[__name__] = _SpecialModuleObject()

--- a/src/klein/resource.py
+++ b/src/klein/resource.py
@@ -1,4 +1,4 @@
-# -*- test-case-name: klein.test.test_resource.GlobalAppTests.test_weird_resource_situation -*-
+# -*- test-case-name: klein.test.test_resource.GlobalAppTests -*-
 
 """
 This module, L{klein.resource}, serves two purposes:
@@ -8,10 +8,17 @@ This module, L{klein.resource}, serves two purposes:
 
     - It's the module where L{KleinResource} is defined.
 """
-
-from ._resource import KleinResource, ensure_utf8_bytes
-from ._app import resource
 from sys import modules
+from typing import TYPE_CHECKING
+
+from ._app import resource
+from ._resource import KleinResource as _KleinResource, ensure_utf8_bytes
+
+if TYPE_CHECKING:
+    from typing import AnyStr, Callable, Text
+    AnyStr, Callable, Text
+    KleinResource = _KleinResource
+    resource = resource
 
 class _SpecialModuleObject(object):
     """
@@ -29,9 +36,11 @@ class _SpecialModuleObject(object):
 
     @property
     def ensure_utf8_bytes(self):
+        # type: () -> Callable[[AnyStr], Text]
         return ensure_utf8_bytes
 
     def __call__(self):
+        # type: () -> _KleinResource
         """
         Return an L{IResource} which suitably wraps this app.
 
@@ -43,6 +52,7 @@ class _SpecialModuleObject(object):
 
 
     def __repr__(self):
+        # type: () -> str
         """
         Give a special C{repr()} to make the dual purpose of this object clear.
         """

--- a/src/klein/resource.py
+++ b/src/klein/resource.py
@@ -32,7 +32,7 @@ class _SpecialModuleObject(object):
         "ensure_utf8_bytes",
     )
 
-    KleinResource = KleinResource
+    KleinResource = _KleinResource
 
     @property
     def ensure_utf8_bytes(self):

--- a/src/klein/test/test_exports.py
+++ b/src/klein/test/test_exports.py
@@ -36,7 +36,7 @@ class PublicSymbolsTestCase(unittest.TestCase):
         import klein as k
         import klein._app as a
 
-        self.assertIdentical(k.resource(), a.resource())
+        self.assertIdentical(k.resource()._app, a.resource()._app)
 
 
     def test_app(self):

--- a/src/klein/test/test_exports.py
+++ b/src/klein/test/test_exports.py
@@ -32,14 +32,11 @@ class PublicSymbolsTestCase(unittest.TestCase):
         # type: () -> None
         """
         Test export of C{resource} from L{klein}.
-        (Move this into C{test_klein} after #224 is fixed.)
         """
         import klein as k
         import klein._app as a
 
-        self.assertIdentical(k.resource, a.resource)
-
-    test_klein_resource.todo = "See #224"
+        self.assertIdentical(k.resource(), a.resource())
 
 
     def test_app(self):
@@ -78,5 +75,3 @@ class PublicSymbolsTestCase(unittest.TestCase):
 
         self.assertIdentical(r.KleinResource, _r.KleinResource)
         self.assertIdentical(r.ensure_utf8_bytes, _r.ensure_utf8_bytes)
-
-    test_resource.todo = "See #224"

--- a/src/klein/test/test_resource.py
+++ b/src/klein/test/test_resource.py
@@ -1286,6 +1286,31 @@ class GlobalAppTests(TestCase):
         self.assertEqual(request.getWrittenData(), b'alive')
 
 
+    def test_weird_resource_situation(self):
+        """
+        Historically, the object named "C{klein.resource}" has had two
+        meanings:
+
+            - One is "C{klein.*} is sort of like a C{klein.Klein} instance, so
+              C{klein.resource()} is sort of like C{klein.Klein.resource()}".
+
+            - The other is "the public module in which
+              C{klein.resource.KleinResource} is defined".
+
+        This used to only work by accident; these meanings both sort of worked
+        but only as long as you followed a certain import convention (C{from
+        klein import resource} for the former, C{from klein.resource import
+        KleinResource} for the latter).  This test ensures that
+        C{klein.resource} is a special object, callable as you would expect
+        from the former, but also having the attributes of the latter.
+        """
+        from klein import resource
+        from klein.resource import KleinResource, ensure_utf8_bytes
+        self.assertEqual(repr(resource), "<special bound method/module klein.resource>")
+        self.assertIdentical(resource.KleinResource, KleinResource)
+        self.assertIdentical(resource.ensure_utf8_bytes, ensure_utf8_bytes)
+
+
 if _PY3:
     import sys
     if sys.version_info >= (3, 5):

--- a/src/klein/test/test_resource.py
+++ b/src/klein/test/test_resource.py
@@ -1306,7 +1306,8 @@ class GlobalAppTests(TestCase):
         """
         from klein import resource
         from klein.resource import KleinResource, ensure_utf8_bytes
-        self.assertEqual(repr(resource), "<special bound method/module klein.resource>")
+        self.assertEqual(repr(resource),
+                         "<special bound method/module klein.resource>")
         self.assertIdentical(resource.KleinResource, KleinResource)
         self.assertIdentical(resource.ensure_utf8_bytes, ensure_utf8_bytes)
 


### PR DESCRIPTION
Fixes #224 

Supersedes #225 

I think we should probably eventually deprecate `klein.resource.KleinResource` as the public name and expose it somewhere else, but for the time being, let's resolve things in as friendly a way as possible, so that everything keeps working regardless of what order you import things in.