### PR TITLE
Release 20.6 (old branch)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -91,7 +91,6 @@ matrix:
 
   allow_failures:
     # Tests against Twisted trunk are allow to fail, as they are not supported.
-    - env: TOXENV=coverage-py27-twtrunk,codecov
     - env: TOXENV=coverage-py38-twtrunk,codecov
 
     # This depends on external web sites, so it's allowed to fail.

--- a/.travis.yml
+++ b/.travis.yml
@@ -79,8 +79,6 @@ matrix:
 
     # Test against Twisted trunk in case something in development breaks us.
     # This is allowed to fail below, since the bug may be in Twisted.
-    - python: 2.7
-      env: TOXENV=coverage-py27-twtrunk,codecov
     - python: 3.8
       env: TOXENV=coverage-py38-twtrunk,codecov
 

--- a/NEWS.rst
+++ b/NEWS.rst
@@ -4,8 +4,9 @@ NEWS
 20.6.0 - 2020-06-??
 -------------------
  * This is the last release of Klein expected to support Python 2.
- * Python 3.8 is now supported by Klein. [`#303 <https://github.com/twisted/klein/pull/303>`_]
+ * This is the last release of Klein expected to support Python 3.5.
  * Python 3.4 is no longer supported by Klein. [`#284 <https://github.com/twisted/klein/pull/284>`_]
+ * Python 3.8 is now supported by Klein. [`#303 <https://github.com/twisted/klein/pull/303>`_]
  * ``klein.app.subroute`` is now also available as ``klein.subroute``. [`#293 <https://github.com/twisted/klein/pull/293>`_]
  * Support for forms and sessions. [`#276 <https://github.com/twisted/klein/pull/276>`_]
  * The ``Klein`` class now supports deep copy by implementing ``__copy__``. [`#74 <https://github.com/twisted/klein/pull/74>`_]

--- a/NEWS.rst
+++ b/NEWS.rst
@@ -1,6 +1,36 @@
 NEWS
 ====
 
+20.6.0 - 2020-06-??
+-------------------
+ * This is the last release of Klein expected to support Python 2.
+ * Python 3.8 is now supported by Klein. [`#303 <https://github.com/twisted/klein/pull/303>`_]
+ * Python 3.4 is no longer supported by Klein. [`#284 <https://github.com/twisted/klein/pull/284>`_]
+ * ``klein.app.subroute`` is now also available as ``klein.subroute``. [`#293 <https://github.com/twisted/klein/pull/293>`_]
+ * Support for forms and sessions. [`#276 <https://github.com/twisted/klein/pull/276>`_]
+ * The ``Klein`` class now supports deep copy by implementing ``__copy__``. [`#74 <https://github.com/twisted/klein/pull/74>`_]
+
+19.6.0 - 2019-06-07
+-------------------
+
+17.10.0 - 2017-10-22
+--------------------
+
+17.2.0 - 2017-03-03
+-------------------
+
+16.12.0 - 2016-12-13
+--------------------
+
+15.3.1 - 2015-12-17
+-------------------
+
+15.2.0 - 2015-11-30
+-------------------
+
+15.1.0 - 2015-07-08
+-------------------
+
 15.0.0 - 2015-01-11
 -------------------
  * [BUG] Klein now includes its test package as part of the distribution. [`#65 <https://github.com/twisted/klein/pull/65>`_]

--- a/docs/release.rst
+++ b/docs/release.rst
@@ -12,7 +12,7 @@ Releasing Klein
 ---------------
 
 #. Start with a clean (no changes) source tree on the master branch.
-#. Create a new release candidate: :code:`tox -e release start`
+#. Create a new release candidate: :code:`tox -e release -- start`
 #. Commit and push the branch
 #. Open a PR from the branch (follow the usual process for opening a PR).
 #. As appropriate, pull the latest code from :code:`master`: :code:`git checkout master && git pull --rebase` (or use the GitHub UI)

--- a/docs/release.rst
+++ b/docs/release.rst
@@ -16,5 +16,7 @@ Releasing Klein
 #. Commit and push the branch
 #. Open a PR from the branch (follow the usual process for opening a PR).
 #. As appropriate, pull the latest code from :code:`master`: :code:`git checkout master && git pull --rebase` (or use the GitHub UI)
-#. To publish a release candidate to PyPI: :code:`tox -e release publish` (add :code:`--test` to submit to TestPyPI instead)
-#. To publish a production release: :code:`tox -e release publish --final`
+#. To publish a release candidate to PyPI: :code:`tox -e release -- publish`
+#. Obtain an approving review for the PR using the usual process.
+#. To publish a production release: :code:`tox -e release -- publish --final`
+#. Merge the PR to the master branch.

