### PR TITLE
Update build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,51 +29,51 @@ matrix:
       env: TOXENV=mypy
 
     - python: 2.7
-      env: TOXENV=coverage-py27-tw171,codecov
-    - python: 2.7
       env: TOXENV=coverage-py27-tw184,codecov
+    - python: 2.7
+      env: TOXENV=coverage-py27-tw192,codecov
     - python: 2.7
       env: TOXENV=coverage-py27-twcurrent,codecov
 
     - python: 3.5
-      env: TOXENV=coverage-py35-tw171,codecov
-    - python: 3.5
       env: TOXENV=coverage-py35-tw184,codecov
+    - python: 3.5
+      env: TOXENV=coverage-py35-tw192,codecov
     - python: 3.5
       env: TOXENV=coverage-py35-twcurrent,codecov
 
     - python: 3.6
-      env: TOXENV=coverage-py36-tw171,codecov
-    - python: 3.6
       env: TOXENV=coverage-py36-tw184,codecov
+    - python: 3.6
+      env: TOXENV=coverage-py36-tw192,codecov
     - python: 3.6
       env: TOXENV=coverage-py36-twcurrent,codecov
 
     - python: 3.7
-      env: TOXENV=coverage-py37-tw171,codecov
-    - python: 3.7
       env: TOXENV=coverage-py37-tw184,codecov
+    - python: 3.7
+      env: TOXENV=coverage-py37-tw192,codecov
     - python: 3.7
       env: TOXENV=coverage-py37-twcurrent,codecov
 
     - python: 3.8
-      env: TOXENV=coverage-py38-tw171,codecov
-    - python: 3.8
       env: TOXENV=coverage-py38-tw184,codecov
+    - python: 3.8
+      env: TOXENV=coverage-py38-tw192,codecov
     - python: 3.8
       env: TOXENV=coverage-py38-twcurrent,codecov
 
     - python: pypy
-      env: TOXENV=coverage-pypy2-tw171,codecov
-    - python: pypy
       env: TOXENV=coverage-pypy2-tw184,codecov
+    - python: pypy
+      env: TOXENV=coverage-pypy2-tw192,codecov
     - python: pypy
       env: TOXENV=coverage-pypy2-twcurrent,codecov
 
     - python: pypy3
-      env: TOXENV=coverage-pypy3-tw171,codecov
-    - python: pypy3
       env: TOXENV=coverage-pypy3-tw184,codecov
+    - python: pypy3
+      env: TOXENV=coverage-pypy3-tw192,codecov
     - python: pypy3
       env: TOXENV=coverage-pypy3-twcurrent,codecov
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -79,8 +79,6 @@ matrix:
 
     # Test against Twisted trunk in case something in development breaks us.
     # This is allowed to fail below, since the bug may be in Twisted.
-    - python: 2.7
-      env: TOXENV=coverage-py27-twtrunk,codecov
     - python: 3.8
       env: TOXENV=coverage-py38-twtrunk,codecov
 
@@ -91,7 +89,6 @@ matrix:
 
   allow_failures:
     # Tests against Twisted trunk are allow to fail, as they are not supported.
-    - env: TOXENV=coverage-py27-twtrunk,codecov
     - env: TOXENV=coverage-py38-twtrunk,codecov
 
     # This depends on external web sites, so it's allowed to fail.

--- a/tox.ini
+++ b/tox.ini
@@ -29,7 +29,7 @@ deps =
     tw187: Twisted==18.7.0
     tw189: Twisted==18.9.0
     tw192: Twisted==19.2.1
-    tw192: Twisted==19.7.0
+    tw197: Twisted==19.7.0
     tw1910: Twisted==19.10.0
     tw203: Twisted==20.3.0
     twcurrent: Twisted

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 
 envlist =
     flake8, black, mypy
-    coverage-py{27,35,36,37,38,py2,py3}-tw{171,184,current,trunk}
+    coverage-py{27,35,36,37,38,py2,py3}-tw{184,192,current,trunk}
     coverage_report
     docs, docs-linkcheck
     packaging
@@ -30,6 +30,8 @@ deps =
     tw189: Twisted==18.9.0
     tw192: Twisted==19.2.1
     tw192: Twisted==19.7.0
+    tw1910: Twisted==19.10.0
+    tw203: Twisted==20.3.0
     twcurrent: Twisted
     twtrunk: https://github.com/twisted/twisted/archive/trunk.zip
 
@@ -338,7 +340,7 @@ allow_untyped_defs = True
 [mypy-constantly]
 ignore_missing_imports = True
 
-[mypy-hyperlink]		
+[mypy-hyperlink]
 ignore_missing_imports = True
 
 [mypy-incremental]


### PR DESCRIPTION
This removes the (fail-able) build with Twisted trunk on Python 2.7, which now always fails, and replaces Twisted 17.1.0 with 19.2.1 in the matrix, per the 2-year compatibility window.