### PR TITLE
Add build stages to Travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,19 +21,27 @@ branches:
 #
 matrix:
   include:
+    - stage: Lint and Code Style
+
     - python: 3.8
       env: TOXENV=flake8
     - python: 3.8
       env: TOXENV=black
     - python: 3.8
       env: TOXENV=mypy
+    - python: 3.8
+      env: TOXENV=packaging
 
-    - python: 3.6
-      env: TOXENV=coverage-py36-tw184,codecov
-    - python: 3.6
-      env: TOXENV=coverage-py36-tw192,codecov
-    - python: 3.6
-      env: TOXENV=coverage-py36-twcurrent,codecov
+    - stage: Tests (Python 3.8)
+
+    - python: 3.8
+      env: TOXENV=coverage-py38-tw184,codecov
+    - python: 3.8
+      env: TOXENV=coverage-py38-tw192,codecov
+    - python: 3.8
+      env: TOXENV=coverage-py38-twcurrent,codecov
+
+    - stage: Tests
 
     - python: 3.7
       env: TOXENV=coverage-py37-tw184,codecov
@@ -42,12 +50,12 @@ matrix:
     - python: 3.7
       env: TOXENV=coverage-py37-twcurrent,codecov
 
-    - python: 3.8
-      env: TOXENV=coverage-py38-tw184,codecov
-    - python: 3.8
-      env: TOXENV=coverage-py38-tw192,codecov
-    - python: 3.8
-      env: TOXENV=coverage-py38-twcurrent,codecov
+    - python: 3.6
+      env: TOXENV=coverage-py36-tw184,codecov
+    - python: 3.6
+      env: TOXENV=coverage-py36-tw192,codecov
+    - python: 3.6
+      env: TOXENV=coverage-py36-twcurrent,codecov
 
     - python: pypy3
       env: TOXENV=coverage-pypy3-tw184,codecov
@@ -65,9 +73,6 @@ matrix:
       env: TOXENV=docs
     - python: 3.8
       env: TOXENV=docs-linkcheck
-
-    - python: 3.8
-      env: TOXENV=packaging
 
   allow_failures:
     # Tests against Twisted trunk are allow to fail, as they are not supported.

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,8 +22,7 @@ branches:
 matrix:
   include:
     - stage: Lint and Code Style
-
-    - python: 3.8
+      python: 3.8
       env: TOXENV=flake8
     - python: 3.8
       env: TOXENV=black
@@ -33,8 +32,7 @@ matrix:
       env: TOXENV=packaging
 
     - stage: Tests (Python 3.8)
-
-    - python: 3.8
+      python: 3.8
       env: TOXENV=coverage-py38-tw184,codecov
     - python: 3.8
       env: TOXENV=coverage-py38-tw192,codecov
@@ -42,8 +40,7 @@ matrix:
       env: TOXENV=coverage-py38-twcurrent,codecov
 
     - stage: Tests
-
-    - python: 3.7
+      python: 3.7
       env: TOXENV=coverage-py37-tw184,codecov
     - python: 3.7
       env: TOXENV=coverage-py37-tw192,codecov


### PR DESCRIPTION
This splits the CI jobs into [three stages](https://travis-ci.org/github/twisted/klein/builds/709526045):
 * Lint and Code Style
 * Tests (Python 3.8)
 * Tests

The purpose of this is to reduce workload on Travis CI in typical cases where the build fails. It does this by first running the cheaper tests (flake8, mypy, black, packaging).  If any of those fail, it stops there.  Otherwise, it runs the Python 3.8 tests, and then if those pass, it runs the rest of the jobs.

This should abort more quickly in most failure cases, and that in turn should avoid a CI run from waiting for jobs in a prior run that already has a failed job.
