### PR TITLE
Get rid of the mypy wrapper script

### DIFF
--- a/src/klein/_dihttp.py
+++ b/src/klein/_dihttp.py
@@ -1,4 +1,3 @@
-
 """
 Dependency-Injected HTTP metadata.
 """
@@ -16,13 +15,12 @@ from zope.interface.interfaces import IInterface
 
 from .interfaces import IDependencyInjector, IRequiredParameter
 
-if TYPE_CHECKING:               # pragma: no cover
+if TYPE_CHECKING:  # pragma: no cover
     from hyperlink import DecodedURL
     from typing import Dict
     from klein.interfaces import IRequestLifecycle
     from twisted.web.iweb import IRequest
     from twisted.python.components import Componentized
-    Componentized, DecodedURL, IRequest, IRequestLifecycle, Dict
 
 
 def urlFromRequest(request):
@@ -49,7 +47,7 @@ def urlFromRequest(request):
     )
 
 
-@provider(IRequiredParameter, IDependencyInjector)
+@provider(IRequiredParameter, IDependencyInjector)  # type: ignore[misc]
 class RequestURL(object):
     """
     Require a hyperlink L{DecodedURL} object from a L{Requirer}.
@@ -75,7 +73,7 @@ class RequestURL(object):
 
 
 
-@implementer(IRequiredParameter, IDependencyInjector)
+@implementer(IRequiredParameter, IDependencyInjector)  # type: ignore[misc]
 @attr.s(frozen=True)
 class RequestComponent(object):
     """
@@ -121,8 +119,10 @@ class Response(object):
     """
     code = attr.ib(type=int, default=200)
     headers = attr.ib(
-        type=Mapping[Union[Text, bytes], Union[Text, bytes,
-                                               Sequence[Union[Text, bytes]]]],
+        type=Mapping[
+            Union[Text, bytes],
+            Union[Text, bytes, Sequence[Union[Text, bytes]]]
+        ],
         default=attr.Factory(dict),
     )
     body = attr.ib(type=Any, default=u'')

--- a/src/klein/_form.py
+++ b/src/klein/_form.py
@@ -77,7 +77,7 @@ class IParsedJSONBody(Interface):
 
 
 
-@implementer(IRequiredParameter)
+@implementer(IRequiredParameter)  # type: ignore[misc]
 @attr.s(frozen=True)
 class Field(object):
     """
@@ -285,7 +285,7 @@ class RenderableForm(object):
     @ivar validationErrors: a L{dict} mapping {L{Field}: L{ValidationError}}
     """
     _form = attr.ib(type='Form')
-    _session = attr.ib(type=ISession)
+    _session = attr.ib(type=ISession)  # type: ignore[misc]
     _action = attr.ib(type=str)
     _method = attr.ib(type=str)
     _enctype = attr.ib(type=str)
@@ -413,7 +413,7 @@ def defaultValidationFailureHandler(
 
     @return: Any object acceptable from a Klein route.
     """
