### PR TITLE
Drop CI support for Python 3.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,13 +33,6 @@ matrix:
     - python: 2.7
       env: TOXENV=coverage-py27-twcurrent,codecov-py27
 
-    - python: 3.5
-      env: TOXENV=coverage-py35-tw171,codecov-py35
-    - python: 3.5
-      env: TOXENV=coverage-py35-tw184,codecov-py35
-    - python: 3.5
-      env: TOXENV=coverage-py35-twcurrent,codecov-py35
-
     - python: 3.6
       env: TOXENV=coverage-py36-tw171,codecov-py36
     - python: 3.6

--- a/.travis/mypy
+++ b/.travis/mypy
@@ -37,22 +37,23 @@ tmp="$(mktemp -t mypy.XXXX)";
 
 mypy "$@"      \
     | grep -v  \
-        -e ': error: Argument "converter" to "attrib" has incompatible type'                             \
-        -e ': error: Method must have at least one argument'                                             \
-        -e ': error: The type alias to [A-Za-z]* is invalid in runtime context'                          \
-        -e '^src/klein/_app.py:[0-9:]*: error: Function is missing a type annotation'                    \
-        -e '^src/klein/_decorators.py:[0-9:]*: error: Function is missing a type annotation'             \
-        -e '^src/klein/_iapp.py:[0-9:]*: error: Function is missing a type annotation'                   \
-        -e '^src/klein/_plating.py:.* error: Function is missing a type annotation'                      \
-        -e '^src/klein/_plating.py:[0-9:]*: error: Need type annotation for '                            \
-        -e '^src/klein/_resource.py:[0-9:]*: error: Function is missing a type annotation'               \
-        -e '^src/klein/test/_trial.py:[0-9:]*: error: Function is missing a type annotation'             \
-        -e '^src/klein/test/py3_test_resource.py:[0-9:]*: error: Function is missing a type annotation'  \
-        -e '^src/klein/test/test_app.py:[0-9:]*: error: Function is missing a type annotation'           \
-        -e '^src/klein/test/test_plating.py:[0-9:]*: error: Function is missing a type annotation'       \
-        -e '^src/klein/test/test_plating.py:[0-9:]*: error: Need type annotation for '                   \
-        -e '^src/klein/test/test_resource.py:[0-9:]*: error: Function is missing a type annotation'      \
-        -e '^src/klein/test/util.py:[0-9:]*: error: Function is missing a type annotation'               \
+        -e ': error: Argument "converter" to "attrib" has incompatible type'                                \
+        -e ': error: Method must have at least one argument'                                                \
+        -e ': error: The type alias to [A-Za-z]* is invalid in runtime context'                             \
+        -e ': note: Use "-> None" if function does not return a value'                                      \
+        -e '^src/klein/_app.py:[0-9:]*: error: Function is missing a [a-z ]* annotation'                    \
+        -e '^src/klein/_decorators.py:[0-9:]*: error: Function is missing a [a-z ]* annotation'             \
+        -e '^src/klein/_iapp.py:[0-9:]*: error: Function is missing a [a-z ]* annotation'                   \
+        -e '^src/klein/_plating.py:.* error: Function is missing a [a-z ]* annotation'                      \
+        -e '^src/klein/_plating.py:[0-9:]*: error: Need type annotation for '                               \
+        -e '^src/klein/_resource.py:[0-9:]*: error: Function is missing a [a-z ]* annotation'               \
+        -e '^src/klein/test/_trial.py:[0-9:]*: error: Function is missing a [a-z ]* annotation'             \
+        -e '^src/klein/test/py3_test_resource.py:[0-9:]*: error: Function is missing a [a-z ]* annotation'  \
+        -e '^src/klein/test/test_app.py:[0-9:]*: error: Function is missing a [a-z ]* annotation'           \
+        -e '^src/klein/test/test_plating.py:[0-9:]*: error: Function is missing a [a-z ]* annotation'       \
+        -e '^src/klein/test/test_plating.py:[0-9:]*: error: Need type annotation for '                      \
+        -e '^src/klein/test/test_resource.py:[0-9:]*: error: Function is missing a [a-z ]* annotation'      \
+        -e '^src/klein/test/util.py:[0-9:]*: error: Function is missing a [a-z ]* annotation'               \
         > "${tmp}" || true;
 
 sort < "${tmp}";

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -45,7 +45,7 @@ Code
   Klein uses `Twisted Trial <http://twistedmatrix.com/documents/current/api/twisted.trial.html>`_ and `tox <https://tox.readthedocs.io/en/latest/>`_ for its tests.
   The command to run the full test suite is ``tox`` with no arguments.
   This will run tests against several versions of Python and Twisted, which can be time-consuming.
-  To run tests against only one or a few versions, pass a ``-e`` argument with an environment from the envlist in ``tox.ini``: for example, ``tox -e py35-twcurrent`` will run tests with Python 3.5 and the current released version of Twisted.
+  To run tests against only one or a few versions, pass a ``-e`` argument with an environment from the envlist in ``tox.ini``: for example, ``tox -e py37-twcurrent`` will run tests with Python 3.7 and the current released version of Twisted.
   To run only one or a few specific tests in the suite, add a filename or fully-qualified Python path to the end of the test invocation: for example, ``tox klein.test.test_app.KleinTestCase.test_foo`` will run only the ``test_foo()`` method of the ``KleinTestCase`` class in ``klein/test/test_app.py``.
   These two test shortcuts can be combined to give you a quick feedback cycle, but make sure to check on the full test suite from time to time to make sure changes haven't had unexpected side effects.
 - Show us your code changes through pull requests sent to `Klein's GitHub repo <https://github.com/twisted/klein>`_.

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,6 @@ if __name__ == "__main__":
             'Operating System :: OS Independent',
             'Programming Language :: Python',
             'Programming Language :: Python :: 2.7',
