### PR TITLE
Upgrade to PyPy 7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -61,18 +61,18 @@ matrix:
     - python: 3.7
       env: TOXENV=coverage-py37-twcurrent,codecov-py37
 
-    - python: pypy2.7-6.0
+    - python: pypy
       env: TOXENV=coverage-pypy2-tw160,codecov-pypy2
-    - python: pypy2.7-6.0
+    - python: pypy
       env: TOXENV=coverage-pypy2-tw171,codecov-pypy2
-    - python: pypy2.7-6.0
+    - python: pypy
       env: TOXENV=coverage-pypy2-twcurrent,codecov-pypy2
 
-    - python: pypy3.5-6.0
+    - python: pypy3
       env: TOXENV=coverage-pypy3-tw160,codecov-pypy3
-    - python: pypy3.5-6.0
+    - python: pypy3
       env: TOXENV=coverage-pypy3-tw171,codecov-pypy3
-    - python: pypy3.5-6.0
+    - python: pypy3
       env: TOXENV=coverage-pypy3-twcurrent,codecov-pypy3
 
     # Test against Twisted trunk in case something in development breaks us.


### PR DESCRIPTION
PyPy 7 is now available on Travis CI via `pypy` and `pypy3`, which have the PyPy2.7 and PyPy3.6-beta interpreters.

This would unblock dropping Python 3.5, if required, eg. https://github.com/twisted/klein/issues/279:

> Anything Python 3 less than 3.6 is weak salsa

And Python 3.5 download numbers are quite low. Here's the pip installs for klein from PyPI for May 2019:

| category | percent | downloads |
|----------|--------:|----------:|
|      3.6 |  47.51% |    17,587 |
|      2.7 |  35.11% |    12,998 |
|      3.7 |  12.00% |     4,443 |
|      3.5 |   4.16% |     1,539 |
| null     |   1.00% |       371 |
|      2.6 |   0.10% |        38 |
|      3.4 |   0.10% |        37 |
|      3.8 |   0.02% |         6 |
| Total    |         |    37,019 |

Source: `pypistats python_minor klein --last-month # pip install pypistats`