### PR TITLE
Correct two off by one errors in line numeration

### DIFF
--- a/docs/introduction/1-gettingstarted.rst
+++ b/docs/introduction/1-gettingstarted.rst
@@ -174,7 +174,7 @@ need to put multiple items into the template?  The route for ``/places/...``
 can show us:
 
 .. literalinclude:: codeexamples/html.py
-    :lines: 52-68
+    :lines: 53-70
 
 Here you can see the special ``<slotname>:list`` renderer in use.  By
 specifying the ``render=`` attribute of a tag (in this case, a ``li`` tag) to


### PR DESCRIPTION
Hi!

I was a bit confused by the documentation here, turns out the literalinclude had the wrong line offset. :)

I think this should correct the discrepancy between html.py and 1-gettingstarted.rst