--- a/docs/release.rst
+++ b/docs/release.rst
@@ -16,10 +16,5 @@ Releasing Klein
 #. Commit and push the branch
 #. Open a PR from the branch (follow the usual process for opening a PR).
 #. As appropriate, pull the latest code from :code:`master`: :code:`git checkout master && git pull --rebase` (or use the GitHub UI)
-#. To publish a release candidate: :code:`tox -e release publish`
-
-#. Clear the directory of any other changes using ``git clean -f -x -d  .``
-#. Make a pull request for this changes.
-   Continue when it is merged.
-#. Generate the tarball and wheel using ``python setup.py sdist bdist_wheel``.
-#. Upload the tarball and wheel using ``twine upload dist/klein-*``.
+#. To publish a release candidate to PyPI: :code:`tox -e release publish` (add :code:`--test` to submit to TestPyPI instead)
+#. To publish a production release: :code:`tox -e release publish --final`

--- a/docs/release.rst
+++ b/docs/release.rst
@@ -8,13 +8,14 @@ Each version is numbered with the major portion being the last two digits of the
 That is, the first release of 2016 would be 16.0, and the second would be 16.1.
 
 
-Doing a Release
+Releasing Klein
 ---------------
 
-#. Create a branch called "release-<version>"
-#. Run :code:`python incremental.update Klein --rc && python incremental.update Klein`
-#. Commit, and push the branch
+#. Start with a clean (no changes) source tree on the master branch.
+#. Create a new release candidate: :code:`tox -e release start`
+#. Commit and push the branch
 #. Open a PR from the branch (follow the usual process for merging a PR).
+
 #. Pull latest :code:`master`: :code:`git checkout master && git pull --rebase`
 #. Clear the directory of any other changes using ``git clean -f -x -d  .``
 #. Tag the release using ``git tag -s <release> -m "Tag <release> release"``

--- a/docs/release.rst
+++ b/docs/release.rst
@@ -14,12 +14,11 @@ Releasing Klein
 #. Start with a clean (no changes) source tree on the master branch.
 #. Create a new release candidate: :code:`tox -e release start`
 #. Commit and push the branch
-#. Open a PR from the branch (follow the usual process for merging a PR).
+#. Open a PR from the branch (follow the usual process for opening a PR).
+#. As appropriate, pull the latest code from :code:`master`: :code:`git checkout master && git pull --rebase` (or use the GitHub UI)
+#. To publish a release candidate: :code:`tox -e release publish`
 
-#. Pull latest :code:`master`: :code:`git checkout master && git pull --rebase`
 #. Clear the directory of any other changes using ``git clean -f -x -d  .``
-#. Tag the release using ``git tag -s <release> -m "Tag <release> release"``
-#. Push up the tag using ``git push --tags``.
 #. Make a pull request for this changes.
    Continue when it is merged.
 #. Generate the tarball and wheel using ``python setup.py sdist bdist_wheel``.

--- a/release.py
+++ b/release.py
@@ -40,8 +40,8 @@ def error(message: str, exitStatus: int) -> NoReturn:
 
 def spawn(args: Sequence[str]) -> None:
     """
-    Spawn a new process with the given arguments, raising L{CalledProcessError}
-    with captured output if the exit status is non-zero.
+    Spawn a new process with the given arguments, raising L{SystemExit} with
+    captured output if the exit status is non-zero.
     """
     print("Executing command:", " ".join(repr(arg) for arg in args))
     try:

--- a/release.py
+++ b/release.py
@@ -3,6 +3,8 @@ from subprocess import CalledProcessError, run
 from sys import exit, stderr
 from typing import Any, Dict, NoReturn, Optional, Sequence
 
+from click import command, group as commandGroup
+
 from git import Repo as Repository
 from git.refs.head import Head
 
@@ -180,30 +182,25 @@ def publishRelease() -> None:
     raise NotImplementedError()
 
 
-def main(argv: Sequence[str]) -> None:
-    """
-    Command line entry point.
-    """
+@commandGroup()
+def main() -> None:
+    pass
 
-    def invalidArguments() -> NoReturn:
-        error(f"invalid arguments: {argv}", 64)
 
-    if len(argv) != 1:
-        invalidArguments()
+@main.command()
+def start() -> None:
+    startRelease()
 
-    subcommand = argv[0]
 
-    if subcommand == "start":
-        startRelease()
-    elif subcommand == "bump":
-        bumpRelease()
-    elif subcommand == "publish":
-        publishRelease()
-    else:
-        invalidArguments()
+@main.command()
+def bump() -> None:
+    bumpRelease()
+
+
+@main.command()
+def publish() -> None:
+    publishRelease()
 
 
 if __name__ == "__main__":
