### PR TITLE
pin pydocstyle to version compatible with flake8-docstrings

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -95,6 +95,9 @@ deps =
     flake8-import-order==0.18.1
     flake8-mutable==1.2.0
     flake8-pep3101==1.2.1
+    # Remove this pin when https://gitlab.com/pycqa/flake8-docstrings/issues/36
+    # is fixed
+    pydocstyle<4.0.0
     pep8-naming==0.8.2
     mccabe==0.6.1
 


### PR DESCRIPTION
This should address the failing build on `master` right now.