### PR TITLE
Enable warn_return_any

### DIFF
--- a/release.py
+++ b/release.py
@@ -8,7 +8,7 @@ from shutil import rmtree
 from subprocess import CalledProcessError, run
 from sys import exit, stderr
 from tempfile import mkdtemp
-from typing import Any, Dict, NoReturn, Optional, Sequence
+from typing import Any, Dict, NoReturn, Optional, Sequence, cast
 
 from click import group as commandGroup, option as commandOption
 
@@ -109,7 +109,7 @@ def releaseTagName(version: Version) -> str:
     """
     Compute the name of the release tag for the given version.
     """
-    return version.public()
+    return cast(str, version.public())
 
 
 def createReleaseBranch(repository: Repository, version: Version) -> Head:

--- a/tox.ini
+++ b/tox.ini
@@ -287,13 +287,13 @@ show_error_codes         = True
 strict_optional          = True
 warn_no_return           = True
 warn_redundant_casts     = True
+warn_return_any          = True
 warn_unreachable         = True
 warn_unused_ignores      = True
 
 # Enable these over time
 
 check_untyped_defs       = False
-warn_return_any          = False
 
 # Disable some checks until effected files fully adopt mypy
 


### PR DESCRIPTION
Enable `warn_return_any` for `mypy`.