-    from sys import argv
-
-    main(argv[1:])
+    main()

--- a/release.py
+++ b/release.py
@@ -148,11 +148,6 @@ def bumpRelease() -> None:
     if version.release_candidate is None:
         error(f"current version is not a release candidate: {version}", 1)
 
-    incrementVersion(candidate=True)
-    version = currentVersion()
-
-    print(f"New release candidate version: {version}")
-
     branch = releaseBranch(repository, version)
 
     if repository.head.ref != branch:
@@ -161,6 +156,11 @@ def bumpRelease() -> None:
             f'not release branch "{branch}"',
             1,
         )
+
+    incrementVersion(candidate=True)
+    version = currentVersion()
+
+    print(f"New release candidate version: {version}")
 
 
 def publishRelease() -> None:

--- a/release.py
+++ b/release.py
@@ -25,7 +25,7 @@ def spawn(args: Sequence[str]) -> None:
 def currentVersion() -> Version:
     versionInfo: Dict[str, Any] = {}
     versonFile = Path(__file__).parent / "src" / "klein" / "_version.py"
-    exec (versonFile.read_text(), versionInfo)
+    exec (versonFile.read_text(), versionInfo)  # noqa: E211  # black py2.7
     return versionInfo["__version__"]
 
 

--- a/release.py
+++ b/release.py
@@ -47,7 +47,7 @@ def currentVersion() -> Version:
     return versionInfo["__version__"]
 
 
-def fadeToBlack():
+def fadeToBlack() -> None:
     """
     Run black to reformat the source code.
     """

--- a/release.py
+++ b/release.py
@@ -1,0 +1,148 @@
+from pathlib import Path
+from subprocess import CalledProcessError, run
+from sys import exit, stderr
+from typing import Any, Dict, NoReturn, Optional, Sequence
+
+from git import Repo as Repository
+from git.refs.head import Head
+
+from incremental import Version
+
+
+def warning(message: str) -> None:
+    print(f"WARNING: {message}", file=stderr)
+
+
+def error(message: str, exitStatus: int) -> NoReturn:
+    print(f"ERROR: {message}", file=stderr)
+    exit(exitStatus)
+
+
+def spawn(args: Sequence[str]) -> None:
+    run(args, capture_output=True, check=True)
+
+
+def currentVersion() -> Version:
+    versionInfo: Dict[str, Any] = {}
+    versonFile = Path(__file__).parent / "src" / "klein" / "_version.py"
+    exec (versonFile.read_text(), versionInfo)
+    return versionInfo["__version__"]
+
+
+def incrementVersion(candidate: bool) -> None:
+    # Incremental doesn't have an API to do this, so we have to run a
+    # subprocess. Boo.
+    args = ["python", "-m", "incremental.update", "klein"]
+    if candidate:
+        args.append("--rc")
+    try:
+        spawn(args)
+    except CalledProcessError as e:
+        error(f"command {e.cmd} failed: {e.stderr}", 1)
+
+
+def releaseBranchName(version: Version) -> str:
+    return f"release-{version.major}.{version.minor}"
+
+
+def releaseBranch(repository: Repository, version: Version) -> Optional[Head]:
+    branchName = releaseBranchName(version)
+
+    if branchName in repository.heads:
+        return repository.heads[branchName]
+
+    return None
+
+
+def createReleaseBranch(repository: Repository, version: Version) -> Head:
+    branchName = releaseBranchName(version)
+
+    if branchName in repository.heads:
+        error(f'Release branch "{branchName}" already exists.', 1)
+
+    print(f'Creating release branch: "{branchName}"')
+    return repository.create_head(branchName)
+
+
+def startRelease() -> None:
+    repository = Repository()
+
+    if repository.head.ref != repository.heads.master:
+        error(
+            f"working copy is from non-master branch: {repository.head.ref}", 1
+        )
+
+    if repository.is_dirty():
+        warning("working copy is dirty")
+
+    version = currentVersion()
+
+    if version.release_candidate is not None:
+        error(f"current version is already a release candidate: {version}", 1)
+
+    incrementVersion(candidate=True)
+    version = currentVersion()
+
+    print(f"New release candidate version: {version}")
+
+    branch = createReleaseBranch(repository, version)
+    branch.checkout()
+
+    print(
+        (
+            f"Next steps:\n"
+            f" • Commit version updates to release branch: {branch}\n"
+            f" • Push the release branch to GitHub\n"
+            f" • Open a pull request on GitHub from the release branch\n"
+        ),
+        end="",
+    )
+
+
+def bumpRelease() -> None:
+    repository = Repository()
+
+    if repository.is_dirty():
+        warning("working copy is dirty")
+
+    version = currentVersion()
+
+    if version.release_candidate is None:
+        error(f"current version is not a release candidate: {version}", 1)
+
+    incrementVersion(candidate=True)
+    version = currentVersion()
+
+    print(f"New release candidate version: {version}")
+
+    branch = releaseBranch(repository, version)
+
+    if repository.head.ref != branch:
+        error(
+            f'working copy is on branch "{repository.head.ref}", '
+            f'not release branch "{branch}"',
+            1,
+        )
+
+
+def main(argv: Sequence[str]) -> None:
+    def invalidArguments() -> NoReturn:
+        error(f"invalid arguments: {argv}", 64)
+
+    if len(argv) != 1:
+        invalidArguments()
+
+    subcommand = argv[0]
+
+    if subcommand == "start":
+        startRelease()
+    elif subcommand == "bump":
+        bumpRelease()
+    else:
+        invalidArguments()
+
+
+if __name__ == "__main__":
+    from sys import argv
+
+    main(argv[1:])

