### PR TITLE
Export type hints

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,9 @@ if __name__ == "__main__":
         name="klein",
         packages=["klein", "klein.storage", "klein.test"],
         package_dir={"": "src"},
-        package_data=dict(klein=["test/idna-tables-properties.csv",],),
+        package_data=dict(
+            klein=["py.typed", "test/idna-tables-properties.csv",],
+        ),
         url="https://github.com/twisted/klein",
         maintainer="Twisted Matrix Laboratories",
         maintainer_email="twisted-python@twistedmatrix.com",

--- a/setup.py
+++ b/setup.py
@@ -47,4 +47,5 @@ if __name__ == "__main__":
         url="https://github.com/twisted/klein",
         maintainer="Twisted Matrix Laboratories",
         maintainer_email="twisted-python@twistedmatrix.com",
+        zip_safe=False,
     )

--- a/src/klein/py.typed
+++ b/src/klein/py.typed
@@ -1,0 +1,1 @@
+# See: https://www.python.org/dev/peps/pep-0561/


### PR DESCRIPTION
Add a `py.typed` file to the `klein` package.

Fixes #294

After #359, we have plenty of useful type hints for clients in the more commonly used parts of Klein.