### PR TITLE
Ignore AttributeError when searching for Klein instance.

### DIFF
--- a/src/klein/_app.py
+++ b/src/klein/_app.py
@@ -147,7 +147,10 @@ class Klein(object):
 
         if self._boundAs is None:
             for name in dir(owner):
-                obj = getattr(owner, name)
+                # Properties may raise an AttributeError on access even though
+                # they're visible on the instance, we can ignore those because
+                # Klein instances won't raise AttributeError.
+                obj = getattr(owner, name, None)
                 if obj is self:
                     self._boundAs = name
                     break

--- a/src/klein/test/test_app.py
+++ b/src/klein/test/test_app.py
@@ -178,6 +178,23 @@ class KleinTestCase(unittest.TestCase):
         self.assertIs(tr.app2, tr.app2)
 
 
+    def test_bindInstanceIgnoresBlankProperties(self):
+        """
+        L{Klein.__get__} doesn't propagate L{AttributeError} when
+        searching for the bound L{Klein} instance.
+        """
+
+        class ClassProperty(object):
+            def __get__(self, oself, owner):
+                raise AttributeError("you just don't have that special something")
+
+        class Oddment(object):
+            __something__ = ClassProperty()
+            app = Klein()
+
+        self.assertIsInstance(Oddment().app, Klein)
+
+
     def test_submountedRoute(self):
         """
         L{Klein.subroute} adds functions as routable endpoints.


### PR DESCRIPTION
Some properties might raise AttributeError even though they are
otherwise visible, we can safely ignore them because Klein will
not do this.

Fixes #257