--- a/release.py
+++ b/release.py
@@ -1,3 +1,6 @@
+# Copyright (c) Twisted Matrix Laboratories.
+# See LICENSE for details.
+
 from enum import Enum
 from os import chdir
 from pathlib import Path

--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,7 @@ if __name__ == "__main__":
             'Programming Language :: Python :: 3.5',
             'Programming Language :: Python :: 3.6',
             'Programming Language :: Python :: 3.7',
+            'Programming Language :: Python :: 3.8',
             'Programming Language :: Python :: Implementation :: CPython',
             'Programming Language :: Python :: Implementation :: PyPy',
             'Topic :: Internet :: WWW/HTTP :: Dynamic Content',

--- a/src/klein/_version.py
+++ b/src/klein/_version.py
@@ -7,5 +7,5 @@ Provides klein version information.
 
 from incremental import Version
 
-__version__ = Version("klein", 19, 6, 0)
+__version__ = Version('klein', 20, 4, 0, release_candidate=1)
 __all__ = ["__version__"]

--- a/src/klein/_version.py
+++ b/src/klein/_version.py
@@ -7,5 +7,5 @@ Provides klein version information.
 
 from incremental import Version
 
-__version__ = Version("klein", 20, 4, 0, release_candidate=1)
+__version__ = Version("klein", 20, 6, 0, release_candidate=1)
 __all__ = ["__version__"]

--- a/src/klein/_version.py
+++ b/src/klein/_version.py
@@ -7,5 +7,5 @@ Provides klein version information.
 
 from incremental import Version
 
-__version__ = Version('klein', 20, 4, 0, release_candidate=1)
+__version__ = Version("klein", 20, 4, 0, release_candidate=1)
 __all__ = ["__version__"]

--- a/tox.ini
+++ b/tox.ini
@@ -582,6 +582,7 @@ skip_install = True
 deps =
     incremental[scripts]==17.5.0
     GitPython==3.1.0
+    click==7.1.2
 
 whitelist_externals =
     git

--- a/tox.ini
+++ b/tox.ini
@@ -580,9 +580,10 @@ basepython = {[default]basepython}
 skip_install = True
 
 deps =
-    incremental[scripts]==17.5.0
-    GitPython==3.1.0
     click==7.1.2
+    GitPython==3.1.0
+    incremental[scripts]==17.5.0
+    twine==3.1.1
 
 passenv =
     SSH_AUTH_SOCK

--- a/tox.ini
+++ b/tox.ini
@@ -584,9 +584,8 @@ deps =
     GitPython==3.1.0
     click==7.1.2
 
-whitelist_externals =
-    git
-    echo
+passenv =
+    SSH_AUTH_SOCK
 
 commands =
     python "{toxinidir}/release.py" {posargs}

--- a/tox.ini
+++ b/tox.ini
@@ -338,19 +338,11 @@ allow_untyped_defs = True
 [mypy-constantly]
 ignore_missing_imports = True
 
+[mypy-git]
+[mypy-git.*]
+ignore_missing_imports = True
+
 [mypy-hyperlink]
-ignore_missing_imports = True
-
-[mypy-incremental]
-ignore_missing_imports = True
-
-[mypy-zope.interface]
-[mypy-zope.interface.*]
-ignore_missing_imports = True
-
-[mypy-treq]
-ignore_missing_imports = True
-[mypy-treq.*]
 ignore_missing_imports = True
 
 [mypy-hypothesis]