-    session = request.getComponent(ISession)
+    session = request.getComponent(ISession)  # type: ignore[misc]
     request.setResponseCode(400)
     enctype = (
         (request.getHeader(b'content-type') or
@@ -463,7 +463,7 @@ class ProtoForm(object):
     Form-builder.
     """
     _componentized = attr.ib(type=Componentized)
-    _lifecycle = attr.ib(type=IRequestLifecycle)
+    _lifecycle = attr.ib(type=IRequestLifecycle)  # type: ignore[misc]
     _fields = attr.ib(type=List[Field], default=attr.Factory(list))
 
     @classmethod
@@ -472,7 +472,7 @@ class ProtoForm(object):
         """
         Create a ProtoForm from a componentized object.
         """
-        rl = IRequestLifecycle(componentized)
+        rl = IRequestLifecycle(componentized)  # type: ignore[misc]
         assert rl is not None
         return cls(componentized, rl)
 
@@ -524,7 +524,7 @@ class FieldValues(object):
 
 
 
-@implementer(IDependencyInjector)
+@implementer(IDependencyInjector)  # type: ignore[misc]
 @attr.s
 class FieldInjector(object):
     """
@@ -532,7 +532,7 @@ class FieldInjector(object):
     """
     _componentized = attr.ib(type=Componentized)
     _field = attr.ib(type=Field)
-    _lifecycle = attr.ib(type=IRequestLifecycle)
+    _lifecycle = attr.ib(type=IRequestLifecycle)  # type: ignore[misc]
 
     def injectValue(self, instance, request, routeParams):
         # type: (Any, IRequest, Dict[str, Any]) -> Any
@@ -588,7 +588,7 @@ def checkCSRF(request):
     it is found.
     """
     # TODO: optionalize CSRF protection for GET forms
-    session = ISession(request, None)
+    session = ISession(request, None)  # type: ignore[misc]
     token = None
     if request.method in (b'GET', b'HEAD'):
         # Idempotent requests don't require CRSF validation.  (Don't have
@@ -741,7 +741,7 @@ class Form(object):
 
 
 
-@implementer(IRequiredParameter, IDependencyInjector)
+@implementer(IRequiredParameter, IDependencyInjector)  # type: ignore[misc]
 @attr.s
 class RenderableFormParam(object):
     """
@@ -766,9 +766,10 @@ class RenderableFormParam(object):
         Create the renderable form from the request.
         """
         return RenderableForm(
-            self._form, ISession(request), self._action, self._method,
-            self._enctype, self._encoding, prevalidationValues={},
-            validationErrors={}
+            self._form,
+            ISession(request),  # type: ignore[misc]
+            self._action, self._method, self._enctype, self._encoding,
+            prevalidationValues={}, validationErrors={},
         )
 
     def finalize(self):

--- a/src/klein/_headers.py
+++ b/src/klein/_headers.py
@@ -14,9 +14,6 @@ from zope.interface import implementer
 from ._imessage import MutableRawHeaders, RawHeader, RawHeaders
 from ._interfaces import IHTTPHeaders, IMutableHTTPHeaders
 
-# Silence linter
-AnyStr, Iterable, Tuple, MutableRawHeaders, RawHeader, RawHeaders
-
 
 __all__ = ()
 
@@ -162,7 +159,7 @@ def rawHeaderNameAndValue(name, value):
 
 # Implementation
 
-@implementer(IHTTPHeaders)
+@implementer(IHTTPHeaders)  # type: ignore[misc]
 @attrs(frozen=True)
 class FrozenHTTPHeaders(object):
     """
@@ -181,7 +178,7 @@ class FrozenHTTPHeaders(object):
 
 
 
-@implementer(IMutableHTTPHeaders)
+@implementer(IMutableHTTPHeaders)  # type: ignore[misc]
 @attrs(frozen=True)
 class MutableHTTPHeaders(object):
     """

--- a/src/klein/_headers_compat.py
+++ b/src/klein/_headers_compat.py
@@ -20,14 +20,12 @@ from ._headers import (
     rawHeaderNameAndValue,
 )
 
-AnyStr, Iterable, RawHeaders, String, Tuple  # Silence linter
-
 
 __all__ = ()
 
 
 
-@implementer(IMutableHTTPHeaders)
+@implementer(IMutableHTTPHeaders)  # type: ignore[misc]
 @attrs(frozen=True)
 class HTTPHeadersWrappingHeaders(object):
     """

--- a/src/klein/_iform.py
+++ b/src/klein/_iform.py
@@ -1,5 +1,3 @@
-
-
 class ValidationError(Exception):
     """
     A L{ValidationError} is raised by L{Field.extractValue}.

--- a/src/klein/_imessage.py
+++ b/src/klein/_imessage.py
@@ -23,8 +23,6 @@ from zope.interface import Attribute, Interface
 
 from ._typing import ifmethod
 
-AnyStr, DecodedURL, Deferred, Iterable, IFount, Text  # Silence linter
-
 
 __all__ = ()
 

--- a/src/klein/_isession.py
+++ b/src/klein/_isession.py
@@ -15,12 +15,11 @@ from ._typing import ifmethod
 if TYPE_CHECKING:               # pragma: no cover
     from twisted.internet.defer import Deferred
     from twisted.python.components import Componentized
-    from typing import Dict, Iterable, List, Text, Type, Sequence
+    from typing import Dict, Iterable, Text, Sequence
     from twisted.web.iweb import IRequest
     from zope.interface.interfaces import IInterface
 
-    Deferred, Text, Componentized, Sequence, IRequest, List, Type
-    Iterable, IInterface, Dict
+
 
 class NoSuchSession(Exception):
     """

--- a/src/klein/_message.py
+++ b/src/klein/_message.py
@@ -15,10 +15,7 @@ from tubes.itube import IFount
 from twisted.internet.defer import Deferred, succeed
 
 from ._imessage import FountAlreadyAccessedError
-from ._interfaces import IHTTPMessage
 from ._tubes import bytesToFount, fountToBytes
-
-Any, Deferred, IHTTPMessage, Optional  # Silence linter
 
 
 __all__ = ()

--- a/src/klein/_request.py
+++ b/src/klein/_request.py
@@ -21,15 +21,12 @@ from zope.interface import implementer
 from ._interfaces import IHTTPHeaders, IHTTPRequest
 from ._message import MessageState, bodyAsBytes, bodyAsFount, validateBody
 
-# Silence linter
-Deferred, IFount, IHTTPHeaders, Text, Union
-
 
 __all__ = ()
 
 
 
-@implementer(IHTTPRequest)
+@implementer(IHTTPRequest)  # type: ignore[misc]
 @attrs(frozen=True)
 class FrozenHTTPRequest(object):
     """
@@ -38,7 +35,9 @@ class FrozenHTTPRequest(object):
 
     method  = attrib(validator=instance_of(Text))        # type: Text
     uri     = attrib(validator=instance_of(DecodedURL))  # type: DecodedURL
-    headers = attrib(validator=provides(IHTTPHeaders))   # type: IHTTPHeaders
+    headers = attrib(
+        validator=provides(IHTTPHeaders)  # type: ignore[misc]
+    )  # type: IHTTPHeaders
 
     _body = attrib(validator=validateBody)  # type: Union[bytes, IFount]
 

--- a/src/klein/_request_compat.py
+++ b/src/klein/_request_compat.py
@@ -27,9 +27,6 @@ from ._message import FountAlreadyAccessedError, MessageState
 from ._request import IHTTPRequest
 from ._tubes import IOFount, fountToBytes
 
-# Silence linter
-Deferred, IFount, IHTTPHeaders, Text
-
 
 __all__ = ()
 
@@ -38,7 +35,7 @@ noneIO = BytesIO()
 
 
 
-@implementer(IHTTPRequest)
+@implementer(IHTTPRequest)  # type: ignore[misc]
 @attrs(frozen=True)
 class HTTPRequestWrappingIRequest(object):
     """

--- a/src/klein/_requirer.py
+++ b/src/klein/_requirer.py
@@ -12,16 +12,16 @@ from ._app import _call
 from ._decorators import bindable, modified
 from .interfaces import EarlyExit, IRequestLifecycle
 
-if TYPE_CHECKING:               # pragma: no cover
-    from typing import Dict, Tuple, Sequence
+if TYPE_CHECKING:  # pragma: no cover
+    from typing import Dict, Sequence
     from twisted.web.iweb import IRequest
     from twisted.internet.defer import Deferred
     from zope.interface.interfaces import IInterface
     from .interfaces import IDependencyInjector, IRequiredParameter
-    IDependencyInjector, IRequiredParameter, IRequest, Dict, Tuple
-    Deferred, IInterface, Sequence
 
-@implementer(IRequestLifecycle)
+
+
+@implementer(IRequestLifecycle)  # type: ignore[misc]
 @attr.s
 class RequestLifecycle(object):
     """
@@ -62,6 +62,8 @@ _routeDecorator = Any           # a decorator like @route
 _routeT = Any                   # a thing decorated by a decorator like @route
 
 _prerequisiteCallback = Callable[[IRequestLifecycle], None]
+
+
 
 @attr.s
 class Requirer(object):
@@ -115,10 +117,12 @@ class Requirer(object):
         """
 
         def decorator(functionWithRequirements):
-            # type: (Any) -> Callable
+            # type: (Callable) -> Callable
             injectionComponents = Componentized()
             lifecycle = RequestLifecycle()
-            injectionComponents.setComponent(IRequestLifecycle, lifecycle)
+            injectionComponents.setComponent(
+                IRequestLifecycle, lifecycle  # type: ignore[misc]
+            )
 
             injectors = {}      # type: Dict[str, IDependencyInjector]
 
@@ -149,12 +153,12 @@ class Requirer(object):
                     result = ee.alternateReturnValue
                 else:
                     result = yield _call(
-                        instance, functionWithRequirements, *args,
-                        **injected
+                        instance, functionWithRequirements, *args, **injected
                     )
                 returnValue(result)
 
-            functionWithRequirements.injectionComponents = injectionComponents
+            fWR, iC = functionWithRequirements, injectionComponents
+            fWR.injectionComponents = iC  # type: ignore[attr-defined]
             routeDecorator(router)
             return functionWithRequirements
 

--- a/src/klein/_response.py
+++ b/src/klein/_response.py
@@ -19,14 +19,12 @@ from zope.interface import implementer
 from ._interfaces import IHTTPHeaders, IHTTPResponse
 from ._message import MessageState, bodyAsBytes, bodyAsFount, validateBody
 
-Deferred, IFount, Union  # Silence linter
-
 
 __all__ = ()
 
 
 
-@implementer(IHTTPResponse)
+@implementer(IHTTPResponse)  # type: ignore[misc]
 @attrs(frozen=True)
 class FrozenHTTPResponse(object):
     """
@@ -35,7 +33,9 @@ class FrozenHTTPResponse(object):
 
     status = attrib(validator=instance_of(int))  # type: int
 
-    headers = attrib(validator=provides(IHTTPHeaders))  # type: IHTTPHeaders
+    headers = attrib(
+        validator=provides(IHTTPHeaders)  # type: ignore[misc]
+    )  # type: IHTTPHeaders
 
     _body = attrib(validator=validateBody)  # type: Union[bytes, IFount]
 

--- a/src/klein/_session.py
+++ b/src/klein/_session.py
@@ -26,14 +26,12 @@ if TYPE_CHECKING:               # pragma: no cover
     from twisted.python.components import Componentized
     from typing import Awaitable, Dict, Sequence, Text, TypeVar
     T = TypeVar('T')
-    (IRequest, Arg, KwArg, VarArg, Callable, Dict, IInterface, Awaitable,
-     Componentized, IRequestLifecycle, Text)
 else:
     Arg = KwArg = lambda t, *x: t
 
 
 
-@implementer(ISessionProcurer)
+@implementer(ISessionProcurer)  # type: ignore[misc]
 @attr.s
 class SessionProcurer(object):
     """
@@ -76,7 +74,7 @@ class SessionProcurer(object):
     @type _setCookieOnGET: L{bool}
     """
 
-    _store = attr.ib(type=ISessionStore)
+    _store = attr.ib(type=ISessionStore)  # type: ignore[misc]
 
     _maxAge = attr.ib(type=int, default=3600)
     _secureCookie = attr.ib(type=bytes, default=b"Klein-Secure-Session")
@@ -92,7 +90,7 @@ class SessionProcurer(object):
     @inlineCallbacks
     def procureSession(self, request, forceInsecure=False):
         # type: (IRequest, bool) -> Any
-        alreadyProcured = request.getComponent(ISession)
+        alreadyProcured = request.getComponent(ISession)  # type: ignore[misc]
         if alreadyProcured is not None:
             if not forceInsecure or not request.isSecure():
                 returnValue(alreadyProcured)
@@ -185,7 +183,7 @@ class SessionProcurer(object):
             )
         if sentSecurely or not request.isSecure():
             # Do not cache the insecure session on the secure request, thanks.
-            request.setComponent(ISession, session)
+            request.setComponent(ISession, session)  # type: ignore[misc]
         returnValue(session)
 
 
@@ -214,7 +212,7 @@ class AuthorizationDenied(Resource, object):
         return "{} DENIED".format(qual(self._interface)).encode('utf-8')
 
 
-@implementer(IDependencyInjector, IRequiredParameter)
+@implementer(IDependencyInjector, IRequiredParameter)  # type: ignore[misc]
 @attr.s
 class Authorization(object):
     """
@@ -290,8 +288,10 @@ class Authorization(object):
         # TODO: this could be optimized to do fewer calls to 'authorize' by
         # collecting all the interfaces that are necessary and then using
         # addBeforeHook; the interface would not need to change.
-        provider = ((yield ISession(request).authorize([self._interface]))
-                    .get(self._interface))
+        session = ISession(request)  # type: ignore[misc]
+        provider = (
+            (yield session.authorize([self._interface])).get(self._interface)
+        )
         if self._required and provider is None:
             raise EarlyExit(self._whenDenied(self._interface, instance))
         # TODO: CSRF protection should probably go here

--- a/src/klein/_session.py
+++ b/src/klein/_session.py
@@ -21,10 +21,10 @@ from .interfaces import (
 )
 
 if TYPE_CHECKING:               # pragma: no cover
-    from mypy_extensions import Arg, KwArg, VarArg
+    from mypy_extensions import Arg, KwArg
     from twisted.web.iweb import IRequest
     from twisted.python.components import Componentized
-    from typing import Awaitable, Dict, Sequence, Text, TypeVar
+    from typing import Dict, Sequence, Text, TypeVar
     T = TypeVar('T')
 else:
     Arg = KwArg = lambda t, *x: t

--- a/src/klein/_tubes.py
+++ b/src/klein/_tubes.py
@@ -5,8 +5,7 @@ Extensions to Tubes.
 """
 
 from io import BytesIO
-from typing import Iterable
-from typing.io import BinaryIO
+from typing import BinaryIO, Iterable
 
 from attr import attrib, attrs
 from attr.validators import instance_of, optional, provides
@@ -19,8 +18,6 @@ from twisted.internet.defer import Deferred
 from twisted.python.failure import Failure
 
 from zope.interface import implementer
-
-BinaryIO, Deferred, Iterable  # Silence linter
 
 
 __all__ = ()

--- a/src/klein/interfaces.py
+++ b/src/klein/interfaces.py
@@ -24,7 +24,7 @@ from ._isession import (
 )
 
 if TYPE_CHECKING:               # pragma: no cover
-    from ._storage.memory import MemorySessionStore, MemorySession
+    from .storage._memory import MemorySessionStore, MemorySession
     from ._session import SessionProcurer, Authorization
     from ._form import Field, RenderableFormParam, FieldInjector
     from ._isession import IRequestLifecycleT as _IRequestLifecycleT

--- a/src/klein/resource.py
+++ b/src/klein/resource.py
@@ -16,8 +16,9 @@ from ._resource import KleinResource as _KleinResource, ensure_utf8_bytes
 
 if TYPE_CHECKING:
     from typing import AnyStr, Callable, Text
-    AnyStr, Callable, Text
     KleinResource = _KleinResource
+
+
 
 class _SpecialModuleObject(object):
     """
@@ -33,10 +34,12 @@ class _SpecialModuleObject(object):
 
     KleinResource = _KleinResource
 
+
     @property
     def ensure_utf8_bytes(self):
         # type: () -> Callable[[AnyStr], Text]
         return ensure_utf8_bytes
+
 
     def __call__(self):
         # type: () -> _KleinResource

--- a/src/klein/storage/_memory.py
+++ b/src/klein/storage/_memory.py
@@ -1,7 +1,7 @@
 # -*- test-case-name: klein.test.test_memory -*-
 from binascii import hexlify
 from os import urandom
-from typing import Any, Callable, Dict, List, TYPE_CHECKING, Text, cast
+from typing import Any, Callable, Dict, Iterable, List, Text, cast
 
 import attr
 from attr import Factory
@@ -16,12 +16,11 @@ from klein.interfaces import (
     ISession, ISessionStore, NoSuchSession, SessionMechanism
 )
 
-if TYPE_CHECKING:               # pragma: no cover
-    List, Deferred, IInterface, Any, Callable, Dict, SessionMechanism
-
 _authCB = Callable[[IInterface, ISession, Componentized], Any]
 
-@implementer(ISession)
+
+
+@implementer(ISession)  # type: ignore[misc]
 @attr.s
 class MemorySession(object):
     """
@@ -31,7 +30,7 @@ class MemorySession(object):
     identifier = attr.ib(type=Text)
     isConfidential = attr.ib(type=bool)
     authenticatedBy = attr.ib(type=SessionMechanism)
-    _authorizationCallback = attr.ib(type=_authCB)
+    _authorizationCallback = attr.ib(type=_authCB)  # type: ignore[misc]
     _components = attr.ib(default=Factory(Componentized),
                           type=Componentized)
 
@@ -50,6 +49,7 @@ class MemorySession(object):
         return succeed(result)
 
 
+
 class _MemoryAuthorizerFunction(object):
     """
     Type shadow for function with the given attribute.
@@ -64,6 +64,8 @@ class _MemoryAuthorizerFunction(object):
 
 _authFn = Callable[[IInterface, ISession, Componentized], Any]
 
+
+
 def declareMemoryAuthorizer(forInterface):
     # type: (IInterface) -> Callable[[Callable], _MemoryAuthorizerFunction]
     """
@@ -77,15 +79,18 @@ def declareMemoryAuthorizer(forInterface):
         return decoratee
     return decorate
 
+
 def _noAuthorization(interface, session, data):
     # type: (IInterface, ISession, Componentized) -> None
     return None
 
-@implementer(ISessionStore)
+
+
+@implementer(ISessionStore)  # type: ignore[misc]
 @attr.s
 class MemorySessionStore(object):
     authorizationCallback = attr.ib(
-        type=_authFn,
+        type=_authFn,  # type: ignore[misc]
         default=_noAuthorization
     )
     _secureStorage = attr.ib(type=Dict[str, Any],
@@ -147,5 +152,5 @@ class MemorySessionStore(object):
 
 
     def sentInsecurely(self, tokens):
-        # type: (List[str]) -> None
+        # type: (Iterable[str]) -> None
         return

--- a/src/klein/test/_trial.py
+++ b/src/klein/test/_trial.py
@@ -14,8 +14,6 @@ from zope.interface import Interface
 from zope.interface.exceptions import Invalid
 from zope.interface.verify import verifyObject
 
-Any, Interface  # Silence linter
-
 
 __all__ = ()
 

--- a/src/klein/test/test_app.py
+++ b/src/klein/test/test_app.py
@@ -5,7 +5,7 @@ import sys
 try:
     from unittest.mock import Mock, patch
 except Exception:
-    from mock import Mock, patch  # type:ignore
+    from mock import Mock, patch  # type:ignore[misc]
 
 from twisted.python.components import registerAdapter
 from twisted.trial import unittest

--- a/src/klein/test/test_form.py
+++ b/src/klein/test/test_form.py
@@ -19,11 +19,10 @@ from klein.interfaces import (
 )
 from klein.storage.memory import MemorySessionStore
 
-if TYPE_CHECKING:               # pragma: no cover
-    from typing import Any, Dict, Tuple, Union
+if TYPE_CHECKING:  # pragma: no cover
+    from typing import Any, Tuple
     from twisted.web.iweb import IRequest
     from klein import RenderableForm
-    Any, IRequest, Text, Union, Dict, Tuple, RenderableForm
 
 
 
@@ -40,13 +39,13 @@ class DanglingField(Field):
 
 @attr.s(hash=False)
 class TestObject(object):
-    sessionStore = attr.ib(type=ISessionStore)
+    sessionStore = attr.ib(type=ISessionStore)  # type: ignore[misc]
     calls = attr.ib(attr.Factory(list), type=List)
 
     router = Klein()
     requirer = Requirer()
 
-    @requirer.prerequisite([ISession])
+    @requirer.prerequisite([ISession])  # type: ignore[misc]
     @inlineCallbacks
     def procureASession(self, request):
         # type: (IRequest) -> Any

--- a/src/klein/test/test_headers.py
+++ b/src/klein/test/test_headers.py
@@ -23,9 +23,6 @@ from .._headers import (
     normalizeHeaderName, normalizeRawHeaders, normalizeRawHeadersFrozen,
 )
 
-# Silence linter
-AnyStr, Dict, Iterable, List, Optional, RawHeaders, Text, Tuple
-
 
 __all__ = ()
 
@@ -371,7 +368,7 @@ class FrozenHTTPHeadersTests(GetValuesTestsMixIn, TestCase):
         L{FrozenHTTPHeaders} implements L{IHTTPHeaders}.
         """
         headers = FrozenHTTPHeaders(rawHeaders=())
-        self.assertProvides(IHTTPHeaders, headers)
+        self.assertProvides(IHTTPHeaders, headers)  # type: ignore[misc]
 
 
     def test_defaultHeaders(self):
@@ -413,7 +410,9 @@ class MutableHTTPHeadersTestsMixIn(GetValuesTestsMixIn):
         Class implements L{IMutableHTTPHeaders}.
         """
         headers = self.headers(rawHeaders=())
-        cast(TestCase, self).assertProvides(IMutableHTTPHeaders, headers)
+        cast(TestCase, self).assertProvides(
+            IMutableHTTPHeaders, headers  # type: ignore[misc]
+        )
 
 
     def test_rawHeaders(self):

--- a/src/klein/test/test_headers_compat.py
+++ b/src/klein/test/test_headers_compat.py
@@ -16,9 +16,6 @@ from .._headers import (
 )
 from .._headers_compat import HTTPHeadersWrappingHeaders
 
-# Silence linter
-IMutableHTTPHeaders, RawHeaders, Text
-
 
 try:
     from twisted.web.http_headers import _sanitizeLinearWhitespace

--- a/src/klein/test/test_memory.py
+++ b/src/klein/test/test_memory.py
@@ -9,7 +9,7 @@ from zope.interface.verify import verifyObject
 from klein.interfaces import ISession, ISessionStore, SessionMechanism
 from klein.storage.memory import MemorySessionStore, declareMemoryAuthorizer
 
-Any
+
 
 class IFoo(Interface):
     """
@@ -36,9 +36,9 @@ class MemoryTests(SynchronousTestCase):
         Verify that the session store complies with the relevant interfaces.
         """
         store = MemorySessionStore()
-        verifyObject(ISessionStore, store)
+        verifyObject(ISessionStore, store)  # type: ignore[misc]
         verifyObject(
-            ISession, self.successResultOf(
+            ISession, self.successResultOf(  # type: ignore[misc]
                 store.newSession(True, SessionMechanism.Header)
             )
         )

--- a/src/klein/test/test_message.py
+++ b/src/klein/test/test_message.py
@@ -11,9 +11,8 @@ from hypothesis import given
 from hypothesis.strategies import binary
 
 from ._trial import TestCase
-from .._message import (
-    FountAlreadyAccessedError, IHTTPMessage, bytesToFount, fountToBytes
-)
+from .._interfaces import IHTTPMessage
+from .._message import FountAlreadyAccessedError, bytesToFount, fountToBytes
 
 
 __all__ = ()
@@ -53,7 +52,9 @@ class FrozenHTTPMessageTestsMixIn(object):
         Message instance implements L{IHTTPMessage}.
         """
         message = self.messageFromBytes()
-        cast(TestCase, self).assertProvides(IHTTPMessage, message)
+        cast(TestCase, self).assertProvides(
+            IHTTPMessage, message  # type: ignore[misc]
+        )
 
 
     @given(binary())

--- a/src/klein/test/test_request.py
+++ b/src/klein/test/test_request.py
@@ -10,10 +10,8 @@ from hyperlink import DecodedURL
 from ._trial import TestCase
 from .test_message import FrozenHTTPMessageTestsMixIn
 from .._headers import FrozenHTTPHeaders
-from .._message import IHTTPMessage
+from .._interfaces import IHTTPMessage
 from .._request import FrozenHTTPRequest, IHTTPRequest
-
-IHTTPMessage  # Silence linter
 
 
 __all__ = ()
@@ -48,7 +46,7 @@ class FrozenHTTPRequestTests(FrozenHTTPMessageTestsMixIn, TestCase):
         L{FrozenHTTPRequest} implements L{IHTTPRequest}.
         """
         request = self.requestFromBytes()
-        self.assertProvides(IHTTPRequest, request)
+        self.assertProvides(IHTTPRequest, request)  # type: ignore[misc]
 
 
     def test_initInvalidBodyType(self):

--- a/src/klein/test/test_request_compat.py
+++ b/src/klein/test/test_request_compat.py
@@ -24,8 +24,6 @@ from .._message import FountAlreadyAccessedError
 from .._request import IHTTPRequest
 from .._request_compat import HTTPRequestWrappingIRequest
 
-DecodedURL, Headers, IRequest, Optional, Text  # Silence linter
-
 
 __all__ = ()
 
@@ -59,7 +57,7 @@ class HTTPRequestWrappingIRequestTests(TestCase):
         L{HTTPRequestWrappingIRequest} implements L{IHTTPRequest}.
         """
         request = HTTPRequestWrappingIRequest(request=self.legacyRequest())
-        self.assertProvides(IHTTPRequest, request)
+        self.assertProvides(IHTTPRequest, request)  # type: ignore[misc]
 
 
     @given(text(alphabet=ascii_uppercase, min_size=1))
@@ -127,7 +125,9 @@ class HTTPRequestWrappingIRequestTests(TestCase):
         """
         legacyRequest = self.legacyRequest()
         request = HTTPRequestWrappingIRequest(request=legacyRequest)
-        self.assertProvides(IHTTPHeaders, request.headers)
+        self.assertProvides(
+            IHTTPHeaders, request.headers  # type: ignore[misc]
+        )
 
 
     def test_bodyAsFountTwice(self):

--- a/src/klein/test/test_requirer.py
+++ b/src/klein/test/test_requirer.py
@@ -1,4 +1,4 @@
-from typing import Iterable, List, TYPE_CHECKING, Text, Tuple
+from typing import Iterable, List, Text, Tuple
 
 from hyperlink import DecodedURL
 

--- a/src/klein/test/test_requirer.py
+++ b/src/klein/test/test_requirer.py
@@ -1,20 +1,18 @@
+from typing import Iterable, List, TYPE_CHECKING, Text, Tuple
 
-from typing import TYPE_CHECKING
+from hyperlink import DecodedURL
 
 from treq.testing import StubTreq
 
 from twisted.trial.unittest import SynchronousTestCase
 from twisted.web.http_headers import Headers
+from twisted.web.iweb import IRequest
 
 from zope.interface import Interface
 
 from klein import Klein, RequestComponent, RequestURL, Requirer, Response
 
-if TYPE_CHECKING:               # pragma: no cover
-    from typing import Text, Iterable, List, Tuple
-    from hyperlink import DecodedURL
-    from twisted.web.iweb import IRequest
-    DecodedURL, Text, Iterable, List, Tuple, IRequest
+
 
 class BadlyBehavedHeaders(Headers):
     """
@@ -32,8 +30,11 @@ class BadlyBehavedHeaders(Headers):
                 yield (key, values)
 
 
+
 router = Klein()
 requirer = Requirer()
+
+
 @requirer.require(router.route("/hello/world", methods=['GET']),
                   url=RequestURL())
 def requiresURL(url):
@@ -43,10 +44,14 @@ def requiresURL(url):
     """
     return url.child(u"hello/ world").asText()
 
+
+
 class ISample(Interface):
     """
     Interface for testing.
     """
+
+
 
 @requirer.prerequisite([ISample])
 def provideSample(request):
@@ -56,6 +61,7 @@ def provideSample(request):
     """
     request.setComponent(ISample, "sample component")
 
+
 @requirer.require(router.route("/retrieve/component", methods=['GET']),
                   component=RequestComponent(ISample))
 def needsComponent(component):
@@ -64,6 +70,7 @@ def needsComponent(component):
     This route requires and returns an L{ISample}.
     """
     return component
+
 
 @requirer.require(router.route("/set/headers"))
 def someHeaders():
@@ -76,6 +83,7 @@ def someHeaders():
               'x-multi-header': [b'two', b'three']},
         "this is the response body"
     )
+
 
 
 class RequireURLTests(SynchronousTestCase):
@@ -98,6 +106,7 @@ class RequireURLTests(SynchronousTestCase):
         self.assertEqual(response,
                          "https://example.com/hello/world/hello%2F%20world")
 
+
     def test_requiresURLNonStandardPort(self):
         # type: () -> None
         """
@@ -115,6 +124,7 @@ class RequireURLTests(SynchronousTestCase):
             "http://example.com:8080/hello/world/hello%2F%20world"
         )
 
+
     def test_requiresURLBadlyBehavedClient(self):
         # type: () -> None
         """
@@ -131,6 +141,8 @@ class RequireURLTests(SynchronousTestCase):
             # Static values from StubTreq - this should probably be tunable.
             "https://127.0.0.1:31337/hello/world/hello%2F%20world"
         )