-            'Programming Language :: Python :: 3.5',
             'Programming Language :: Python :: 3.6',
             'Programming Language :: Python :: 3.7',
             'Programming Language :: Python :: Implementation :: CPython',

--- a/src/klein/_session.py
+++ b/src/klein/_session.py
@@ -21,16 +21,15 @@ from .interfaces import (
 )
 
 if TYPE_CHECKING:               # pragma: no cover
+    from mypy_extensions import Arg, KwArg, VarArg
     from twisted.web.iweb import IRequest
     from twisted.python.components import Componentized
-    from mypy_extensions import KwArg, VarArg, Arg
-    from typing import TypeVar, Awaitable, Dict, Text
+    from typing import Awaitable, Dict, Sequence, Text, TypeVar
     T = TypeVar('T')
     (IRequest, Arg, KwArg, VarArg, Callable, Dict, IInterface, Awaitable,
      Componentized, IRequestLifecycle, Text)
 else:
     Arg = KwArg = lambda t, *x: t
-
 
 
 
@@ -117,7 +116,7 @@ class SessionProcurer(object):
                 [it for it in [request.getCookie(cookie)
                                for cookie in [self._secureCookie,
                                               self._insecureCookie]] if it]
-            )
+            )  # type: Sequence[Text]
             # Does it seem like this check is expensive? It sure is! Don't want
             # to do it? Turn on your dang HTTPS!
             yield self._store.sentInsecurely(allPossibleSentTokens)

--- a/tox.ini
+++ b/tox.ini
@@ -22,6 +22,7 @@ basepython =
     py35: python3.5
     py36: python3.6
     py37: python3.7
+    py38: python3.8
 
     pypy2: pypy
     pypy3: pypy3
@@ -40,25 +41,26 @@ deps =
     tw184: Twisted==18.4.0
     tw187: Twisted==18.7.0
     tw189: Twisted==18.9.0
-    tw192: Twisted==19.2.0
+    tw192: Twisted==19.2.1
+    tw192: Twisted==19.7.0
     twcurrent: Twisted
     twtrunk: https://github.com/twisted/twisted/archive/trunk.zip
 
-    attrs==19.1.0
+    attrs==19.3.0
     hyperlink==19.0.0
     incremental==17.5.0
     six==1.12.0
     Tubes==0.2.0
-    Werkzeug==0.15.4
+    Werkzeug==0.16.0
     zope.interface==4.6.0
 
     {trial,coverage}: treq==18.6.0
-    {trial,coverage}: hypothesis==4.24.3
+    {trial,coverage}: hypothesis==4.41.2
     {trial,coverage}: idna==2.8
     {trial,coverage}-py{27,py2}: mock==3.0.5
-    {trial,coverage}-py{27,py2}: typing==3.6.6
+    {trial,coverage}-py{27,py2}: typing==3.7.4.1
 
-    coverage: coverage==4.5.3
+    coverage: coverage==4.5.4
 
 passenv =
     # See https://github.com/codecov/codecov-python/blob/5b9d539a6a09bc84501b381b563956295478651a/README.md#using-tox
@@ -89,9 +91,9 @@ commands =
 skip_install = True
 
 deps =
-    flake8==3.7.7
-    flake8-bugbear==19.3.0
-    flake8-docstrings==1.3.0
+    flake8==3.7.8
+    flake8-bugbear==19.8.0
+    flake8-docstrings==1.5.0
     flake8-import-order==0.18.1
     flake8-mutable==1.2.0
     flake8-pep3101==1.2.1
@@ -173,8 +175,8 @@ basepython = python3.7
 skip_install = True
 
 deps =
-    mypy==0.701
-    mypy_extensions==0.4.1
+    mypy==0.740
+    mypy_extensions==0.4.3
 
 commands =
     "{toxinidir}/.travis/environment"
@@ -225,7 +227,7 @@ commands =
 
 deps =
     {[testenv:twistedchecker]deps}
-    diff_cover==2.1.0
+    diff_cover==2.4.0
 
 basepython = python2.7
 

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@ envlist =
     flake8
     mypy
 
-    coverage-py{27,35,36,37,py2,py3}-tw{171,184,current,trunk}
+    coverage-py{27,36,37,py2,py3}-tw{171,184,current,trunk}
 
     docs, docs-linkcheck
 


### PR DESCRIPTION
Current usage stats via `pypistats python_minor klein --last-month`:

| category | percent | downloads |
|----------|--------:|----------:|
| 3.6      |  42.06% |     8,791 |
| 2.7      |  30.26% |     6,324 |
| 3.7      |  21.27% |     4,446 |
| 3.5      |   4.06% |       849 |
| null     |   2.19% |       457 |
| 2.6      |   0.07% |        15 |
| 3.4      |   0.07% |        15 |
| 3.8      |   0.02% |         5 |
| Total    |         |    20,902 |

Date range: 2019-09-01 - 2019-09-30