@@ -361,14 +353,25 @@ ignore_missing_imports = True
 [mypy-idna]
 ignore_missing_imports = True
 
+[mypy-incremental]
+ignore_missing_imports = True
+
+[mypy-setuptools.*]
+ignore_missing_imports = True
+
+[mypy-treq]
+ignore_missing_imports = True
+[mypy-treq.*]
+ignore_missing_imports = True
+
 [mypy-tubes.*]
 ignore_missing_imports = True
 
 [mypy-twisted.*]
 ignore_missing_imports = True
 
-[mypy-git]
-[mypy-git.*]
+[mypy-zope.interface]
+[mypy-zope.interface.*]
 ignore_missing_imports = True
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -111,7 +111,7 @@ setenv =
     BLACK_LINT_ARGS=--check
 
 commands =
-    black {env:BLACK_LINT_ARGS:} src
+    black {env:BLACK_LINT_ARGS:} {posargs:release.py src}
 
 
 [testenv:black-reformat]
@@ -150,7 +150,7 @@ deps =
     git+git://github.com/PyCQA/pyflakes@ffe9386#egg=pyflakes
 
 commands =
-    flake8 {posargs:src/{env:PY_MODULE}}
+    flake8 {posargs:release.py setup.py src/{env:PY_MODULE}}
 
 
 [flake8]
@@ -275,7 +275,7 @@ commands =
         --config-file="{toxinidir}/tox.ini"    \
         --cache-dir="{toxworkdir}/mypy_cache"  \
         {tty:--pretty:}                        \
-        {posargs:src}
+        {posargs:release.py setup.py src}
 
 
 [mypy]
@@ -338,7 +338,7 @@ allow_untyped_defs = True
 [mypy-constantly]
 ignore_missing_imports = True
 
-[mypy-hyperlink]		
+[mypy-hyperlink]
 ignore_missing_imports = True
 
 [mypy-incremental]
@@ -365,6 +365,10 @@ ignore_missing_imports = True
 ignore_missing_imports = True
 
 [mypy-twisted.*]
+ignore_missing_imports = True
+
+[mypy-git]
+[mypy-git.*]
 ignore_missing_imports = True
 
 
@@ -535,3 +539,27 @@ deps =
 
 commands =
     pip freeze
+
+
+##
+# Release
+##
+
+[testenv:release]
+
+description = create a prerelease branch
+
+basepython = {[default]basepython}
+
+skip_install = True
+
+deps =
+    incremental[scripts]==17.5.0
+    GitPython==3.1.0
+
+whitelist_externals =
+    git
+    echo
+
+commands =
+    python "{toxinidir}/release.py" {posargs}

--- a/tox.ini
+++ b/tox.ini
@@ -572,7 +572,7 @@ commands =
 
 [testenv:release]
 
-description = create a prerelease branch
+description = invoke tool to manage a release branch
 
 basepython = {[default]basepython}
 

--- a/tox.ini
+++ b/tox.ini
@@ -341,11 +341,22 @@ allow_untyped_defs = True
 [mypy-constantly]
 ignore_missing_imports = True
 
-[mypy-git]
 [mypy-git.*]
 ignore_missing_imports = True
 
 [mypy-hyperlink]
+ignore_missing_imports = True
+
+[mypy-incremental]
+ignore_missing_imports = True
+
+[mypy-zope.interface]
+[mypy-zope.interface.*]
+ignore_missing_imports = True
+
+[mypy-treq]
+ignore_missing_imports = True
+[mypy-treq.*]
 ignore_missing_imports = True
 
 [mypy-hypothesis]
@@ -356,25 +367,13 @@ ignore_missing_imports = True
 [mypy-idna]
 ignore_missing_imports = True
 
-[mypy-incremental]
-ignore_missing_imports = True
-
-[mypy-setuptools.*]
-ignore_missing_imports = True
-
-[mypy-treq]
-ignore_missing_imports = True
-[mypy-treq.*]
+[mypy-setuptools]
 ignore_missing_imports = True
 
 [mypy-tubes.*]
 ignore_missing_imports = True
 
 [mypy-twisted.*]
-ignore_missing_imports = True
-
-[mypy-zope.interface]
-[mypy-zope.interface.*]
 ignore_missing_imports = True
 
 


### PR DESCRIPTION
This PR is a Klein 20.6 release.

The primary goal for this release is to ship all work that's currently been done with support for Python 2.7 before we drop support for Python 2.7, so that we leave the 2.7 users with the latest available progress.

In addition to incrementing the version, this PR adds a script for automating the release process.