### PR TITLE
twisted trunk has dropped python 3.4 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,7 @@ matrix:
     - python: 3.4
       env: TOXENV=coverage-py34-tw171,codecov
     - python: 3.4
-      env: TOXENV=coverage-py34-twcurrent,codecov
+      env: TOXENV=coverage-py34-tw189,codecov
 
     - python: 3.5
       env: TOXENV=coverage-py35-tw160,codecov

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,8 @@ envlist =
     flake8
     mypy
 
-    coverage-py{27,34,35,36,37,py2,py3}-tw{166,171,current,trunk}
+    coverage-py{27,35,36,37,py2,py3}-tw{166,171,current,trunk}
+    coverage-py34-tw{166,171,189}
 
     docs, docs-linkcheck
 
@@ -38,6 +39,7 @@ deps =
     tw171: Twisted==17.1.0
     tw175: Twisted==17.5.0
     tw179: Twisted==17.9.0
+    tw189: Twisted==18.9.0
     twcurrent: Twisted
     twtrunk: https://github.com/twisted/twisted/archive/trunk.zip
 


### PR DESCRIPTION
Stop testing 3.4 against twisted trunk, both in local tox and in Travis.