+
+
 
 class RequireComponentTests(SynchronousTestCase):
     """
@@ -150,6 +162,7 @@ class RequireComponentTests(SynchronousTestCase):
         self.assertEqual(
             response, "sample component"
         )
+
 
 
 class ResponseTests(SynchronousTestCase):

--- a/src/klein/test/test_response.py
+++ b/src/klein/test/test_response.py
@@ -8,10 +8,8 @@ Tests for L{klein._response}.
 from ._trial import TestCase
 from .test_message import FrozenHTTPMessageTestsMixIn
 from .._headers import FrozenHTTPHeaders
-from .._message import IHTTPMessage
+from .._interfaces import IHTTPMessage
 from .._response import FrozenHTTPResponse, IHTTPResponse
-
-IHTTPMessage  # Silence linter
 
 
 __all__ = ()
@@ -45,7 +43,7 @@ class FrozenHTTPResponseTests(FrozenHTTPMessageTestsMixIn, TestCase):
         L{FrozenHTTPResponse} implements L{IHTTPResponse}.
         """
         response = self.responseFromBytes()
-        self.assertProvides(IHTTPResponse, response)
+        self.assertProvides(IHTTPResponse, response)  # type: ignore[misc]
 
 
     def test_initInvalidBodyType(self):

--- a/src/klein/test/test_session.py
+++ b/src/klein/test/test_session.py
@@ -16,7 +16,7 @@ from klein._typing import ifmethod
 from klein.interfaces import ISession, NoSuchSession, TooLateForCookies
 from klein.storage.memory import MemorySessionStore, declareMemoryAuthorizer
 
