### PR TITLE
Set BLACK_LINT_ARGS in Tox black environment

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -105,6 +105,9 @@ skip_install = True
 deps =
     black==19.10b0
 
+setenv =
+    BLACK_LINT_ARGS=--check
+
 commands =
     black {env:BLACK_LINT_ARGS:} src
 
@@ -376,7 +379,7 @@ basepython = {[default]basepython}
 skip_install = True
 
 deps =
-    coverage==5.0
+    coverage==5.0.3
 
 setenv =
     {[default]setenv}


### PR DESCRIPTION
In the `black` Tox environment, `black` is running such that it reformats the code, when it should only be checking the code.  This PR fixes that.

Now we get the correct error with a formatting oopsie, rather than actually fixing the code for you:

```console
$ tox -e black
black installed: appdirs==1.4.3,attrs==19.3.0,black==19.10b0,Click==7.0,pathspec==0.7.0,regex==2020.1.8,toml==0.10.0,typed-ast==1.4.1
black run-test-pre: PYTHONHASHSEED='3269586295'
black run-test: commands[0] | black --check src
would reformat /Users/wsanchez/Dropbox/Developer/Twisted/klein/src/klein/_app.py
Oh no! 💥 💔 💥
1 file would be reformatted, 48 files would be left unchanged.
ERROR: InvocationError for command /Users/wsanchez/Dropbox/Developer/Twisted/klein/.tox/black/bin/black --check src (exited with code 1)
________________________________________________________________________________________________________________________________________ summary _________________________________________________________________________________________________________________________________________
ERROR:   black: commands failed
```

The `black-reformat` environment still does actual reformatting as intended:

```console
$ tox -e black-reformat
black-reformat recreate: /Users/wsanchez/Dropbox/Developer/Twisted/klein/.tox/black-reformat
black-reformat installdeps: black==19.10b0
black-reformat installed: appdirs==1.4.3,attrs==19.3.0,black==19.10b0,Click==7.0,pathspec==0.7.0,regex==2020.1.8,toml==0.10.0,typed-ast==1.4.1
black-reformat run-test-pre: PYTHONHASHSEED='524689562'
black-reformat run-test: commands[0] | black src
reformatted /Users/wsanchez/Dropbox/Developer/Twisted/klein/src/klein/_app.py
All done! ✨ 🍰 ✨
1 file reformatted, 48 files left unchanged.
________________________________________________________________________________________________________________________________________ summary _________________________________________________________________________________________________________________________________________
  black-reformat: commands succeeded
  congratulations :)
```