### PR TITLE
Use config to exclude TYPE_CHECKING branches from coverage

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,3 +1,8 @@
 [run]
 branch = True
 source = klein
+
+[report]
+exclude_lines =
+    pragma: no cover
+    if TYPE_CHECKING:

--- a/src/klein/__init__.py
+++ b/src/klein/__init__.py
@@ -6,7 +6,7 @@ from ._app import Klein, handle_errors, route, run, urlFor, url_for
 from ._plating import Plating
 from ._version import __version__ as _incremental_version
 
-if TYPE_CHECKING:  # pragma: no cover
+if TYPE_CHECKING:
     # Inform mypy of import shenanigans.
     from .resource import _SpecialModuleObject
     resource = _SpecialModuleObject()

--- a/src/klein/_interfaces.py
+++ b/src/klein/_interfaces.py
@@ -21,7 +21,7 @@ from ._imessage import (
 IKleinRequest  # Silence linter
 
 
-if TYPE_CHECKING:  # pragma: no cover
+if TYPE_CHECKING:
     from typing import Union
 
     from ._headers import FrozenHTTPHeaders, MutableHTTPHeaders

--- a/src/klein/_typing.py
+++ b/src/klein/_typing.py
@@ -4,7 +4,7 @@ from typing import TYPE_CHECKING
 __all__ = ()
 
 
-if TYPE_CHECKING:  # pragma: no cover
+if TYPE_CHECKING:
     ifmethod = staticmethod
 else:
     def ifmethod(method):

--- a/src/klein/resource.py
+++ b/src/klein/resource.py
@@ -14,7 +14,7 @@ from typing import TYPE_CHECKING
 from ._app import resource as _globalResourceMethod
 from ._resource import KleinResource as _KleinResource, ensure_utf8_bytes
 
-if TYPE_CHECKING:  # pragma: no cover
+if TYPE_CHECKING:
     from typing import AnyStr, Callable, Text
     AnyStr, Callable, Text
     KleinResource = _KleinResource


### PR DESCRIPTION
At @glyph suggestion, use `coverage`'s config to exclude `TYPE_CHECKING` branches from coverage instead of pragmas.