### PR TITLE
Remove py2-specific mock, typing import handling.

### DIFF
--- a/src/klein/test/test_app.py
+++ b/src/klein/test/test_app.py
@@ -1,11 +1,7 @@
 from __future__ import absolute_import, division
 
 import sys
-
-try:
-    from unittest.mock import Mock, patch
-except Exception:
-    from mock import Mock, patch  # type:ignore[misc]
+from unittest.mock import Mock, patch
 
 from twisted.python.components import registerAdapter
 from twisted.trial import unittest

--- a/src/klein/test/test_resource.py
+++ b/src/klein/test/test_resource.py
@@ -2,11 +2,7 @@ from __future__ import absolute_import, division
 
 import os
 from io import BytesIO
-
-try:
-    from unittest.mock import Mock, call
-except Exception:
-    from mock import Mock, call
+from unittest.mock import Mock, call
 
 from six.moves.urllib.parse import parse_qs
 

--- a/tox.ini
+++ b/tox.ini
@@ -44,11 +44,8 @@ deps =
     zope.interface==5.1.0
 
     {test,coverage}: treq==20.3.0
-    {test,coverage}-py{27,py2}: hypothesis==4.57.1  # rq.filter: <5
-    {test,coverage}-py{35,36,37,38,39,py3}: hypothesis==5.8.6
+    {test,coverage}: hypothesis==5.8.6
     {test,coverage}: idna==2.8
-    {test,coverage}-py{27,py2}: mock==3.0.5  # rq.filter: <4
-    {test,coverage}-py{27,py2}: typing==3.7.4.1
 
     coverage: {[testenv:coverage_report]deps}
 


### PR DESCRIPTION
Remove py2-specific `mock`, `typing` import handling.