-if TYPE_CHECKING:               # pragma: no cover
+if TYPE_CHECKING:  # pragma: no cover
     from twisted.web.iweb import IRequest
     from twisted.internet.defer import Deferred
     from twisted.python.components import Componentized
@@ -24,7 +24,8 @@ if TYPE_CHECKING:               # pragma: no cover
     from typing import Tuple, List
     sessions = List[ISession]
     errors = List[NoSuchSession]
-    IRequest, Deferred, sessions, errors, Tuple, Componentized, IInterface
+
+
 
 class ISimpleTest(Interface):
     """
@@ -97,7 +98,7 @@ def simpleSessionRouter():
 
     requirer = Requirer()
 
-    @requirer.prerequisite([ISession])
+    @requirer.prerequisite([ISession])  # type: ignore[misc]
     def procure(request):
         # type: (IRequest) -> Deferred
         return sproc.procureSession(request)

--- a/src/klein/test/test_trial.py
+++ b/src/klein/test/test_trial.py
@@ -7,6 +7,7 @@ Tests for L{klein.test._trial}.
 from zope.interface import Interface, implementer
 
 from ._trial import TestCase
+from .._typing import ifmethod
 
 
 __all__ = ()
@@ -22,6 +23,7 @@ class TestCaseTests(TestCase):
         """
         Frobbable object.
         """
+        @ifmethod
         def frob():
             # type: () -> None
             """

--- a/tox.ini
+++ b/tox.ini
@@ -97,11 +97,14 @@ deps =
     flake8-import-order==0.18.1
     flake8-mutable==1.2.0
     flake8-pep3101==1.2.1
+    mccabe==0.6.1
+    pep8-naming==0.8.2
+    pycodestyle==2.5.0
     # Remove this pin when https://gitlab.com/pycqa/flake8-docstrings/issues/36
     # is fixed
     pydocstyle<4.0.0
-    pep8-naming==0.8.2
-    mccabe==0.6.1
+    # pin pyflakes pending a release with https://github.com/PyCQA/pyflakes/pull/455
+    git+git://github.com/PyCQA/pyflakes@ffe9386#egg=pyflakes
 
 basepython = python3.7
 
@@ -165,10 +168,12 @@ max-complexity = 60
 
 
 ##
-# Mypy linting
+# Mypy static type checking
 ##
 
 [testenv:mypy]
+
+description = run Mypy (static type checker)
 
 basepython = python3.7
 
@@ -181,24 +186,100 @@ deps =
 commands =
     "{toxinidir}/.travis/environment"
 
-    "{toxinidir}/.travis/mypy" --config-file="{toxinidir}/tox.ini" {posargs:src}
+    mypy                                       \
+        --config-file="{toxinidir}/tox.ini"    \
+        --cache-dir="{toxworkdir}/mypy_cache"  \
+        {tty:--pretty:}                        \
+        {posargs:src}
 
 
 [mypy]
 
 # Global settings
 
-warn_redundant_casts = True
-warn_unused_ignores = True
-strict_optional = True
-show_column_numbers = True
+disallow_untyped_defs    = True
+show_column_numbers      = True
+show_error_codes         = True
+strict_optional          = True
+warn_no_return           = True
+warn_redundant_casts     = True
+warn_unused_ignores      = True
 
-# Module default settings
-# disallow_untyped_calls = True
-disallow_untyped_defs = True
-# warn_return_any = True
+# Enable these over time
 
-# Need some stub files to get rid of this
+check_untyped_defs       = False
+disallow_incomplete_defs = False
+no_implicit_optional     = False
+warn_return_any          = False
+warn_unreachable         = False
+
+# Disable some checks until effected files fully adopt mypy
+
+[mypy-klein._app]
+allow_untyped_defs = True
+
+[mypy-klein._decorators]
+allow_untyped_defs = True
+
+[mypy-klein._iapp]
+allow_untyped_defs = True
+
+[mypy-klein._plating]
+allow_untyped_defs = True
+
+[mypy-klein._resource]
+allow_untyped_defs = True
+
+[mypy-klein.test._trial]
+allow_untyped_defs = True
+
+[mypy-klein.test.py3_test_resource]
+allow_untyped_defs = True
+
+[mypy-klein.test.test_app]
+allow_untyped_defs = True
+
+[mypy-klein.test.test_plating]
+allow_untyped_defs = True
+
+[mypy-klein.test.test_resource]
+allow_untyped_defs = True
+
+[mypy-klein.test.util]
+allow_untyped_defs = True
+
+# Don't complain about dependencies known to lack type hints
+
+[mypy-constantly]
+ignore_missing_imports = True
+
+[mypy-incremental]
+ignore_missing_imports = True
+
+[mypy-zope.interface]
+[mypy-zope.interface.*]
+ignore_missing_imports = True
+
+[mypy-treq]
+ignore_missing_imports = True
+[mypy-treq.*]
+ignore_missing_imports = True
+
+[mypy-hyperlink]
+ignore_missing_imports = True
+
+[mypy-hypothesis]
+ignore_missing_imports = True
+[mypy-hypothesis.*]
+ignore_missing_imports = True
+
+[mypy-idna]
+ignore_missing_imports = True
+
+[mypy-tubes.*]
+ignore_missing_imports = True
+
+[mypy-twisted.*]
 ignore_missing_imports = True
 
 


### PR DESCRIPTION
Get rid of the mypy script, ignore untyped definitions in a bunch of files, and apply enough `# type: ignore hooey` to quiet various errors from `mypy` for now.

Note that number `# type: ignore[misc]` are added to silence errors related to `zope.interface` classes and a work-around using `Union` types from @glyph.

This also removed unnecessary references to type symbols that were added to silence `flake8`, which now sees uses in type hints, and then removes some actually unused symbols that are caught by `flake8`.
