### PR TITLE
Use inline type hint syntax

### DIFF
--- a/src/klein/_app.py
+++ b/src/klein/_app.py
@@ -54,7 +54,7 @@ KleinErrorHandler = Callable[
 
 
 def _call(
-    __klein_instance__: Optional[Klein],
+    __klein_instance__: Optional["Klein"],
     __klein_f__: Callable,
     *args: Any,
     **kwargs: Any,
@@ -194,7 +194,7 @@ class Klein(object):
 
         return KleinResource(self)
 
-    def __get__(self, instance: Any, owner: object) -> Klein:
+    def __get__(self, instance: Any, owner: object) -> "Klein":
         """
         Get an instance of L{Klein} bound to C{instance}.
         """

--- a/src/klein/_app.py
+++ b/src/klein/_app.py
@@ -100,7 +100,7 @@ class KleinRequest(object):
         self.branch_segments = [""]
 
         # Don't annotate as optional, since you should never set this to None
-        self.mapper = None  # type: MapAdapter # type: ignore[assignment]
+        self.mapper: MapAdapter = None  # type: ignore[assignment]
 
     def url_for(
         self,

--- a/src/klein/_app.py
+++ b/src/klein/_app.py
@@ -18,7 +18,6 @@ from typing import (
     List,
     Mapping,
     Optional,
-    Text,
     Union,
     cast,
 )
@@ -54,8 +53,12 @@ KleinErrorHandler = Callable[
 ]
 
 
-def _call(__klein_instance__, __klein_f__, *args, **kwargs):
-    # type: (Optional[Klein], Callable, Any, Any) -> Deferred
+def _call(
+    __klein_instance__: Optional[Klein],
+    __klein_f__: Callable,
+    *args: Any,
+    **kwargs: Any,
+) -> Deferred:
     """
     Call C{__klein_f__} with the given C{*args} and C{**kwargs}.
 
@@ -78,24 +81,22 @@ def _call(__klein_instance__, __klein_f__, *args, **kwargs):
 
 
 def buildURL(
-    mapper,  # type: MapAdapter
-    endpoint,  # type: Text
-    values=None,  # type: Optional[Mapping[Text, Text]]
-    method=None,  # type: Optional[Text]
-    force_external=False,  # type: bool
-    append_unknown=True,  # type: bool
-):
-    # type: (...) -> Text
+    mapper: MapAdapter,
+    endpoint: str,
+    values: Optional[Mapping[str, str]] = None,
+    method: Optional[str] = None,
+    force_external: bool = False,
+    append_unknown: bool = True,
+) -> str:
     return cast(
-        Text,
+        str,
         mapper.build(endpoint, values, method, force_external, append_unknown),
     )
 
 
 @implementer(IKleinRequest)
 class KleinRequest(object):
-    def __init__(self, request):
-        # type: (Request) -> None
+    def __init__(self, request: Request) -> None:
         self.branch_segments = [""]
 
         # Don't annotate as optional, since you should never set this to None
@@ -103,13 +104,12 @@ class KleinRequest(object):
 
     def url_for(
         self,
-        endpoint,  # type: Text
-        values=None,  # type: Optional[Mapping[Text, Text]]
-        method=None,  # type: Optional[Text]
-        force_external=False,  # type: bool
-        append_unknown=True,  # type: bool
-    ):
-        # type: (...) -> Text
+        endpoint: str,
+        values: Optional[Mapping[str, str]] = None,
+        method: Optional[str] = None,
+        force_external: bool = False,
+        append_unknown: bool = True,
+    ) -> str:
         return buildURL(
             self.mapper,
             endpoint,
@@ -135,45 +135,41 @@ class Klein(object):
 
     _subroute_segments = 0
 
-    def __init__(self):
-        # type: () -> None
+    def __init__(self) -> None:
         self._url_map = Map()
-        self._endpoints = {}  # type: Dict[Text, KleinRoute]
-        self._error_handlers = []  # type: List[KleinErrorHandler]
-        self._instance = None  # type: Optional[Klein]
-        self._boundAs = None  # type: Optional[Text]
+        self._endpoints: Dict[str, KleinRoute] = {}
+        self._error_handlers: List[KleinErrorHandler] = []
+        self._instance: Optional[Klein] = None
+        self._boundAs: Optional[str] = None
 
-    def __eq__(self, other):
-        # type: (Any) -> bool
+    def __eq__(self, other: Any) -> bool:
         if isinstance(other, Klein):
             return vars(self) == vars(other)
         return NotImplemented
 
-    def __ne__(self, other):
-        # type: (Any) -> bool
+    def __ne__(self, other: Any) -> bool:
         result = self.__eq__(other)
         if result is NotImplemented:
             return result
         return not result
 
     @property
-    def url_map(self):
-        # type: () -> Map
+    def url_map(self) -> Map:
         """
         Read only property exposing L{Klein._url_map}.
         """
         return self._url_map
 
     @property
-    def endpoints(self):
-        # type: () -> Dict[Text, KleinRoute]
+    def endpoints(self) -> Dict[str, KleinRoute]:
         """
         Read only property exposing L{Klein._endpoints}.
         """
         return self._endpoints
 
-    def execute_endpoint(self, endpoint, request, *args, **kwargs):
-        # type: (Text, IRequest, Any, Any) -> KleinRenderable
+    def execute_endpoint(
+        self, endpoint: str, request: IRequest, *args: Any, **kwargs: Any
+    ) -> KleinRenderable:
         """
         Execute the named endpoint with all arguments and possibly a bound
         instance.
@@ -181,15 +177,15 @@ class Klein(object):
         endpoint_f = self._endpoints[endpoint]
         return endpoint_f(self._instance, request, *args, **kwargs)
 
-    def execute_error_handler(self, handler, request, failure):
-        # type: (KleinErrorHandler, IRequest, Failure) -> KleinRenderable
+    def execute_error_handler(
+        self, handler: KleinErrorHandler, request: IRequest, failure: Failure,
+    ) -> KleinRenderable:
         """
         Execute the passed error handler, possibly with a bound instance.
         """
         return handler(self._instance, request, failure)
 
-    def resource(self):
-        # type: () -> KleinResource
+    def resource(self) -> KleinResource:
         """
         Return an L{IResource} which suitably wraps this app.
 
@@ -198,8 +194,7 @@ class Klein(object):
 
         return KleinResource(self)
 
-    def __get__(self, instance, owner):
-        # type: (Any, object) -> Klein
+    def __get__(self, instance: Any, owner: object) -> Klein:
         """
         Get an instance of L{Klein} bound to C{instance}.
         """
@@ -238,8 +233,7 @@ class Klein(object):
         return k
 
     @staticmethod
-    def _segments_in_url(url):
-        # type: (Text) -> int
+    def _segments_in_url(url: str) -> int:
         segment_count = url.count("/")
         if url.endswith("/"):
             segment_count -= 1
@@ -271,16 +265,16 @@ class Klein(object):
         segment_count = self._segments_in_url(url) + self._subroute_segments
 
         @named("router for '" + url + "'")
-        def deco(f):
-            # type: (KleinRoute) -> KleinRoute
+        def deco(f: KleinRoute) -> KleinRoute:
             kwargs.setdefault("endpoint", f.__name__)
             if kwargs.pop("branch", False):
                 branchKwargs = kwargs.copy()
                 branchKwargs["endpoint"] = branchKwargs["endpoint"] + "_branch"
 
                 @modified("branch route '{url}' executor".format(url=url), f)
-                def branch_f(instance, request, *a, **kw):
-                    # type: (Any, IRequest, Any, Any) -> KleinRenderable
+                def branch_f(
+                    instance: Any, request: IRequest, *a: Any, **kw: Any,
+                ) -> KleinRenderable:
                     IKleinRequest(request).branch_segments = kw.pop(
                         "__rest__", ""
                     ).split("/")
@@ -302,8 +296,9 @@ class Klein(object):
                 )
 
             @modified("route '{url}' executor".format(url=url), f)
-            def _f(instance, request, *a, **kw):
-                # type: (Any, IRequest, Any, Any) -> KleinRenderable
+            def _f(
+                instance: Any, request: IRequest, *a: Any, **kw: Any,
+            ) -> KleinRenderable:
                 return _call(instance, f, request, *a, **kw)
 
             _f = cast(KleinRoute, _f)
@@ -432,14 +427,13 @@ class Klein(object):
 
     def urlFor(
         self,
-        request,  # type: IKleinRequest
-        endpoint,  # type: Text
-        values=None,  # type: Optional[Mapping[Text, Text]]
-        method=None,  # type: Optional[Text]
-        force_external=False,  # type: bool
-        append_unknown=True,  # type: bool
-    ):
-        # type: (...) -> Text
+        request: IKleinRequest,
+        endpoint: str,
+        values: Optional[Mapping[str, str]] = None,
+        method: Optional[str] = None,
+        force_external: bool = False,
+        append_unknown: bool = True,
+    ) -> str:
         host = request.getHeader(b"host")
         if host is None:
             if force_external:
@@ -461,13 +455,12 @@ class Klein(object):
 
     def run(
         self,
-        host=None,  # type: Optional[str]
-        port=None,  # type: Optional[int]
-        logFile=None,  # type: Optional[IO]
-        endpoint_description=None,  # type: Optional[str]
-        displayTracebacks=True,  # type: bool
-    ):
-        # type: (...) -> None
+        host: Optional[str] = None,
+        port: Optional[int] = None,
+        logFile: Optional[IO] = None,
+        endpoint_description: Optional[str] = None,
+        displayTracebacks: bool = True,
+    ) -> None:
         """
         Run a minimal twisted.web server on the specified C{port}, bound to the
         interface specified by C{host} and logging to C{logFile}.

--- a/src/klein/_decorators.py
+++ b/src/klein/_decorators.py
@@ -1,11 +1,10 @@
 from functools import wraps
-from typing import Callable, Optional, Text, TypeVar
+from typing import Callable, Optional, TypeVar
 
 C = TypeVar("C", bound=Callable)
 
 
-def bindable(bindable):
-    # type: (C) -> C
+def bindable(bindable: C) -> C:
     """
     Mark a method as a "bindable" method.
 
@@ -29,11 +28,8 @@ def bindable(bindable):
 
 
 def modified(
-    modification,  # type: Text
-    original,  # type: Callable
-    modifier=None,  # type: Optional[Callable]
-):
-    # type: (...) -> Callable
+    modification: str, original: Callable, modifier: Optional[Callable] = None,
+) -> Callable:
     """
     Annotate a callable as a modified wrapper of an original callable.
 
@@ -53,8 +49,7 @@ def modified(
         likely calls it.
     """
 
-    def decorator(wrapper):
-        # type: (Callable[..., C]) -> Callable[..., C]
+    def decorator(wrapper: Callable[..., C]) -> Callable[..., C]:
         result = named(modification + " for " + original.__name__)(
             wraps(original)(wrapper)
         )
@@ -70,8 +65,7 @@ def modified(
     return decorator
 
 
-def named(name):
-    # type: (Text) -> Callable[[C], C]
+def named(name: str) -> Callable[[C], C]:
     """
     Change the name of a function to the given name.
     """
@@ -85,13 +79,12 @@ def named(name):
     return decorator
 
 
-def originalName(function):
-    # type: (Callable) -> Text
+def originalName(function: Callable) -> str:
     """
     Get the original, user-specified name of C{function}, chasing back any
     wrappers applied with C{modified}.
     """
-    fnext = function  # type: Optional[Callable]
+    fnext: Optional[Callable] = function
     while fnext is not None:
         function = fnext
         fnext = getattr(function, "__original__", None)

--- a/src/klein/_dihttp.py
+++ b/src/klein/_dihttp.py
@@ -2,7 +2,7 @@
 Dependency-Injected HTTP metadata.
 """
 
-from typing import Any, Dict, Mapping, Sequence, Text, Union
+from typing import Any, Dict, Mapping, Sequence, Union
 
 import attr
 
@@ -123,7 +123,7 @@ class Response(object):
     code = attr.ib(type=int, default=200)
     headers = attr.ib(
         type=Mapping[
-            Union[Text, bytes], Union[Text, bytes, Sequence[Union[Text, bytes]]]
+            Union[str, bytes], Union[str, bytes, Sequence[Union[str, bytes]]]
         ],
         default=attr.Factory(dict),
     )

--- a/src/klein/_dihttp.py
+++ b/src/klein/_dihttp.py
@@ -115,7 +115,7 @@ class Response(object):
         - some HTTP headers
 
         - a body object, which can be anything else Klein understands; for
-          example, an IResource, an IRenderable, text, bytes, etc.
+          example, an IResource, an IRenderable, str, bytes, etc.
 
     @since: Klein NEXT
     """

--- a/src/klein/_dihttp.py
+++ b/src/klein/_dihttp.py
@@ -23,8 +23,7 @@ from .interfaces import (
 )
 
 
-def urlFromRequest(request):
-    # type: (IRequest) -> DecodedURL
+def urlFromRequest(request: IRequest) -> DecodedURL:
     sentHeader = request.getHeader(b"host")
     if sentHeader is not None:
         sentHeader = sentHeader.decode("charmap")
@@ -57,19 +56,21 @@ class RequestURL(object):
 
     @classmethod
     def registerInjector(
-        cls, injectionComponents, parameterName, requestLifecycle
-    ):
-        # type: (Componentized, str, IRequestLifecycle) -> IDependencyInjector
+        cls,
+        injectionComponents: Componentized,
+        parameterName: str,
+        requestLifecycle: IRequestLifecycle,
+    ) -> IDependencyInjector:
         return cls()
 
     @classmethod
-    def injectValue(cls, instance, request, routeParams):
-        # type: (Any, IRequest, Dict[str, Any]) -> DecodedURL
+    def injectValue(
+        cls, instance: Any, request: IRequest, routeParams: Dict[str, Any],
+    ) -> DecodedURL:
         return urlFromRequest(request)
 
     @classmethod
-    def finalize(cls):
-        # type: () -> None
+    def finalize(cls) -> None:
         "Nothing to do upon finalization."
 
 
@@ -85,17 +86,19 @@ class RequestComponent(object):
     interface = attr.ib(type=IInterface)
 
     def registerInjector(
-        self, injectionComponents, parameterName, requestLifecycle
-    ):
-        # type: (Componentized, str, IRequestLifecycle) -> IDependencyInjector
+        self,
+        injectionComponents: Componentized,
+        parameterName: str,
+        requestLifecycle: IRequestLifecycle,
+    ) -> IDependencyInjector:
         return self
 
-    def injectValue(self, instance, request, routeParams):
-        # type: (Any, IRequest, Dict[str, Any]) -> DecodedURL
+    def injectValue(
+        self, instance: Any, request: IRequest, routeParams: Dict[str, Any]
+    ) -> DecodedURL:
         return request.getComponent(self.interface)
 
-    def finalize(cls):
-        # type: () -> None
+    def finalize(cls) -> None:
         "Nothing to do upon finalization."
 
 
@@ -126,8 +129,7 @@ class Response(object):
     )
     body = attr.ib(type=Any, default="")
 
-    def _applyToRequest(self, request):
-        # type: (IRequest) -> Any
+    def _applyToRequest(self, request: IRequest) -> Any:
         """
         Apply this L{Response} to the given L{IRequest}, setting its response
         code and headers.

--- a/src/klein/_form.py
+++ b/src/klein/_form.py
@@ -118,7 +118,7 @@ class Field(object):
             protoForm.addField(self.maybeNamed(parameterName)),
         )
 
-    def maybeNamed(self, name: str) -> Field:
+    def maybeNamed(self, name: str) -> "Field":
         """
         Create a new L{Field} like this one, but with all the name default
         values filled in.
@@ -221,7 +221,7 @@ class Field(object):
             raise ValidationError(str(ve))
 
     @classmethod
-    def text(cls, **kw: Any) -> Field:
+    def text(cls, **kw: Any) -> "Field":
         """
         Shorthand for a form field that contains a short string, and will be
         rendered as a plain <input>.
@@ -229,7 +229,7 @@ class Field(object):
         return cls(converter=textConverter, formInputType="text", **kw)
 
     @classmethod
-    def password(cls, **kw: Any) -> Field:
+    def password(cls, **kw: Any) -> "Field":
         """
         Shorthand for a form field that, like L{text}, contains a short string,
         but should be obscured when typed (and, to the extent possible,
@@ -238,7 +238,7 @@ class Field(object):
         return cls(converter=textConverter, formInputType="password", **kw)
 
     @classmethod
-    def hidden(cls, name: str, value: str, **kw: Any) -> Field:
+    def hidden(cls, name: str, value: str, **kw: Any) -> "Field":
         """
         Shorthand for a hidden field.
         """
@@ -257,7 +257,7 @@ class Field(object):
         maximum: Optional[int] = None,
         kind: Type = float,
         **kw: Any,
-    ) -> Field:
+    ) -> "Field":
         """
         An integer within the range [minimum, maximum].
         """
@@ -277,7 +277,7 @@ class Field(object):
         return cls(converter=bounded_number, formInputType="number", **kw)
 
     @classmethod
-    def submit(cls, value: str) -> Field:
+    def submit(cls, value: str) -> "Field":
         """
         A field representing a submit button, with a value (displayed on the
         button).
@@ -402,7 +402,7 @@ class RenderableForm(object):
 
 @bindable
 def defaultValidationFailureHandler(
-    instance: Optional[object], request: IRequest, fieldValues: FieldValues,
+    instance: Optional[object], request: IRequest, fieldValues: "FieldValues",
 ) -> Element:
     """
     This is the default validation failure handler, which will be used by form
@@ -485,7 +485,7 @@ class ProtoForm(object):
     _fields = attr.ib(type=List[Field], default=attr.Factory(list))
 
     @classmethod
-    def fromComponentized(cls, componentized: Componentized) -> ProtoForm:
+    def fromComponentized(cls, componentized: Componentized) -> "ProtoForm":
         """
         Create a ProtoForm from a componentized object.
         """
@@ -493,7 +493,7 @@ class ProtoForm(object):
         assert rl is not None
         return cls(componentized, rl)
 
-    def addField(self, field: Field) -> FieldInjector:
+    def addField(self, field: Field) -> "FieldInjector":
         """
         Add the given field to the form ultimately created here.
         """
@@ -726,7 +726,7 @@ class Form(object):
         method: str = "POST",
         enctype: str = RenderableForm.ENCTYPE_FORM_DATA,
         encoding: str = "utf-8",
-    ) -> RenderableFormParam:
+    ) -> "RenderableFormParam":
         """
         A form parameter that can render a form declared as a number of fields
         on another route.
@@ -781,7 +781,7 @@ class RenderableFormParam(object):
         injectionComponents: Componentized,
         parameterName: str,
         requestLifecycle: IRequestLifecycle,
-    ) -> RenderableFormParam:
+    ) -> "RenderableFormParam":
         return self
 
     def injectValue(

--- a/src/klein/_form.py
+++ b/src/klein/_form.py
@@ -12,7 +12,6 @@ from typing import (
     List,
     Optional,
     Sequence,
-    Text,
     Type,
     cast,
 )
@@ -49,13 +48,11 @@ class CrossSiteRequestForgery(Resource, object):
     Cross site request forgery detected.  Request aborted.
     """
 
-    def __init__(self, message):
-        # type: (str) -> None
+    def __init__(self, message: str) -> None:
         super(CrossSiteRequestForgery, self).__init__()
         self.message = message
 
-    def render(self, request):
-        # type: (IRequest) -> bytes
+    def render(self, request: IRequest) -> bytes:
         """
         For all HTTP methods, return a 403.
         """
@@ -66,8 +63,7 @@ class CrossSiteRequestForgery(Resource, object):
 CSRF_PROTECTION = "__csrf_protection__"
 
 
-def textConverter(value):
-    # type: (AnyStr) -> Text
+def textConverter(value: AnyStr) -> str:
     """
     Converter for form values (which may be any type of string) into text.
     """
@@ -103,14 +99,16 @@ class Field(object):
     default = attr.ib(type=Optional[Any], default=None, cmp=False)
     required = attr.ib(type=bool, default=True)
     noLabel = attr.ib(type=bool, default=False)
-    value = attr.ib(type=Text, default="")
+    value = attr.ib(type=str, default="")
     error = attr.ib(type=ValidationError, default=None)
 
     # IRequiredParameter
     def registerInjector(
-        self, injectionComponents, parameterName, requestLifecycle
-    ):
-        # type: (Componentized, str, IRequestLifecycle) -> IDependencyInjector
+        self,
+        injectionComponents: Componentized,
+        parameterName: str,
+        requestLifecycle: IRequestLifecycle,
+    ) -> IDependencyInjector:
         """
         Register this form field as a dependency injector.
         """
@@ -120,8 +118,7 @@ class Field(object):
             protoForm.addField(self.maybeNamed(parameterName)),
         )
 
-    def maybeNamed(self, name):
-        # type: (str) -> Field
+    def maybeNamed(self, name: str) -> Field:
         """
         Create a new L{Field} like this one, but with all the name default
         values filled in.
@@ -130,8 +127,9 @@ class Field(object):
         @type name: a native L{str}
         """
 
-        def maybe(it, that=name):
-            # type: (Optional[str], Optional[str]) -> Optional[str]
+        def maybe(
+            it: Optional[str], that: Optional[str] = name
+        ) -> Optional[str]:
             return that if it is None else it
 
         return attr.assoc(
@@ -143,8 +141,7 @@ class Field(object):
             ),
         )
 
-    def asTags(self):
-        # type: () -> Iterable[Tag]
+    def asTags(self) -> Iterable[Tag]:
         """
         Convert this L{Field} into some stuff that can be rendered in a
         L{twisted.web.template}.
@@ -171,13 +168,12 @@ class Field(object):
             yield input_tag
             yield error_tags
 
-    def extractValue(self, request):
-        # type: (IRequest) -> Any
+    def extractValue(self, request: IRequest) -> Any:
         """
         Extract a value from the request.
 
         In the case of key/value form posts, this attempts to reliably make the
-        value into Text.  In the case of a JSON post, however, it will simply
+        value into str.  In the case of a JSON post, however, it will simply
         extract the value from the top-level dictionary, which means it could
         be any arrangement of JSON-serializiable objects.
         """
@@ -205,8 +201,7 @@ class Field(object):
         else:
             return None
 
-    def validateValue(self, value):
-        # type: (Any) -> Any
+    def validateValue(self, value: Any) -> Any:
         """
         Validate the given text and return a converted Python object to use, or
         fail with L{ValidationError}.
@@ -226,7 +221,7 @@ class Field(object):
             raise ValidationError(str(ve))
 
     @classmethod
-    def text(cls, **kw):  # type: (**Any) -> Field
+    def text(cls, **kw: Any) -> Field:
         """
         Shorthand for a form field that contains a short string, and will be
         rendered as a plain <input>.
@@ -234,7 +229,7 @@ class Field(object):
         return cls(converter=textConverter, formInputType="text", **kw)
 
     @classmethod
-    def password(cls, **kw):  # type: (**Any) -> Field
+    def password(cls, **kw: Any) -> Field:
         """
         Shorthand for a form field that, like L{text}, contains a short string,
         but should be obscured when typed (and, to the extent possible,
@@ -243,8 +238,7 @@ class Field(object):
         return cls(converter=textConverter, formInputType="password", **kw)
 
     @classmethod
-    def hidden(cls, name, value, **kw):
-        # type: (str, Text, **Any) -> Field
+    def hidden(cls, name: str, value: str, **kw: Any) -> Field:
         """
         Shorthand for a hidden field.
         """
@@ -257,14 +251,18 @@ class Field(object):
         ).maybeNamed(name)
 
     @classmethod
-    def number(cls, minimum=None, maximum=None, kind=float, **kw):
-        # type: (Optional[int], Optional[int], Type, **Any) -> Field
+    def number(
+        cls,
+        minimum: Optional[int] = None,
+        maximum: Optional[int] = None,
+        kind: Type = float,
+        **kw: Any,
+    ) -> Field:
         """
         An integer within the range [minimum, maximum].
         """
 
-        def bounded_number(text):
-            # type: (AnyStr) -> Any
+        def bounded_number(text: AnyStr) -> Any:
             try:
                 value = kind(text)
             except (ValueError, ArithmeticError):
@@ -279,8 +277,7 @@ class Field(object):
         return cls(converter=bounded_number, formInputType="number", **kw)
 
     @classmethod
-    def submit(cls, value):
-        # type: (Text) -> Field
+    def submit(cls, value: str) -> Field:
         """
         A field representing a submit button, with a value (displayed on the
         button).
@@ -300,7 +297,7 @@ class RenderableForm(object):
     An L{IRenderable} representing a renderable form.
 
     @ivar prevalidationValues: a L{dict} mapping {L{Field}: L{list} of
-        L{Text}}, representing the value that each field received as part of
+        L{str}}, representing the value that each field received as part of
         the request.
 
     @ivar validationErrors: a L{dict} mapping {L{Field}: L{ValidationError}}
@@ -313,8 +310,8 @@ class RenderableForm(object):
     _enctype = attr.ib(type=str)
     _encoding = attr.ib(type=str)
     prevalidationValues = attr.ib(
-        type=Dict[Field, Optional[Text]],
-        default=cast(Dict[Field, Optional[Text]], attr.Factory(dict)),
+        type=Dict[Field, Optional[str]],
+        default=cast(Dict[Field, Optional[str]], attr.Factory(dict)),
     )
     validationErrors = attr.ib(
         type=Dict[Field, ValidationError],
@@ -324,16 +321,14 @@ class RenderableForm(object):
     ENCTYPE_FORM_DATA = "multipart/form-data"
     ENCTYPE_URL_ENCODED = "application/x-www-form-urlencoded"
 
-    def _fieldForCSRF(self):
-        # type: () -> Field
+    def _fieldForCSRF(self) -> Field:
         """
         @return: A hidden L{Field} containing the cross-site request forgery
             protection token.
         """
         return Field.hidden(CSRF_PROTECTION, self._session.identifier)
 
-    def _fieldsToRender(self):
-        # type: () -> Iterable[Field]
+    def _fieldsToRender(self) -> Iterable[Field]:
         """
         @return: an interable of L{Field} objects to include in the HTML
             representation of this form.  This includes:
@@ -367,16 +362,14 @@ class RenderableForm(object):
 
     # Public interface below.
 
-    def lookupRenderMethod(self, name):
-        # type: (str) -> NoReturn
+    def lookupRenderMethod(self, name: str) -> NoReturn:
         """
         Form renderers don't supply any render methods, so this just always
         raises L{MissingRenderMethod}.
         """
         raise MissingRenderMethod(self, name)
 
-    def render(self, request):
-        # type: (IRequest) -> Tag
+    def render(self, request: IRequest) -> Tag:
         """
         Render this form to the given request.
         """
@@ -391,8 +384,7 @@ class RenderableForm(object):
             action=self._action, method=self._method, **formAttributes
         )(field.asTags() for field in self._fieldsToRender())
 
-    def glue(self):
-        # type: () -> Iterable[Tag]
+    def glue(self) -> Iterable[Tag]:
         """
         Provide any glue necessary to render this form; this must be dropped
         into the template within the C{<form>} tag.
@@ -410,11 +402,8 @@ class RenderableForm(object):
 
 @bindable
 def defaultValidationFailureHandler(
-    instance,  # type: Optional[object]
-    request,  # type: IRequest
-    fieldValues,  # type: FieldValues
-):
-    # type: (...) -> Element
+    instance: Optional[object], request: IRequest, fieldValues: FieldValues,
+) -> Element:
     """
     This is the default validation failure handler, which will be used by form
     handlers (i.e. any routes which use L{klein.Requirer} to require a field)
@@ -496,8 +485,7 @@ class ProtoForm(object):
     _fields = attr.ib(type=List[Field], default=attr.Factory(list))
 
     @classmethod
-    def fromComponentized(cls, componentized):
-        # type: (Componentized) -> ProtoForm
+    def fromComponentized(cls, componentized: Componentized) -> ProtoForm:
         """
         Create a ProtoForm from a componentized object.
         """
@@ -505,8 +493,7 @@ class ProtoForm(object):
         assert rl is not None
         return cls(componentized, rl)
 
-    def addField(self, field):
-        # type: (Field) -> FieldInjector
+    def addField(self, field: Field) -> FieldInjector:
         """
         Add the given field to the form ultimately created here.
         """
@@ -529,13 +516,12 @@ class FieldValues(object):
 
     form = attr.ib(type="Form")
     arguments = attr.ib(type=Dict[str, Any])
-    prevalidationValues = attr.ib(type=Dict[Field, Optional[Text]])
+    prevalidationValues = attr.ib(type=Dict[Field, Optional[str]])
     validationErrors = attr.ib(type=Dict[Field, ValidationError])
     _injectionComponents = attr.ib(type=Componentized)
 
     @inlineCallbacks
-    def validate(self, instance, request):
-        # type: (Any, IRequest) -> Deferred
+    def validate(self, instance: Any, request: IRequest) -> Deferred:
         """
         If any validation errors have occurred, raise a relevant exception.
         """
@@ -562,8 +548,9 @@ class FieldInjector(object):
     _field = attr.ib(type=Field)
     _lifecycle = attr.ib(type=IRequestLifecycle)
 
-    def injectValue(self, instance, request, routeParams):
-        # type: (Any, IRequest, Dict[str, Any]) -> Any
+    def injectValue(
+        self, instance: Any, request: IRequest, routeParams: Dict[str, Any]
+    ) -> Any:
         """
         Inject the given value into the form.
         """
@@ -571,8 +558,7 @@ class FieldInjector(object):
             self._field.pythonArgumentName
         )
 
-    def finalize(self):
-        # type: () -> None
+    def finalize(self) -> None:
         """
         Finalize this ProtoForm into a real form.
         """
@@ -587,8 +573,7 @@ class FieldInjector(object):
         # side-effect-free (like a search field) that can be handled even
         # without a CSRF token.
         @bindable
-        def populateValuesHook(instance, request):
-            # type: (Any, IRequest) -> Deferred
+        def populateValuesHook(instance: Any, request: IRequest) -> Deferred:
             return finalForm.populateRequestValues(
                 self._componentized, instance, request
             )
@@ -607,8 +592,7 @@ class IValidationFailureHandler(Interface):
     """
 
 
-def checkCSRF(request):
-    # type: (IRequest) -> None
+def checkCSRF(request: IRequest) -> None:
     """
     Check the request for cross-site request forgery, raising an EarlyExit if
     it is found.
@@ -650,8 +634,9 @@ class Form(object):
     fields = attr.ib(type=Sequence[Field])
 
     @staticmethod
-    def onValidationFailureFor(handler):
-        # type: (_requirerFunctionWithForm) -> Callable[[Callable], Callable]
+    def onValidationFailureFor(
+        handler: _requirerFunctionWithForm,
+    ) -> Callable[[Callable], Callable]:
         """
         Register a function to be run in the event of a validation failure for
         the input to a particular form handler.
@@ -684,8 +669,7 @@ class Form(object):
             C{(request, form) -> thing klein can render}.
         """
 
-        def decorate(decoratee):
-            # type: (Callable) -> Callable
+        def decorate(decoratee: Callable) -> Callable:
             handler.injectionComponents.setComponent(
                 IValidationFailureHandler, decoratee
             )
@@ -694,8 +678,12 @@ class Form(object):
         return decorate
 
     @inlineCallbacks
-    def populateRequestValues(self, injectionComponents, instance, request):
-        # type: (Componentized, Any, IRequest) -> Deferred
+    def populateRequestValues(
+        self,
+        injectionComponents: Componentized,
+        instance: Any,
+        request: IRequest,
+    ) -> Deferred:
         """
         Extract the values present in this request and populate a
         L{FieldValues} object.
@@ -733,13 +721,12 @@ class Form(object):
     @classmethod
     def rendererFor(
         cls,
-        decoratedFunction,  # type: _requirerFunctionWithForm
-        action,  # type: Text
-        method="POST",  # type: Text
-        enctype=RenderableForm.ENCTYPE_FORM_DATA,  # type: Text
-        encoding="utf-8",  # type: str
-    ):
-        # type: (...) -> RenderableFormParam
+        decoratedFunction: _requirerFunctionWithForm,
+        action: str,
+        method: str = "POST",
+        enctype: str = RenderableForm.ENCTYPE_FORM_DATA,
+        encoding: str = "utf-8",
+    ) -> RenderableFormParam:
         """
         A form parameter that can render a form declared as a number of fields
         on another route.
@@ -767,9 +754,9 @@ class Form(object):
         As a L{RenderableForm} provides L{IRenderable}, you may return the
         parameter directly
         """
-        form = IForm(
+        form: Optional[Form] = IForm(
             decoratedFunction.injectionComponents, None
-        )  # type: Optional[Form]
+        )
         if form is None:
             form = Form([])
         return RenderableFormParam(form, action, method, enctype, encoding)
@@ -784,19 +771,22 @@ class RenderableFormParam(object):
     """
 
     _form = attr.ib(type=Form)
-    _action = attr.ib(type=Text)
-    _method = attr.ib(type=Text)
-    _enctype = attr.ib(type=Text)
-    _encoding = attr.ib(type=Text)
+    _action = attr.ib(type=str)
+    _method = attr.ib(type=str)
+    _enctype = attr.ib(type=str)
+    _encoding = attr.ib(type=str)
 
     def registerInjector(
-        self, injectionComponents, parameterName, requestLifecycle
-    ):
-        # type: (Componentized, str, IRequestLifecycle) -> RenderableFormParam
+        self,
+        injectionComponents: Componentized,
+        parameterName: str,
+        requestLifecycle: IRequestLifecycle,
+    ) -> RenderableFormParam:
         return self
 
-    def injectValue(self, instance, request, routeParams):
-        # type: (Any, IRequest, Dict[str, Any]) -> RenderableForm
+    def injectValue(
+        self, instance: Any, request: IRequest, routeParams: Dict[str, Any]
+    ) -> RenderableForm:
         """
         Create the renderable form from the request.
         """
@@ -811,8 +801,7 @@ class RenderableFormParam(object):
             validationErrors={},
         )
 
-    def finalize(self):
-        # type: () -> None
+    def finalize(self) -> None:
         """
         Nothing to do upon finalization.
         """

--- a/src/klein/_headers.py
+++ b/src/klein/_headers.py
@@ -39,7 +39,7 @@ def headerNameAsBytes(name: String) -> bytes:
 
 def headerNameAsText(name: String) -> str:
     """
-    Convert a header name to text if necessary.
+    Convert a header name to str if necessary.
     """
     if isinstance(name, str):
         return name
@@ -59,7 +59,7 @@ def headerValueAsBytes(value: String) -> bytes:
 
 def headerValueAsText(value: String) -> str:
     """
-    Convert a header value to text if necessary.
+    Convert a header value to str if necessary.
     """
     if isinstance(value, str):
         return value
@@ -116,7 +116,7 @@ def getFromRawHeaders(rawHeaders: RawHeaders, name: AnyStr) -> Iterable[AnyStr]:
         rawName = headerNameAsBytes(normalizeHeaderName(name))
         return (headerValueAsText(v) for n, v in rawHeaders if rawName == n)
 
-    raise TypeError("name {!r} must be text or bytes".format(name))
+    raise TypeError("name {!r} must be str or bytes".format(name))
 
 
 def rawHeaderName(name: String) -> bytes:
@@ -125,7 +125,7 @@ def rawHeaderName(name: String) -> bytes:
     elif isinstance(name, str):
         return headerNameAsBytes(name)
     else:
-        raise TypeError("name {!r} must be text or bytes".format(name))
+        raise TypeError("name {!r} must be str or bytes".format(name))
 
 
 def rawHeaderNameAndValue(name: String, value: String) -> Tuple[bytes, bytes]:
@@ -141,12 +141,12 @@ def rawHeaderNameAndValue(name: String, value: String) -> Tuple[bytes, bytes]:
     elif isinstance(name, str):
         if not isinstance(value, str):
             raise TypeError(
-                "value {!r} must be text to match name {!r}".format(value, name)
+                "value {!r} must be str to match name {!r}".format(value, name)
             )
         return (headerNameAsBytes(name), headerValueAsBytes(value))
 
     else:
-        raise TypeError("name {!r} must be text or bytes".format(name))
+        raise TypeError("name {!r} must be str or bytes".format(name))
 
 
 # Implementation

--- a/src/klein/_headers_compat.py
+++ b/src/klein/_headers_compat.py
@@ -5,7 +5,7 @@
 Support for interoperability with L{twisted.web.http_headers.Headers}.
 """
 
-from typing import AnyStr, Iterable, Text, Tuple, cast
+from typing import AnyStr, Iterable, Tuple, cast
 
 from attr import attrib, attrs
 from attr.validators import instance_of
@@ -59,7 +59,7 @@ class HTTPHeadersWrappingHeaders(object):
             values = cast(
                 Iterable[AnyStr], self._headers.getRawHeaders(name, default=())
             )
-        elif isinstance(name, Text):
+        elif isinstance(name, str):
             values = (
                 headerValueAsText(value)
                 for value in self._headers.getRawHeaders(

--- a/src/klein/_headers_compat.py
+++ b/src/klein/_headers_compat.py
@@ -42,13 +42,11 @@ class HTTPHeadersWrappingHeaders(object):
     # NOTE: In case Headers has different ideas about encoding text than we do,
     # always interact with it using bytes, not text.
 
-    _headers = attrib(validator=instance_of(Headers))  # type: Headers
+    _headers: Headers = attrib(validator=instance_of(Headers))
 
     @property
-    def rawHeaders(self):
-        # type: () -> RawHeaders
-        def pairs():
-            # type: () -> Iterable[Tuple[bytes, bytes]]
+    def rawHeaders(self) -> RawHeaders:
+        def pairs() -> Iterable[Tuple[bytes, bytes]]:
             for name, values in self._headers.getAllRawHeaders():
                 name = normalizeHeaderName(name)
                 for value in values:
@@ -56,8 +54,7 @@ class HTTPHeadersWrappingHeaders(object):
 
         return tuple(pairs())
 
-    def getValues(self, name):
-        # type: (AnyStr) -> Iterable[AnyStr]
+    def getValues(self, name: AnyStr) -> Iterable[AnyStr]:
         if isinstance(name, bytes):
             values = cast(
                 Iterable[AnyStr], self._headers.getRawHeaders(name, default=())
@@ -74,12 +71,10 @@ class HTTPHeadersWrappingHeaders(object):
 
         return values
 
-    def remove(self, name):
-        # type: (String) -> None
+    def remove(self, name: String) -> None:
         self._headers.removeHeader(rawHeaderName(name))
 
-    def addValue(self, name, value):
-        # type: (AnyStr, AnyStr) -> None
+    def addValue(self, name: AnyStr, value: AnyStr) -> None:
         rawName, rawValue = rawHeaderNameAndValue(name, value)
 
         self._headers.addRawHeader(rawName, rawValue)

--- a/src/klein/_headers_compat.py
+++ b/src/klein/_headers_compat.py
@@ -40,7 +40,7 @@ class HTTPHeadersWrappingHeaders(object):
     """
 
     # NOTE: In case Headers has different ideas about encoding text than we do,
-    # always interact with it using bytes, not text.
+    # always interact with it using bytes, not str.
 
     _headers: Headers = attrib(validator=instance_of(Headers))
 
@@ -67,7 +67,7 @@ class HTTPHeadersWrappingHeaders(object):
                 )
             )
         else:
-            raise TypeError("name {!r} must be text or bytes".format(name))
+            raise TypeError("name {!r} must be str or bytes".format(name))
 
         return values
 

--- a/src/klein/_iform.py
+++ b/src/klein/_iform.py
@@ -3,8 +3,7 @@ class ValidationError(Exception):
     A L{ValidationError} is raised by L{Field.extractValue}.
     """
 
-    def __init__(self, message):
-        # type: (str) -> None
+    def __init__(self, message: str) -> None:
         """
         Initialize a L{ValidationError} with a message to show to the user.
         """

--- a/src/klein/_imessage.py
+++ b/src/klein/_imessage.py
@@ -11,7 +11,7 @@ Do not import directly from here, except:
 This will ensure that type checking works.
 """
 
-from typing import AnyStr, Iterable, MutableSequence, Sequence, Text, Tuple
+from typing import AnyStr, Iterable, MutableSequence, Sequence, Tuple
 
 from hyperlink import DecodedURL
 
@@ -68,7 +68,7 @@ class IHTTPHeaders(Interface):
     well-behaved implementations.
     """
 
-    rawHeaders = Attribute(
+    rawHeaders: RawHeaders = Attribute(
         """
         Raw header data as a tuple in the from: C{((name, value), ...)}.
         C{name} and C{value} are bytes.
@@ -76,11 +76,10 @@ class IHTTPHeaders(Interface):
         Headers with multiple values are provided as separate name and value
         pairs.
         """
-    )  # type: RawHeaders
+    )
 
     @ifmethod
-    def getValues(name):
-        # type: (AnyStr) -> Iterable[AnyStr]
+    def getValues(name: AnyStr) -> Iterable[AnyStr]:
         """
         Get the values associated with the given header name.
 
@@ -103,8 +102,7 @@ class IMutableHTTPHeaders(IHTTPHeaders):
     """
 
     @ifmethod
-    def remove(name):
-        # type: (AnyStr) -> None
+    def remove(name: AnyStr) -> None:
         """
         Remove all header name/value pairs for the given header name.
 
@@ -115,8 +113,7 @@ class IMutableHTTPHeaders(IHTTPHeaders):
         """
 
     @ifmethod
-    def addValue(name, value):
-        # type: (AnyStr, AnyStr) -> None
+    def addValue(name: AnyStr, value: AnyStr) -> None:
         """
         Add the given header name/value pair.
 
@@ -132,11 +129,10 @@ class IHTTPMessage(Interface):
     HTTP entity.
     """
 
-    headers = Attribute("Entity headers.")  # type: IHTTPHeaders
+    headers: IHTTPHeaders = Attribute("Entity headers.")
 
     @ifmethod
-    def bodyAsFount():
-        # type: () -> IFount
+    def bodyAsFount() -> IFount:
         """
         The entity body, as a fount.
 
@@ -153,8 +149,7 @@ class IHTTPMessage(Interface):
         """
 
     @ifmethod
-    def bodyAsBytes():
-        # type: () -> Deferred[bytes]
+    def bodyAsBytes() -> Deferred[bytes]:
         """
         The entity body, as bytes.
 
@@ -180,8 +175,8 @@ class IHTTPRequest(IHTTPMessage):
     HTTP request.
     """
 
-    method = Attribute("Request method.")  # type: Text
-    uri = Attribute("Request URI.")  # type: DecodedURL
+    method: str = Attribute("Request method.")
+    uri: DecodedURL = Attribute("Request URI.")
 
 
 class IHTTPResponse(IHTTPMessage):
@@ -189,4 +184,4 @@ class IHTTPResponse(IHTTPMessage):
     HTTP response.
     """
 
-    status = Attribute("Response status code.")  # type: int
+    status: int = Attribute("Response status code.")

--- a/src/klein/_imessage.py
+++ b/src/klein/_imessage.py
@@ -149,7 +149,7 @@ class IHTTPMessage(Interface):
         """
 
     @ifmethod
-    def bodyAsBytes() -> Deferred[bytes]:
+    def bodyAsBytes() -> Deferred:
         """
         The entity body, as bytes.
 

--- a/src/klein/_imessage.py
+++ b/src/klein/_imessage.py
@@ -86,7 +86,7 @@ class IHTTPHeaders(Interface):
         If the given name is L{bytes}, the value will be returned as the raw
         header L{bytes}.
 
-        If the given name is L{Text}, the name will be encoded as ISO-8859-1
+        If the given name is L{str}, the name will be encoded as ISO-8859-1
         and the value will be returned as text, by decoding the raw header
         value bytes with ISO-8859-1.
 
@@ -106,7 +106,7 @@ class IMutableHTTPHeaders(IHTTPHeaders):
         """
         Remove all header name/value pairs for the given header name.
 
-        If the given name is L{Text}, it will be encoded as ISO-8859-1 before
+        If the given name is L{str}, it will be encoded as ISO-8859-1 before
         comparing to the (L{bytes}) header names.
 
         @param name: The name of the header to remove.
@@ -119,8 +119,8 @@ class IMutableHTTPHeaders(IHTTPHeaders):
 
         If the given name is L{bytes}, the value must also be L{bytes}.
 
-        If the given name is L{Text}, it will be encoded as ISO-8859-1, and the
-        value, which must also be L{Text}, will be encoded as ISO-8859-1.
+        If the given name is L{str}, it will be encoded as ISO-8859-1, and the
+        value, which must also be L{str}, will be encoded as ISO-8859-1.
         """
 
 

--- a/src/klein/_interfaces.py
+++ b/src/klein/_interfaces.py
@@ -78,10 +78,10 @@ if TYPE_CHECKING:  # pragma: no cover
 
 else:
     IHTTPHeaders = _IHTTPHeaders
-    IMutableHTTPHeaders = _IMutableHTTPHeaders
     IHTTPMessage = _IHTTPMessage
     IHTTPRequest = _IHTTPRequest
     IHTTPResponse = _IHTTPResponse
+    IMutableHTTPHeaders = _IMutableHTTPHeaders
 
 
 __all__ = ()

--- a/src/klein/_interfaces.py
+++ b/src/klein/_interfaces.py
@@ -27,7 +27,7 @@ class IKleinRequest(Interface):
 
     @ifmethod
     def url_for(
-        request: IKleinRequest,
+        request: "IKleinRequest",
         endpoint: str,
         values: Optional[Mapping[str, str]] = None,
         method: Optional[str] = None,

--- a/src/klein/_interfaces.py
+++ b/src/klein/_interfaces.py
@@ -7,7 +7,7 @@ All Zope Interface classes should be imported from here so that type checking
 works, since mypy doesn't otherwise get along with Zope Interface.
 """
 
-from typing import Mapping, Optional, TYPE_CHECKING, Text
+from typing import Mapping, Optional, TYPE_CHECKING
 
 from zope.interface import Attribute, Interface
 
@@ -27,14 +27,13 @@ class IKleinRequest(Interface):
 
     @ifmethod
     def url_for(
-        request,  # type: IKleinRequest
-        endpoint,  # type: Text
-        values=None,  # type: Optional[Mapping[Text, Text]]
-        method=None,  # type: Optional[Text]
-        force_external=False,  # type: bool
-        append_unknown=True,  # type: bool
-    ):
-        # type: (...) -> Text
+        request: IKleinRequest,
+        endpoint: str,
+        values: Optional[Mapping[str, str]] = None,
+        method: Optional[str] = None,
+        force_external: bool = False,
+        append_unknown: bool = True,
+    ) -> str:
         """
         L{werkzeug.routing.MapAdapter.build}
         """

--- a/src/klein/_isession.py
+++ b/src/klein/_isession.py
@@ -61,7 +61,7 @@ class ISession(Interface):
 
     identifier = Attribute(
         """
-        L{unicode} identifying a session.
+        L{str} identifying a session.
 
         This value should be:
 

--- a/src/klein/_isession.py
+++ b/src/klein/_isession.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, Iterable, Sequence, TYPE_CHECKING, Union
+from typing import Any, Dict, Iterable, Sequence, TYPE_CHECKING
 
 import attr
 
@@ -12,11 +12,6 @@ from zope.interface import Attribute, Interface
 from zope.interface.interfaces import IInterface
 
 from ._typing import ifmethod
-
-if TYPE_CHECKING:  # pragma: no cover
-    from ._requirer import RequestLifecycle
-
-    IRequestLifecycleT = Union[RequestLifecycle, "IRequestLifecycle"]
 
 
 class NoSuchSession(Exception):
@@ -325,6 +320,21 @@ class IDependencyInjector(Interface):
         """
 
 
+class _IRequestLifecycle(Interface):
+    """
+    Interface for adding hooks to the phases of a request's lifecycle.
+    """
+
+
+if TYPE_CHECKING:
+    from typing import Union
+    from ._requirer import RequestLifecycle
+
+    IRequestLifecycle = Union[_IRequestLifecycle, RequestLifecycle]
+else:
+    IRequestLifecycle = _IRequestLifecycle
+
+
 class IRequiredParameter(Interface):
     """
     A declaration that a given Python parameter is required to satisfy a given
@@ -335,7 +345,7 @@ class IRequiredParameter(Interface):
     def registerInjector(
         injectionComponents: Componentized,
         parameterName: str,
-        lifecycle: IRequestLifecycleT,
+        lifecycle: IRequestLifecycle,
     ) -> IDependencyInjector:
         """
         Register the given injector at method-decoration time, informing it of
@@ -354,12 +364,6 @@ class IRequiredParameter(Interface):
             DependencyInjectors may cooperate on logic that needs to be
             duplicated, such as provisioning a session.
         """
-
-
-class IRequestLifecycle(Interface):
-    """
-    Interface for adding hooks to the phases of a request's lifecycle.
-    """
 
 
 @attr.s

--- a/src/klein/_isession.py
+++ b/src/klein/_isession.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, Iterable, Sequence, TYPE_CHECKING, Text, Union
+from typing import Any, Dict, Iterable, Sequence, TYPE_CHECKING, Union
 
 import attr
 
@@ -43,8 +43,9 @@ class ISessionStore(Interface):
     """
 
     @ifmethod
-    def newSession(isConfidential, authenticatedBy):
-        # type: (bool, SessionMechanism) -> Deferred
+    def newSession(
+        isConfidential: bool, authenticatedBy: SessionMechanism,
+    ) -> Deferred:
         """
         Create a new L{ISession}.
 
@@ -53,8 +54,11 @@ class ISessionStore(Interface):
         """
 
     @ifmethod
-    def loadSession(identifier, isConfidential, authenticatedBy):
-        # type: (Text, bool, SessionMechanism) -> Deferred
+    def loadSession(
+        identifier: str,
+        isConfidential: bool,
+        authenticatedBy: SessionMechanism,
+    ) -> Deferred:
         """
         Load a session given the given identifier and security properties.
 
@@ -74,8 +78,7 @@ class ISessionStore(Interface):
         """
 
     @ifmethod
-    def sentInsecurely(identifiers):
-        # type: (Sequence[Text]) -> None
+    def sentInsecurely(identifiers: Sequence[str]) -> None:
         """
         The transport layer has detected that the given identifiers have been
         sent over an unauthenticated transport.
@@ -93,8 +96,7 @@ class ISimpleAccountBinding(Interface):
     """
 
     @ifmethod
-    def bindIfCredentialsMatch(username, password):
-        # type: (Text, Text) -> None
+    def bindIfCredentialsMatch(username: str, password: str) -> None:
         """
         Attach the session this is a component of to an account with the given
         username and password, if the given username and password correctly
@@ -102,8 +104,7 @@ class ISimpleAccountBinding(Interface):
         """
 
     @ifmethod
-    def boundAccounts():
-        # type: () -> Deferred
+    def boundAccounts() -> Deferred:
         """
         Retrieve the accounts currently associated with the session this is a
         component of.
@@ -112,16 +113,14 @@ class ISimpleAccountBinding(Interface):
         """
 
     @ifmethod
-    def unbindThisSession():
-        # type: () -> None
+    def unbindThisSession() -> None:
         """
         Disassociate the session this is a component of from any accounts it's
         logged in to.
         """
 
     @ifmethod
-    def createAccount(username, email, password):
-        # type: (Text, Text, Text) -> None
+    def createAccount(username: str, email: str, password: str) -> None:
         """
         Create a new account with the given username, email and password.
         """
@@ -144,15 +143,13 @@ class ISimpleAccount(Interface):
         """
     )
 
-    def bindSession(self, session):
-        # type: (ISession) -> None
+    def bindSession(self, session: ISession) -> None:
         """
         Bind the given session to this account; i.e. authorize the given
         session to act on behalf of this account.
         """
 
-    def changePassword(self, newPassword):
-        # type: (Text) -> None
+    def changePassword(self, newPassword: str) -> None:
         """
         Change the password of this account.
         """
@@ -164,8 +161,9 @@ class ISessionProcurer(Interface):
     that store, given HTTP request objects.
     """
 
-    def procureSession(self, request, forceInsecure=False):
-        # type: (IRequest, bool, bool) -> Deferred
+    def procureSession(
+        self, request: IRequest, forceInsecure: bool = False
+    ) -> Deferred:
         """
         Retrieve a session using whatever technique is necessary.
 
@@ -265,8 +263,7 @@ class ISession(Interface):
     )
 
     @ifmethod
-    def authorize(interfaces):
-        # type: (Iterable[IInterface]) -> Deferred
+    def authorize(interfaces: Iterable[IInterface]) -> Deferred:
         """
         Retrieve other objects from this session.
 
@@ -293,8 +290,9 @@ class IDependencyInjector(Interface):
     """
 
     @ifmethod
-    def injectValue(instance, request, routeParams):
-        # type: (Any, IRequest, Dict[str, Any]) -> Any
+    def injectValue(
+        instance: Any, request: IRequest, routeParams: Dict[str, Any]
+    ) -> Any:
         """
         Return a value to be injected into the parameter name specified by the
         IRequiredParameter.  This may return a Deferred, or an object, or an
@@ -311,8 +309,7 @@ class IDependencyInjector(Interface):
         """
 
     @ifmethod
-    def finalize():
-        # type: () -> None
+    def finalize() -> None:
         """
         Finalize this injector before allowing the route to be created.
 
@@ -335,8 +332,11 @@ class IRequiredParameter(Interface):
     """
 
     @ifmethod
-    def registerInjector(injectionComponents, parameterName, lifecycle):
-        # type: (Componentized, str, IRequestLifecycleT) -> IDependencyInjector
+    def registerInjector(
+        injectionComponents: Componentized,
+        parameterName: str,
+        lifecycle: IRequestLifecycleT,
+    ) -> IDependencyInjector:
         """
         Register the given injector at method-decoration time, informing it of
         its Python parameter name.

--- a/src/klein/_message.py
+++ b/src/klein/_message.py
@@ -42,8 +42,7 @@ class MessageState(object):
     )
 
 
-def validateBody(instance, attribute, body):
-    # type: (Any, Any, InternalBody) -> None
+def validateBody(instance: Any, attribute: Any, body: InternalBody) -> None:
     """
     Validator for L{InternalBody}.
     """
@@ -52,8 +51,7 @@ def validateBody(instance, attribute, body):
         raise TypeError("body must be bytes or IFount")
 
 
-def bodyAsFount(body, state):
-    # type: (InternalBody, MessageState) -> IFount
+def bodyAsFount(body: InternalBody, state: MessageState) -> IFount:
     """
     Return a fount for a given L{InternalBody}.
     """
@@ -70,8 +68,7 @@ def bodyAsFount(body, state):
     return body
 
 
-def bodyAsBytes(body, state):
-    # type: (InternalBody, MessageState) -> Deferred[bytes]
+def bodyAsBytes(body: InternalBody, state: MessageState) -> Deferred[bytes]:
     """
     Return bytes for a given L{InternalBody}.
     """
@@ -84,8 +81,7 @@ def bodyAsBytes(body, state):
     if state.cachedBody is not None:
         return succeed(state.cachedBody)
 
-    def cache(bodyBytes):
-        # type: (bytes) -> bytes
+    def cache(bodyBytes: bytes) -> bytes:
         state.cachedBody = bodyBytes
         return bodyBytes
 

--- a/src/klein/_message.py
+++ b/src/klein/_message.py
@@ -68,7 +68,7 @@ def bodyAsFount(body: InternalBody, state: MessageState) -> IFount:
     return body
 
 
-def bodyAsBytes(body: InternalBody, state: MessageState) -> Deferred[bytes]:
+def bodyAsBytes(body: InternalBody, state: MessageState) -> Deferred:
     """
     Return bytes for a given L{InternalBody}.
     """

--- a/src/klein/_plating.py
+++ b/src/klein/_plating.py
@@ -32,8 +32,7 @@ ATOM_TYPES = (
 )
 
 
-def _should_return_json(request):
-    # type: (IRequest) -> bool
+def _should_return_json(request: IRequest) -> bool:
     """
     Should the given request result in a JSON entity-body?
     """
@@ -41,8 +40,7 @@ def _should_return_json(request):
 
 
 @inlineCallbacks
-def resolveDeferredObjects(root):
-    # type: (Any) -> Deferred
+def resolveDeferredObjects(root: Any) -> Deferred:
     """
     Wait on possibly nested L{Deferred}s that represent a JSON
     serializable object.
@@ -58,7 +56,7 @@ def resolveDeferredObjects(root):
 
     result = [None]
     setResult = partial(setitem, result, 0)
-    stack = [(root, setResult)]  # type: StackType
+    stack: StackType = [(root, setResult)]
 
     while stack:
         mightBeDeferred, setter = stack.pop()
@@ -69,7 +67,7 @@ def resolveDeferredObjects(root):
         if isinstance(obj, ATOM_TYPES):
             setter(obj)
         elif isinstance(obj, list):
-            parent = [None] * len(obj)  # type: Any
+            parent: Any = [None] * len(obj)
             setter(parent)
             stack.extend(
                 reversed(
@@ -170,8 +168,9 @@ class PlatedElement(Element):
             wrapped = self._renderers[name]
 
             @modified("plated render wrapper", wrapped)
-            def renderWrapper(request, tag, *args, **kw):
-                # type: (IRequest, Tag, *Any, **Any) -> Any
+            def renderWrapper(
+                request: IRequest, tag: Tag, *args: Any, **kw: Any
+            ) -> Any:
                 return _call(
                     self._boundInstance, wrapped, request, tag, *args, **kw
                 )
@@ -232,8 +231,9 @@ class Plating(object):
             @modified("plating route renderer", method, routing)
             @bindable
             @inlineCallbacks
-            def mymethod(instance, request, *args, **kw):
-                # type: (Any, IRequest, *Any, **Any) -> Any
+            def mymethod(
+                instance: Any, request: IRequest, *args: Any, **kw: Any
+            ) -> Any:
                 data = yield _call(instance, method, request, *args, **kw)
                 if _should_return_json(request):
                     json_data = self._defaults.copy()

--- a/src/klein/_request.py
+++ b/src/klein/_request.py
@@ -43,5 +43,5 @@ class FrozenHTTPRequest(object):
     def bodyAsFount(self) -> IFount:
         return bodyAsFount(self._body, self._state)
 
-    def bodyAsBytes(self) -> Deferred[bytes]:
+    def bodyAsBytes(self) -> Deferred:
         return bodyAsBytes(self._body, self._state)

--- a/src/klein/_request.py
+++ b/src/klein/_request.py
@@ -5,7 +5,7 @@
 HTTP request API.
 """
 
-from typing import Text, Union
+from typing import Union
 
 from attr import Factory, attrib, attrs
 from attr.validators import instance_of, provides
@@ -32,20 +32,16 @@ class FrozenHTTPRequest(object):
     Immutable HTTP request.
     """
 
-    method = attrib(validator=instance_of(Text))  # type: Text
-    uri = attrib(validator=instance_of(DecodedURL))  # type: DecodedURL
-    headers = attrib(validator=provides(IHTTPHeaders))  # type: IHTTPHeaders
+    method: str = attrib(validator=instance_of(str))
+    uri: DecodedURL = attrib(validator=instance_of(DecodedURL))
+    headers: IHTTPHeaders = attrib(validator=provides(IHTTPHeaders))
 
-    _body = attrib(validator=validateBody)  # type: Union[bytes, IFount]
+    _body: Union[bytes, IFount] = attrib(validator=validateBody)
 
-    _state = attrib(
-        default=Factory(MessageState), init=False
-    )  # type: MessageState
+    _state: MessageState = attrib(default=Factory(MessageState), init=False)
 
-    def bodyAsFount(self):
-        # type: () -> IFount
+    def bodyAsFount(self) -> IFount:
         return bodyAsFount(self._body, self._state)
 
-    def bodyAsBytes(self):
-        # type: () -> Deferred[bytes]
+    def bodyAsBytes(self) -> Deferred[bytes]:
         return bodyAsBytes(self._body, self._state)

--- a/src/klein/_request_compat.py
+++ b/src/klein/_request_compat.py
@@ -6,7 +6,7 @@ Support for interoperability with L{twisted.web.iweb.IRequest}.
 """
 
 from io import BytesIO
-from typing import Text, cast
+from typing import cast
 
 from attr import Factory, attrib, attrs
 from attr.validators import provides
@@ -43,20 +43,16 @@ class HTTPRequestWrappingIRequest(object):
     This is an L{IHTTPRequest} implementation that wraps an L{IRequest} object.
     """
 
-    _request = attrib(validator=provides(IRequest))  # type: IRequest
+    _request: IRequest = attrib(validator=provides(IRequest))
 
-    _state = attrib(
-        default=Factory(MessageState), init=False
-    )  # type: MessageState
+    _state: MessageState = attrib(default=Factory(MessageState), init=False)
 
     @property
-    def method(self):
-        # type: () -> Text
-        return cast(Text, self._request.method.decode("ascii"))
+    def method(self) -> str:
+        return cast(str, self._request.method.decode("ascii"))
 
     @property
-    def uri(self):
-        # type: () -> DecodedURL
+    def uri(self) -> DecodedURL:
         request = self._request
 
         # This code borrows from t.w.server.Request._prePathURL.
@@ -83,12 +79,10 @@ class HTTPRequestWrappingIRequest(object):
         return DecodedURL.fromText("{}://{}/{}".format(scheme, netloc, path))
 
     @property
-    def headers(self):
-        # type: () -> IHTTPHeaders
+    def headers(self) -> IHTTPHeaders:
         return HTTPHeadersWrappingHeaders(headers=self._request.requestHeaders)
 
-    def bodyAsFount(self):
-        # type: () -> IFount
+    def bodyAsFount(self) -> IFount:
         source = self._request.content
         if source is noneIO:
             raise FountAlreadyAccessedError()
@@ -99,13 +93,11 @@ class HTTPRequestWrappingIRequest(object):
 
         return fount
 
-    def bodyAsBytes(self):
-        # type: () -> Deferred[bytes]
+    def bodyAsBytes(self) -> Deferred[bytes]:
         if self._state.cachedBody is not None:
             return succeed(self._state.cachedBody)
 
-        def cache(bodyBytes):
-            # type: (bytes) -> bytes
+        def cache(bodyBytes: bytes) -> bytes:
             self._state.cachedBody = bodyBytes
             return bodyBytes
 

--- a/src/klein/_request_compat.py
+++ b/src/klein/_request_compat.py
@@ -93,7 +93,7 @@ class HTTPRequestWrappingIRequest(object):
 
         return fount
 
-    def bodyAsBytes(self) -> Deferred[bytes]:
+    def bodyAsBytes(self) -> Deferred:
         if self._state.cachedBody is not None:
             return succeed(self._state.cachedBody)
 

--- a/src/klein/_requirer.py
+++ b/src/klein/_requirer.py
@@ -28,8 +28,12 @@ class RequestLifecycle(object):
 
     _prepareHooks = attr.ib(type=List, default=attr.Factory(list))
 
-    def addPrepareHook(self, beforeHook, requires=(), provides=()):
-        # type: (Callable, Sequence[IInterface], Sequence[IInterface]) -> None
+    def addPrepareHook(
+        self,
+        beforeHook: Callable,
+        requires: Sequence[IInterface] = (),
+        provides: Sequence[IInterface] = (),
+    ) -> None:
         """
         Add a hook that promises to prepare the request by supplying the given
         interfaces as components on the request, and requires the given
@@ -42,8 +46,7 @@ class RequestLifecycle(object):
         self._prepareHooks.append(beforeHook)
 
     @inlineCallbacks
-    def runPrepareHooks(self, instance, request):
-        # type: (Any, IRequest) -> Deferred
+    def runPrepareHooks(self, instance: Any, request: IRequest) -> Deferred:
         """
         Execute all the hooks added with L{RequestLifecycle.addPrepareHook}.
         This is invoked by the L{requires} route machinery.
@@ -74,10 +77,9 @@ class Requirer(object):
 
     def prerequisite(
         self,
-        providesComponents,  # type: Sequence[IInterface]
-        requiresComponents=(),  # type: Sequence[IInterface]
-    ):
-        # type: (...) -> Callable[[Callable], Callable]
+        providesComponents: Sequence[IInterface],
+        requiresComponents: Sequence[IInterface] = (),
+    ) -> Callable[[Callable], Callable]:
         """
         Specify a component that is a pre-requisite of every request routed
         through this requirer's C{require} method.  Used like so::
@@ -95,10 +97,8 @@ class Requirer(object):
             order you want them to be called.
         """
 
-        def decorator(prerequisiteMethod):
-            # type: (Callable) -> Callable
-            def oneHook(lifecycle):
-                # type: (IRequestLifecycle) -> None
+        def decorator(prerequisiteMethod: Callable) -> Callable:
+            def oneHook(lifecycle: IRequestLifecycle) -> None:
                 lifecycle.addPrepareHook(
                     prerequisiteMethod,
                     requires=requiresComponents,
@@ -110,19 +110,19 @@ class Requirer(object):
 
         return decorator
 
-    def require(self, routeDecorator, **requiredParameters):
-        # type: (_routeT, **IRequiredParameter) -> _routeDecorator
+    def require(
+        self, routeDecorator: _routeT, **requiredParameters: IRequiredParameter
+    ) -> _routeDecorator:
         """
         Inject the given dependencies while running the given route.
         """
 
-        def decorator(functionWithRequirements):
-            # type: (Callable) -> Callable
+        def decorator(functionWithRequirements: Callable) -> Callable:
             injectionComponents = Componentized()
             lifecycle = RequestLifecycle()
             injectionComponents.setComponent(IRequestLifecycle, lifecycle)
 
-            injectors = {}  # type: Dict[str, IDependencyInjector]
+            injectors: Dict[str, IDependencyInjector] = {}
 
             for parameterName, required in requiredParameters.items():
                 injectors[parameterName] = required.registerInjector(
@@ -138,8 +138,9 @@ class Requirer(object):
             @modified("dependency-injecting route", functionWithRequirements)
             @bindable
             @inlineCallbacks
-            def router(instance, request, *args, **routeParams):
-                # type: (Any, IRequest, *Any, **Any) -> Any
+            def router(
+                instance: Any, request: IRequest, *args: Any, **routeParams: Any
+            ) -> Any:
                 injected = routeParams.copy()
                 try:
                     yield lifecycle.runPrepareHooks(instance, request)

--- a/src/klein/_resource.py
+++ b/src/klein/_resource.py
@@ -4,7 +4,7 @@ from __future__ import absolute_import, division
 
 from twisted.internet import defer
 from twisted.python import failure, log
-from twisted.python.compat import intToBytes, unicode
+from twisted.python.compat import intToBytes
 from twisted.web import server
 from twisted.web.iweb import IRenderable
 from twisted.web.resource import IResource, Resource, getChildForRequest
@@ -19,10 +19,10 @@ from ._interfaces import IKleinRequest
 
 def ensure_utf8_bytes(v):
     """
-    Coerces a value which is either a C{unicode} or C{str} to a C{str}.
-    If ``v`` is a C{unicode} object it is encoded as utf-8.
+    Coerces a value which is either a C{str} or C{bytes} to a C{bytes}.
+    If ``v`` is a C{str} object it is encoded as utf-8.
     """
-    if isinstance(v, unicode):
+    if isinstance(v, str):
         v = v.encode("utf-8")
     return v
 
@@ -68,7 +68,7 @@ def _extractURLparts(request):
 
     @return: L{tuple} of the URL scheme, the server name, the server port, the
         path info and the script name.
-    @rtype: L{tuple} of L{unicode}, L{unicode}, L{int}, L{unicode}, L{unicode}
+    @rtype: L{tuple} of L{str}, L{str}, L{int}, L{str}, L{str}
     """
     server_name = request.getRequestHostname()
     if hasattr(request.getHost(), "port"):
@@ -274,7 +274,7 @@ class KleinResource(Resource):
 
         def write_response(r):
             if r is not _StandInResource:
-                if isinstance(r, unicode):
+                if isinstance(r, str):
                     r = r.encode("utf-8")
 
                 if (r is not None) and (r != NOT_DONE_YET):

--- a/src/klein/_response.py
+++ b/src/klein/_response.py
@@ -30,20 +30,16 @@ class FrozenHTTPResponse(object):
     Immutable HTTP response.
     """
 
-    status = attrib(validator=instance_of(int))  # type: int
+    status: int = attrib(validator=instance_of(int))
 
-    headers = attrib(validator=provides(IHTTPHeaders))  # type: IHTTPHeaders
+    headers: IHTTPHeaders = attrib(validator=provides(IHTTPHeaders))
 
-    _body = attrib(validator=validateBody)  # type: Union[bytes, IFount]
+    _body: Union[bytes, IFount] = attrib(validator=validateBody)
 
-    _state = attrib(
-        default=Factory(MessageState), init=False
-    )  # type: MessageState
+    _state: MessageState = attrib(default=Factory(MessageState), init=False)
 
-    def bodyAsFount(self):
-        # type: () -> IFount
+    def bodyAsFount(self) -> IFount:
         return bodyAsFount(self._body, self._state)
 
-    def bodyAsBytes(self):
-        # type: () -> Deferred[bytes]
+    def bodyAsBytes(self) -> Deferred[bytes]:
         return bodyAsBytes(self._body, self._state)

--- a/src/klein/_response.py
+++ b/src/klein/_response.py
@@ -41,5 +41,5 @@ class FrozenHTTPResponse(object):
     def bodyAsFount(self) -> IFount:
         return bodyAsFount(self._body, self._state)
 
-    def bodyAsBytes(self) -> Deferred[bytes]:
+    def bodyAsBytes(self) -> Deferred:
         return bodyAsBytes(self._body, self._state)

--- a/src/klein/_session.py
+++ b/src/klein/_session.py
@@ -1,6 +1,6 @@
 # -*- test-case-name: klein.test.test_session -*-
 
-from typing import Any, Callable, Dict, Optional, Sequence, Text, Union
+from typing import Any, Callable, Dict, Optional, Sequence, Union
 
 import attr
 
@@ -85,8 +85,9 @@ class SessionProcurer(object):
     _setCookieOnGET = attr.ib(type=bool, default=True)
 
     @inlineCallbacks
-    def procureSession(self, request, forceInsecure=False):
-        # type: (IRequest, bool) -> Any
+    def procureSession(
+        self, request: IRequest, forceInsecure: bool = False
+    ) -> Any:
         alreadyProcured = request.getComponent(ISession)
         if alreadyProcured is not None:
             if not forceInsecure or not request.isSecure():
@@ -95,7 +96,7 @@ class SessionProcurer(object):
         if request.isSecure():
             if forceInsecure:
                 tokenHeader = self._insecureTokenHeader
-                cookieName = self._insecureCookie  # type: Union[Text, bytes]
+                cookieName: Union[str, bytes] = self._insecureCookie
                 sentSecurely = False
             else:
                 tokenHeader = self._secureTokenHeader
@@ -104,7 +105,7 @@ class SessionProcurer(object):
         else:
             # Have we inadvertently disclosed a secure token over an insecure
             # transport, for example, due to a buggy client?
-            allPossibleSentTokens = sum(
+            allPossibleSentTokens: Sequence[str] = sum(
                 [
                     request.requestHeaders.getRawHeaders(header, [])
                     for header in [
@@ -120,7 +121,7 @@ class SessionProcurer(object):
                     for cookie in [self._secureCookie, self._insecureCookie]
                 ]
                 if it
-            ]  # type: Sequence[Text]
+            ]
             # Does it seem like this check is expensive? It sure is! Don't want
             # to do it? Turn on your dang HTTPS!
             yield self._store.sentInsecurely(allPossibleSentTokens)
@@ -213,13 +214,11 @@ _requirerResult = Callable[
 
 
 class AuthorizationDenied(Resource, object):
-    def __init__(self, interface, instance):
-        # type: (IInterface, Any) -> None
+    def __init__(self, interface: IInterface, instance: Any) -> None:
         self._interface = interface
         super(AuthorizationDenied, self).__init__()
 
-    def render(self, request):
-        # type: (IRequest) -> bytes
+    def render(self, request: IRequest) -> bytes:
         request.setResponseCode(UNAUTHORIZED)
         return "{} DENIED".format(qual(self._interface)).encode("utf-8")
 
@@ -285,16 +284,21 @@ class Authorization(object):
         type=Callable[[IInterface, Any], Any], default=AuthorizationDenied
     )
 
-    def registerInjector(self, injectionComponents, parameterName, lifecycle):
-        # type: (Componentized, str, IRequestLifecycle) -> IDependencyInjector
+    def registerInjector(
+        self,
+        injectionComponents: Componentized,
+        parameterName: str,
+        lifecycle: IRequestLifecycle,
+    ) -> IDependencyInjector:
         """
         Register this authorization to inject a parameter.
         """
         return self
 
     @inlineCallbacks
-    def injectValue(self, instance, request, routeParams):
-        # type: (Any, IRequest, Dict[str, Any]) -> Any
+    def injectValue(
+        self, instance: Any, request: IRequest, routeParams: Dict[str, Any]
+    ) -> Any:
         """
         Inject a value by asking the request's session.
         """
@@ -310,8 +314,7 @@ class Authorization(object):
         # TODO: CSRF protection should probably go here
         returnValue(provider)
 
-    def finalize(self):
-        # type: () -> None
+    def finalize(self) -> None:
         """
         Nothing to finalize when registering.
         """

--- a/src/klein/_tubes.py
+++ b/src/klein/_tubes.py
@@ -24,10 +24,8 @@ __all__ = ()
 
 
 # See https://github.com/twisted/tubes/issues/60
-def fountToBytes(fount):
-    # type: (IFount) -> Deferred[bytes]
-    def collect(chunks):
-        # type: (Iterable[bytes]) -> bytes
+def fountToBytes(fount: IFount) -> Deferred[bytes]:
+    def collect(chunks: Iterable[bytes]) -> bytes:
         return b"".join(chunks)
 
     d = fountToDeferred(fount)
@@ -36,8 +34,7 @@ def fountToBytes(fount):
 
 
 # See https://github.com/twisted/tubes/issues/60
-def bytesToFount(data):
-    # type: (bytes) -> IFount
+def bytesToFount(data: bytes) -> IFount:
     return IOFount(source=BytesIO(data))
 
 
@@ -51,44 +48,37 @@ class IOFount(object):
 
     outputType = ISegment
 
-    _source = attrib()  # type: BinaryIO
+    _source: BinaryIO = attrib()
 
-    drain = attrib(
+    drain: IDrain = attrib(
         validator=optional(provides(IDrain)), default=None, init=False
-    )  # type: IDrain
+    )
     _paused = attrib(validator=instance_of(bool), default=False, init=False)
 
-    def __attrs_post_init__(self):
-        # type: () -> None
+    def __attrs_post_init__(self) -> None:
         self._pauser = Pauser(self._pause, self._resume)
 
-    def _flowToDrain(self):
-        # type: () -> None
+    def _flowToDrain(self) -> None:
         if self.drain is not None and not self._paused:
             data = self._source.read()
             if data:
                 self.drain.receive(data)
             self.drain.flowStopped(Failure(StopIteration()))
 
-    def flowTo(self, drain):
-        # type: (IDrain) -> IFount
+    def flowTo(self, drain: IDrain) -> IFount:
         result = beginFlowingTo(self, drain)
         self._flowToDrain()
         return result
 
-    def pauseFlow(self):
-        # type: () -> Any
+    def pauseFlow(self) -> Any:
         return self._pauser.pause()
 
-    def stopFlow(self):
-        # type: () -> Any
+    def stopFlow(self) -> Any:
         return self._pauser.resume()
 
-    def _pause(self):
-        # type: () -> None
+    def _pause(self) -> None:
         self._paused = True
 
-    def _resume(self):
-        # type: () -> None
+    def _resume(self) -> None:
         self._paused = False
         self._flowToDrain()

--- a/src/klein/_tubes.py
+++ b/src/klein/_tubes.py
@@ -24,7 +24,7 @@ __all__ = ()
 
 
 # See https://github.com/twisted/tubes/issues/60
-def fountToBytes(fount: IFount) -> Deferred[bytes]:
+def fountToBytes(fount: IFount) -> Deferred:
     def collect(chunks: Iterable[bytes]) -> bytes:
         return b"".join(chunks)
 

--- a/src/klein/_typing.py
+++ b/src/klein/_typing.py
@@ -3,14 +3,13 @@ from typing import Callable, TYPE_CHECKING, Union
 try:
     from typing import Awaitable
 except ImportError:
-    Awaitable = Union  # type: ignore
+    Awaitable = Union  # type: ignore[assignment,misc]
 
 
 __all__ = ()
 
 
-def _ifmethod(method):
-    # type: (Callable) -> Callable
+def _ifmethod(method: Callable) -> Callable:
     return method
 
 

--- a/src/klein/interfaces.py
+++ b/src/klein/interfaces.py
@@ -22,61 +22,61 @@ from ._isession import (
 )
 
 if TYPE_CHECKING:  # pragma: no cover
-    from .storage._memory import MemorySessionStore, MemorySession
-    from ._session import SessionProcurer, Authorization
-    from ._form import Field, RenderableFormParam, FieldInjector
-    from ._isession import IRequestLifecycleT as _IRequestLifecycleT
-    from ._dihttp import RequestURL, RequestComponent
-
     from typing import Union
 
-    ISessionStore = Union[_ISessionStore, MemorySessionStore]
-    ISessionProcurer = Union[_ISessionProcurer, SessionProcurer]
-    ISession = Union[_ISession, MemorySession]
-    ISimpleAccount = _ISimpleAccount
-    ISimpleAccountBinding = _ISimpleAccountBinding
+    from ._dihttp import RequestURL, RequestComponent
+    from ._form import Field, RenderableFormParam, FieldInjector
+    from ._requirer import RequestLifecycle
+    from ._session import SessionProcurer, Authorization
+    from .storage._memory import MemorySessionStore, MemorySession
+
     IDependencyInjector = Union[
         _IDependencyInjector,
         Authorization,
-        RenderableFormParam,
         FieldInjector,
-        RequestURL,
+        RenderableFormParam,
         RequestComponent,
+        RequestURL,
     ]
+    IRequestLifecycle = Union[_IRequestLifecycle, RequestLifecycle]
     IRequiredParameter = Union[
         _IRequiredParameter,
         Authorization,
         Field,
         RenderableFormParam,
-        RequestURL,
         RequestComponent,
+        RequestURL,
     ]
-    IRequestLifecycle = _IRequestLifecycleT
+    ISession = Union[_ISession, MemorySession]
+    ISessionProcurer = Union[_ISessionProcurer, SessionProcurer]
+    ISessionStore = Union[_ISessionStore, MemorySessionStore]
+    ISimpleAccount = _ISimpleAccount
+    ISimpleAccountBinding = _ISimpleAccountBinding
 else:
+    IDependencyInjector = _IDependencyInjector
+    IRequestLifecycle = _IRequestLifecycle
+    IRequiredParameter = _IRequiredParameter
     ISession = _ISession
+    ISessionProcurer = _ISessionProcurer
     ISessionStore = _ISessionStore
     ISimpleAccount = _ISimpleAccount
-    ISessionProcurer = _ISessionProcurer
     ISimpleAccountBinding = _ISimpleAccountBinding
-    IDependencyInjector = _IDependencyInjector
-    IRequiredParameter = _IRequiredParameter
-    IRequestLifecycle = _IRequestLifecycle
 
 __all__ = (
+    "EarlyExit",
+    "IDependencyInjector",
     "IKleinRequest",
+    "IRequestLifecycle",
+    "IRequiredParameter",
+    "ISession",
+    "ISessionProcurer",
+    "ISessionStore",
+    "ISimpleAccount",
+    "ISimpleAccountBinding",
     "NoSuchSession",
+    "SessionMechanism",
     "TooLateForCookies",
     "TransactionEnded",
-    "ISessionStore",
-    "ISimpleAccountBinding",
-    "ISimpleAccount",
-    "ISessionProcurer",
-    "IDependencyInjector",
-    "IRequiredParameter",
-    "IRequestLifecycle",
-    "EarlyExit",
-    "SessionMechanism",
-    "ISession",
     "ValidationError",
     "ValueAbsent",
 )

--- a/src/klein/resource.py
+++ b/src/klein/resource.py
@@ -10,7 +10,7 @@ This module, L{klein.resource}, serves two purposes:
 """
 
 from sys import modules
-from typing import AnyStr, Callable, Text
+from typing import AnyStr, Callable
 
 from ._app import resource as _globalResourceMethod
 from ._resource import KleinResource as _KleinResource, ensure_utf8_bytes
@@ -33,12 +33,10 @@ class _SpecialModuleObject(object):
     KleinResource = _KleinResource
 
     @property
-    def ensure_utf8_bytes(self):
-        # type: () -> Callable[[AnyStr], Text]
+    def ensure_utf8_bytes(self) -> Callable[[AnyStr], str]:
         return ensure_utf8_bytes
 
-    def __call__(self):
-        # type: () -> _KleinResource
+    def __call__(self) -> _KleinResource:
         """
         Return an L{IResource} which suitably wraps this app.
 
@@ -48,8 +46,7 @@ class _SpecialModuleObject(object):
         # confusion.
         return _globalResourceMethod()
 
-    def __repr__(self):
-        # type: () -> str
+    def __repr__(self) -> str:
         """
         Give a special C{repr()} to make the dual purpose of this object clear.
         """

--- a/src/klein/test/_trial.py
+++ b/src/klein/test/_trial.py
@@ -21,8 +21,7 @@ class TestCase(SynchronousTestCase):
     Extensions to L{SynchronousTestCase}.
     """
 
-    def assertProvides(self, interface, obj):
-        # type: (Interface, Any) -> None
+    def assertProvides(self, interface: Interface, obj: Any) -> None:
         """
         Assert that a object provides an interface.
 

--- a/src/klein/test/test_exports.py
+++ b/src/klein/test/test_exports.py
@@ -10,8 +10,7 @@ class PublicSymbolsTestCase(unittest.TestCase):
     Tests for public API modules.
     """
 
-    def test_klein(self):
-        # type: () -> None
+    def test_klein(self) -> None:
         """
         Test exports from L{klein}.
         """
@@ -26,8 +25,7 @@ class PublicSymbolsTestCase(unittest.TestCase):
 
         self.assertIdentical(k.Plating, p.Plating)
 
-    def test_klein_resource(self):
-        # type: () -> None
+    def test_klein_resource(self) -> None:
         """
         Test export of C{resource} from L{klein}.
         """
@@ -36,8 +34,7 @@ class PublicSymbolsTestCase(unittest.TestCase):
 
         self.assertIdentical(k.resource()._app, a.resource()._app)
 
-    def test_app(self):
-        # type: () -> None
+    def test_app(self) -> None:
         """
         Test exports from L{klein.app}.
         """
@@ -50,8 +47,7 @@ class PublicSymbolsTestCase(unittest.TestCase):
         self.assertIdentical(a.route, _a.route)
         self.assertIdentical(a.run, _a.run)
 
-    def test_interfaces(self):
-        # type: () -> None
+    def test_interfaces(self) -> None:
         """
         Test exports from L{klein.interfaces}.
         """
@@ -60,8 +56,7 @@ class PublicSymbolsTestCase(unittest.TestCase):
 
         self.assertIdentical(i.IKleinRequest, _i.IKleinRequest)
 
-    def test_resource(self):
-        # type: () -> None
+    def test_resource(self) -> None:
         """
         Test exports from L{klein.resource}.
         """

--- a/src/klein/test/test_form.py
+++ b/src/klein/test/test_form.py
@@ -1,4 +1,4 @@
-from typing import Any, List, Text, Tuple, cast
+from typing import Any, List, Tuple, cast
 from xml.etree import ElementTree
 
 import attr
@@ -31,8 +31,7 @@ class DanglingField(Field):
     told.
     """
 
-    def maybeNamed(self, name):
-        # type: (Text) -> Field
+    def maybeNamed(self, name: str) -> Field:
         return self
 
 
@@ -46,8 +45,7 @@ class TestObject(object):
 
     @requirer.prerequisite([ISession])
     @inlineCallbacks
-    def procureASession(self, request):
-        # type: (IRequest) -> Any
+    def procureASession(self, request: IRequest) -> Any:
         try:
             yield (
                 SessionProcurer(
@@ -64,8 +62,7 @@ class TestObject(object):
         router.route("/dangling-param", methods=["POST"]),
         dangling=DanglingField(lambda x: x, "text"),
     )
-    def danglingParameter(self, dangling):
-        # type: (str) -> None
+    def danglingParameter(self, dangling: str) -> None:
         "..."
 
     @requirer.require(
@@ -73,8 +70,7 @@ class TestObject(object):
         name=Field.text(),
         value=Field.number(),
     )
-    def handler(self, name, value):
-        # type: (Text, float) -> bytes
+    def handler(self, name: str, value: float) -> bytes:
         self.calls.append((name, value))
         return b"yay"
 
@@ -83,8 +79,7 @@ class TestObject(object):
         name=Field.text(),
         button=Field.submit("OK"),
     )
-    def handlerWithSubmit(self, name, button):
-        # type: (str, str) -> None
+    def handlerWithSubmit(self, name: str, button: str) -> None:
         """
         Form with a submit button.
         """
@@ -92,8 +87,7 @@ class TestObject(object):
     @requirer.require(
         router.route("/password-field", methods=["POST"]), pw=Field.password()
     )
-    def gotPassword(self, pw):
-        # type: (Text) -> bytes
+    def gotPassword(self, pw: str) -> bytes:
         self.calls.append(("password", pw))
         return b"password received"
 
@@ -102,8 +96,7 @@ class TestObject(object):
         name=Field.text(),
         value=Field.number(required=False, default=7.0),
     )
-    def notRequired(self, name, value):
-        # type: (IRequest, Text, float) -> bytes
+    def notRequired(self, name: str, value: float) -> bytes:
         self.calls.append((name, value))
         return b"okay"
 
@@ -111,8 +104,7 @@ class TestObject(object):
         router.route("/constrained", methods=["POST"]),
         goldilocks=Field.number(minimum=3, maximum=9),
     )
-    def constrained(self, goldilocks):
-        # type: (int) -> bytes
+    def constrained(self, goldilocks: int) -> bytes:
         self.calls.append(("constrained", goldilocks))
         return b"got it"
 
@@ -120,24 +112,21 @@ class TestObject(object):
         router.route("/render", methods=["GET"]),
         form=Form.rendererFor(handler, action="/handle"),
     )
-    def renderer(self, form):
-        # type: (IRequest, Form) -> Form
+    def renderer(self, form: Form) -> Form:
         return form
 
     @requirer.require(
         router.route("/render-submit", methods=["GET"]),
         form=Form.rendererFor(handlerWithSubmit, action="/handle-submit"),
     )
-    def submitRenderer(self, form):
-        # type: (IRequest, RenderableForm) -> RenderableForm
+    def submitRenderer(self, form: RenderableForm) -> RenderableForm:
         return form
 
     @requirer.require(
         router.route("/render-custom", methods=["GET"]),
         form=Form.rendererFor(handler, action="/handle"),
     )
-    def customFormRender(self, form):
-        # type: (RenderableForm) -> Any
+    def customFormRender(self, form: RenderableForm) -> Any:
         """
         Include just the glue necessary for CSRF protection and let the
         application render the rest of the form.
@@ -148,13 +137,10 @@ class TestObject(object):
         router.route("/render-cascade", methods=["GET"]),
         form=Form.rendererFor(handler, action="/handle"),
     )
-    def cascadeRenderer(self, form):
-        # type: (RenderableForm) -> RenderableForm
-
+    def cascadeRenderer(self, form: RenderableForm) -> RenderableForm:
         class CustomElement(Element):
             @renderer
-            def customize(self, request, tag):
-                # type: (IRequest, Any) -> Any
+            def customize(self, request: IRequest, tag: Any) -> Any:
                 return tag("customized")
 
         form.validationErrors[form._form.fields[0]] = ValidationError(
@@ -167,15 +153,13 @@ class TestObject(object):
         router.route("/handle-validation", methods=["POST"]),
         value=Field.number(maximum=10),
     )
-    def customValidation(self, value):
-        # type: (int) -> None
+    def customValidation(self, value: int) -> None:
         """
         never called.
         """
 
     @requirer.require(Form.onValidationFailureFor(customValidation))
-    def customFailureHandling(self, values):
-        # type: (RenderableForm) -> bytes
+    def customFailureHandling(self, values: RenderableForm) -> bytes:
         """
         Handle validation failure.
         """
@@ -183,8 +167,7 @@ class TestObject(object):
         return b"~special~"
 
     @requirer.require(router.route("/handle-empty", methods=["POST"]),)
-    def emptyHandler(self):
-        # type: () -> bytes
+    def emptyHandler(self) -> bytes:
         """
         Empty form handler; just for testing rendering.
         """
@@ -193,13 +176,11 @@ class TestObject(object):
         router.route("/render-empty", methods=["GET"]),
         form=Form.rendererFor(emptyHandler, action="/handle-empty"),
     )
-    def emptyRenderer(self, form):
-        # type: (RenderableForm) -> RenderableForm
+    def emptyRenderer(self, form: RenderableForm) -> RenderableForm:
         return form
 
 
-def simpleFormRouter():
-    # type: () -> Tuple[Klein, List[Tuple[str, int]]]
+def simpleFormRouter() -> Tuple[Klein, List[Tuple[str, int]]]:
     """
     Create a simple router hooked up to a field handler.
     """
@@ -213,8 +194,7 @@ def simpleFormRouter():
         value=Field.number(),
         custom=Field(formInputType="number", converter=int, required=False),
     )
-    def justGet(name, value, custom):
-        # type: (str, int, int) -> bytes
+    def justGet(name: str, value: int, custom: int) -> bytes:
         calls.append((name, value or custom))
         return b"got"
 
@@ -226,19 +206,17 @@ class TestForms(SynchronousTestCase):
     Tests for L{klein.Form} and associated tools.
     """
 
-    def test_textConverter(self):
-        # type: () -> None
+    def test_textConverter(self) -> None:
         """
         Convert a string of either type to text.
         """
         text = "f\xf6o"
         for string in (text, text.encode("utf-8")):
             result = textConverter(string)  # type: ignore[type-var]
-            self.assertIsInstance(result, Text)
+            self.assertIsInstance(result, str)
             self.assertEqual(result, text)
 
-    def test_handling(self):
-        # type: () -> None
+    def test_handling(self) -> None:
         """
         A handler for a Form with Fields receives those fields as input, as
         passed by an HTTP client.
@@ -262,8 +240,7 @@ class TestForms(SynchronousTestCase):
         self.assertEqual(self.successResultOf(content(response)), b"yay")
         self.assertEqual(to.calls, [("hello", 1234)])
 
-    def test_handlingPassword(self):
-        # type: () -> None
+    def test_handlingPassword(self) -> None:
         """
         From the perspective of form handling, passwords are handled like
         strings.
@@ -289,8 +266,7 @@ class TestForms(SynchronousTestCase):
         )
         self.assertEqual(to.calls, [("password", "asdfjkl;")])
 
-    def test_numberConstraints(self):
-        # type: () -> None
+    def test_numberConstraints(self) -> None:
         """
         Number parameters have minimum and maximum validations and the object
         will not be called when the values exceed them.
@@ -331,8 +307,7 @@ class TestForms(SynchronousTestCase):
         self.assertEqual(self.successResultOf(content(justRight)), b"got it")
         self.assertEqual(to.calls, [("constrained", 7)])
 
-    def test_missingRequiredParameter(self):
-        # type: () -> None
+    def test_missingRequiredParameter(self) -> None:
         """
         If required fields are missing, a default error form is presented and
         the form's handler is not called.
@@ -359,8 +334,7 @@ class TestForms(SynchronousTestCase):
         )
         self.assertEqual(to.calls, [])
 
-    def test_noName(self):
-        # type: () -> None
+    def test_noName(self) -> None:
         """
         A handler for a Form with a Field that doesn't have a name will return
         an error explaining the problem.
@@ -385,8 +359,7 @@ class TestForms(SynchronousTestCase):
             str(errors[0].value), "Cannot extract unnamed form field."
         )
 
-    def test_handlingGET(self):
-        # type: () -> None
+    def test_handlingGET(self) -> None:
         """
         A GET handler for a Form with Fields receives query parameters matching
         those field names as input.
@@ -404,8 +377,7 @@ class TestForms(SynchronousTestCase):
         self.assertEqual(self.successResultOf(content(response)), b"got")
         self.assertEqual(calls, [("hello, big world", 4321)])
 
-    def test_validatingParameters(self):
-        # type: () -> None
+    def test_validatingParameters(self) -> None:
         """
         When a parameter fails to validate - for example, a non-number passed
         to a numeric Field, the request fails with a 400 and the default
@@ -432,8 +404,7 @@ class TestForms(SynchronousTestCase):
         self.assertEqual(len(errors), 1)
         self.assertEquals(errors[0].text, "not a valid number")
 
-    def test_customParameterValidation(self):
-        # type: () -> None
+    def test_customParameterValidation(self) -> None:
         """
         When a custom parameter fails to validate by raising ValueError - for
         example, a non-number passed to a numeric Field, the request fails with
@@ -465,8 +436,7 @@ class TestForms(SynchronousTestCase):
             errorText, "invalid literal for int() with base 10: 'not a number'",
         )
 
-    def test_handlingJSON(self):
-        # type: () -> None
+    def test_handlingJSON(self) -> None:
         """
         A handler for a form with Fields receives those fields as input, as
         passed by an HTTP client that submits a JSON POST body.
@@ -490,8 +460,7 @@ class TestForms(SynchronousTestCase):
         self.assertEqual(self.successResultOf(content(response)), b"yay")
         self.assertEqual(to.calls, [("hello", 1234)])
 
-    def test_missingOptionalParameterJSON(self):
-        # type: () -> None
+    def test_missingOptionalParameterJSON(self) -> None:
         """
         If a required Field is missing from the JSON body, its default value is
         used.
@@ -524,8 +493,7 @@ class TestForms(SynchronousTestCase):
         self.assertEqual(self.successResultOf(content(response2)), b"okay")
         self.assertEqual(to.calls, [("one", 7.0), ("two", 2.0)])
 
-    def test_rendering(self):
-        # type: () -> None
+    def test_rendering(self) -> None:
         """
         When a route requires form fields, it renders a form with those fields.
         """
@@ -555,8 +523,7 @@ class TestForms(SynchronousTestCase):
             submitButton[0].attrib["name"], "__klein_auto_submit__"
         )
 
-    def test_renderingExplicitSubmit(self):
-        # type: () -> None
+    def test_renderingExplicitSubmit(self) -> None:
         """
         When a form renderer specifies a submit button, no automatic submit
         button is rendered.
@@ -585,8 +552,7 @@ class TestForms(SynchronousTestCase):
         self.assertEqual(len(submitButton), 1)
         self.assertEqual(submitButton[0].attrib["name"], "button")
 
-    def test_renderingFormGlue(self):
-        # type: () -> None
+    def test_renderingFormGlue(self) -> None:
         """
         When a form renderer renders just the glue, none of the rest of the
         form is included.
@@ -618,8 +584,7 @@ class TestForms(SynchronousTestCase):
         )
         self.assertEqual(protectionField[0].attrib["value"], session.identifier)
 
-    def test_renderingEmptyForm(self):
-        # type: () -> None
+    def test_renderingEmptyForm(self) -> None:
         """
         When a form renderer specifies a submit button, no automatic submit
         button is rendered.
@@ -654,8 +619,7 @@ class TestForms(SynchronousTestCase):
         )
         self.assertEqual(protectionField[0].attrib["value"], session.identifier)
 
-    def test_renderLookupError(self):
-        # type: () -> None
+    def test_renderLookupError(self) -> None:
         """
         RenderableForm raises L{MissingRenderMethod} if anything attempst to
         look up a render method on it.
@@ -679,8 +643,7 @@ class TestForms(SynchronousTestCase):
         self.assertEqual(len(failures), 1)
         self.assertIn("MissingRenderMethod", str(failures[0]))
 
-    def test_customValidationHandling(self):
-        # type: () -> None
+    def test_customValidationHandling(self) -> None:
         """
         L{Form.onValidationFailureFor} handles form validation failures by
         handing its thing a renderable form.
@@ -714,8 +677,7 @@ class TestForms(SynchronousTestCase):
             [("value", 300)],
         )
 
-    def test_renderingWithNoSessionYet(self):
-        # type: () -> None
+    def test_renderingWithNoSessionYet(self) -> None:
         """
         When a route is rendered with no session, it sets a cookie to establish
         a new session.
@@ -731,8 +693,7 @@ class TestForms(SynchronousTestCase):
             actual = actual.decode("utf-8")
         self.assertIn(expected, actual)
 
-    def test_noSessionPOST(self):
-        # type: () -> None
+    def test_noSessionPOST(self) -> None:
         """
         An unauthenticated, CSRF-protected form will return a 403 Forbidden
         status code.
@@ -750,8 +711,7 @@ class TestForms(SynchronousTestCase):
         self.assertEqual(response.code, 403)
         self.assertIn(b"CSRF", self.successResultOf(content(response)))
 
-    def test_cookieNoToken(self):
-        # type: () -> None
+    def test_cookieNoToken(self) -> None:
         """
         A cookie-authenticated, CSRF-protected form will return a 403 Forbidden
         status code when a CSRF protection token is not supplied.
@@ -775,8 +735,7 @@ class TestForms(SynchronousTestCase):
         self.assertEqual(response.code, 403)
         self.assertIn(b"CSRF", self.successResultOf(content(response)))
 
-    def test_cookieWithToken(self):
-        # type: () -> None
+    def test_cookieWithToken(self) -> None:
         """
         A cookie-authenticated, CRSF-protected form will call the form as
         expected.

--- a/src/klein/test/test_headers.py
+++ b/src/klein/test/test_headers.py
@@ -6,7 +6,7 @@ Tests for L{klein._headers}.
 """
 
 from collections import defaultdict
-from typing import AnyStr, Dict, Iterable, List, Optional, Text, Tuple, cast
+from typing import AnyStr, Dict, Iterable, List, Optional, Tuple, cast
 
 from hypothesis import given
 from hypothesis.strategies import binary, iterables, text, tuples
@@ -36,22 +36,22 @@ __all__ = ()
 
 
 def encodeName(name):
-    # type: (Text) -> Optional[bytes]
+    # type: (str) -> Optional[bytes]
     return name.encode(HEADER_NAME_ENCODING)
 
 
 def encodeValue(name):
-    # type: (Text) -> Optional[bytes]
+    # type: (str) -> Optional[bytes]
     return name.encode(HEADER_VALUE_ENCODING)
 
 
 def decodeName(name):
-    # type: (bytes) -> Text
+    # type: (bytes) -> str
     return name.decode(HEADER_NAME_ENCODING)
 
 
 def decodeValue(name):
-    # type: (bytes) -> Text
+    # type: (bytes) -> str
     return name.decode(HEADER_VALUE_ENCODING)
 
 
@@ -86,9 +86,9 @@ class EncodingTests(TestCase):
 
     @given(latin1_text(min_size=1))
     def test_headerNameAsBytesWithText(self, name):
-        # type: (Text) -> None
+        # type: (str) -> None
         """
-        L{headerNameAsBytes} encodes L{Text} using L{HEADER_NAME_ENCODING}.
+        L{headerNameAsBytes} encodes L{str} using L{HEADER_NAME_ENCODING}.
         """
         rawName = encodeName(name)
         self.assertEqual(headerNameAsBytes(name), rawName)
@@ -103,9 +103,9 @@ class EncodingTests(TestCase):
 
     @given(text(min_size=1))
     def test_headerNameAsTextWithText(self, name):
-        # type: (Text) -> None
+        # type: (str) -> None
         """
-        L{headerNameAsText} passes through L{Text}.
+        L{headerNameAsText} passes through L{str}.
         """
         self.assertIdentical(headerNameAsText(name), name)
 
@@ -119,9 +119,9 @@ class EncodingTests(TestCase):
 
     @given(latin1_text(min_size=1))
     def test_headerValueAsBytesWithText(self, value):
-        # type: (Text) -> None
+        # type: (str) -> None
         """
-        L{headerValueAsBytes} encodes L{Text} using L{HEADER_VALUE_ENCODING}.
+        L{headerValueAsBytes} encodes L{str} using L{HEADER_VALUE_ENCODING}.
         """
         rawValue = encodeValue(value)
         self.assertEqual(headerValueAsBytes(value), rawValue)
@@ -136,9 +136,9 @@ class EncodingTests(TestCase):
 
     @given(text(min_size=1))
     def test_headerValueAsTextWithText(self, value):
-        # type: (Text) -> None
+        # type: (str) -> None
         """
-        L{headerValueAsText} passes through L{Text}.
+        L{headerValueAsText} passes through L{str}.
         """
         self.assertIdentical(headerValueAsText(value), value)
 
@@ -179,7 +179,7 @@ class RawHeadersConversionTests(TestCase):
 
     @given(latin1_text())
     def test_pairNameText(self, name):
-        # type: (Text) -> None
+        # type: (str) -> None
         """
         L{normalizeRawHeaders} converts ISO-8859-1-encodable text names into
         bytes.
@@ -194,7 +194,7 @@ class RawHeadersConversionTests(TestCase):
 
     @given(latin1_text())
     def test_pairValueText(self, value):
-        # type: (Text) -> None
+        # type: (str) -> None
         """
         L{normalizeRawHeaders} converts ISO-8859-1-encodable text values into
         bytes.
@@ -245,7 +245,7 @@ class GetValuesTestsMixIn(object):
             )
 
     def headerNormalize(self, value):
-        # type: (Text) -> Text
+        # type: (str) -> str
         """
         Test hook for the normalization of header text values, which is a
         behavior Twisted has changed after version 18.9.0.
@@ -254,10 +254,10 @@ class GetValuesTestsMixIn(object):
 
     @given(iterables(tuples(ascii_text(min_size=1), latin1_text())))
     def test_getTextName(self, textPairs):
-        # type: (Iterable[Tuple[Text, Text]]) -> None
+        # type: (Iterable[Tuple[str, str]]) -> None
         """
-        C{getValues} returns an iterable of L{Text} values for
-        the given L{Text} header name.
+        C{getValues} returns an iterable of L{str} values for
+        the given L{str} header name.
 
         This test only inserts Latin1 text into the header values, which is
         valid data.
@@ -266,7 +266,7 @@ class GetValuesTestsMixIn(object):
             (name, headerValueSanitize(value)) for name, value in textPairs
         )
 
-        textValues = defaultdict(list)  # type: Dict[Text, List[Text]]
+        textValues = defaultdict(list)  # type: Dict[str, List[str]]
         for name, value in textHeaders:
             textValues[normalizeHeaderName(name)].append(value)
 
@@ -284,10 +284,10 @@ class GetValuesTestsMixIn(object):
 
     @given(iterables(tuples(ascii_text(min_size=1), binary())))
     def test_getTextNameBinaryValues(self, pairs):
-        # type: (Iterable[Tuple[Text, bytes]]) -> None
+        # type: (Iterable[Tuple[str, bytes]]) -> None
         """
-        C{getValues} returns an iterable of L{Text} values for
-        the given L{Text} header name.
+        C{getValues} returns an iterable of L{str} values for
+        the given L{str} header name.
 
         This test only inserts binary data into the header values, which
         includes invalid data if you are a sane person, but arguably
@@ -300,7 +300,7 @@ class GetValuesTestsMixIn(object):
             for name, value in pairs
         )
 
-        binaryValues = defaultdict(list)  # type: Dict[Text, List[bytes]]
+        binaryValues = defaultdict(list)  # type: Dict[str, List[bytes]]
         for name, value in rawHeaders:
             binaryValues[headerNameAsText(normalizeHeaderName(name))].append(
                 value
@@ -423,7 +423,7 @@ class MutableHTTPHeadersTestsMixIn(GetValuesTestsMixIn):
     def test_removeTextName(self):
         # type: () -> None
         """
-        L{IMutableHTTPHeaders.remove} removes all values for the given L{Text}
+        L{IMutableHTTPHeaders.remove} removes all values for the given L{str}
         header name.
         """
         rawHeaders = ((b"a", b"1"), (b"b", b"2a"), (b"c", b"3"), (b"b", b"2b"))
@@ -466,8 +466,8 @@ class MutableHTTPHeadersTestsMixIn(GetValuesTestsMixIn):
     def test_addValueTextName(self):
         # type: () -> None
         """
-        L{IMutableHTTPHeaders.addValue} adds the given L{Text} value for the
-        given L{Text} header name.
+        L{IMutableHTTPHeaders.addValue} adds the given L{str} value for the
+        given L{str} header name.
         """
         rawHeaders = ((b"a", b"1"), (b"b", b"2a"))
         headers = self.headers(rawHeaders=rawHeaders)
@@ -481,7 +481,7 @@ class MutableHTTPHeadersTestsMixIn(GetValuesTestsMixIn):
         # type: () -> None
         """
         L{IMutableHTTPHeaders.addValue} raises L{TypeError} when the given
-        header name is L{bytes} and the given value is L{Text}.
+        header name is L{bytes} and the given value is L{str}.
         """
         headers = self.headers(rawHeaders=())
 
@@ -496,7 +496,7 @@ class MutableHTTPHeadersTestsMixIn(GetValuesTestsMixIn):
         # type: () -> None
         """
         L{IMutableHTTPHeaders.addValue} raises L{TypeError} when the given
-        header name is L{Text} and the given value is L{bytes}.
+        header name is L{str} and the given value is L{bytes}.
         """
         headers = self.headers(rawHeaders=())
 

--- a/src/klein/test/test_headers.py
+++ b/src/klein/test/test_headers.py
@@ -35,28 +35,23 @@ from .._headers import (
 __all__ = ()
 
 
-def encodeName(name):
-    # type: (str) -> Optional[bytes]
+def encodeName(name: str) -> Optional[bytes]:
     return name.encode(HEADER_NAME_ENCODING)
 
 
-def encodeValue(name):
-    # type: (str) -> Optional[bytes]
+def encodeValue(name: str) -> Optional[bytes]:
     return name.encode(HEADER_VALUE_ENCODING)
 
 
-def decodeName(name):
-    # type: (bytes) -> str
+def decodeName(name: bytes) -> str:
     return name.decode(HEADER_NAME_ENCODING)
 
 
-def decodeValue(name):
-    # type: (bytes) -> str
+def decodeValue(name: bytes) -> str:
     return name.decode(HEADER_VALUE_ENCODING)
 
 
-def headerValueSanitize(value):
-    # type: (AnyStr) -> AnyStr
+def headerValueSanitize(value: AnyStr) -> AnyStr:
     """
     Sanitize a header value by replacing linear whitespace with spaces.
     """
@@ -77,16 +72,14 @@ class EncodingTests(TestCase):
     """
 
     @given(binary())
-    def test_headerNameAsBytesWithBytes(self, name):
-        # type: (bytes) -> None
+    def test_headerNameAsBytesWithBytes(self, name: bytes) -> None:
         """
         L{headerNameAsBytes} passes through L{bytes}.
         """
         self.assertIdentical(headerNameAsBytes(name), name)
 
     @given(latin1_text(min_size=1))
-    def test_headerNameAsBytesWithText(self, name):
-        # type: (str) -> None
+    def test_headerNameAsBytesWithText(self, name: str) -> None:
         """
         L{headerNameAsBytes} encodes L{str} using L{HEADER_NAME_ENCODING}.
         """
@@ -94,32 +87,28 @@ class EncodingTests(TestCase):
         self.assertEqual(headerNameAsBytes(name), rawName)
 
     @given(binary())
-    def test_headerNameAsTextWithBytes(self, name):
-        # type: (bytes) -> None
+    def test_headerNameAsTextWithBytes(self, name: bytes) -> None:
         """
         L{headerNameAsText} decodes L{bytes} using L{HEADER_NAME_ENCODING}.
         """
         self.assertEqual(headerNameAsText(name), decodeName(name))
 
     @given(text(min_size=1))
-    def test_headerNameAsTextWithText(self, name):
-        # type: (str) -> None
+    def test_headerNameAsTextWithText(self, name: str) -> None:
         """
         L{headerNameAsText} passes through L{str}.
         """
         self.assertIdentical(headerNameAsText(name), name)
 
     @given(binary())
-    def test_headerValueAsBytesWithBytes(self, value):
-        # type: (bytes) -> None
+    def test_headerValueAsBytesWithBytes(self, value: bytes) -> None:
         """
         L{headerValueAsBytes} passes through L{bytes}.
         """
         self.assertIdentical(headerValueAsBytes(value), value)
 
     @given(latin1_text(min_size=1))
-    def test_headerValueAsBytesWithText(self, value):
-        # type: (str) -> None
+    def test_headerValueAsBytesWithText(self, value: str) -> None:
         """
         L{headerValueAsBytes} encodes L{str} using L{HEADER_VALUE_ENCODING}.
         """
@@ -127,16 +116,14 @@ class EncodingTests(TestCase):
         self.assertEqual(headerValueAsBytes(value), rawValue)
 
     @given(binary())
-    def test_headerValueAsTextWithBytes(self, value):
-        # type: (bytes) -> None
+    def test_headerValueAsTextWithBytes(self, value: bytes) -> None:
         """
         L{headerValueAsText} decodes L{bytes} using L{HEADER_VALUE_ENCODING}.
         """
         self.assertEqual(headerValueAsText(value), decodeValue(value))
 
     @given(text(min_size=1))
-    def test_headerValueAsTextWithText(self, value):
-        # type: (str) -> None
+    def test_headerValueAsTextWithText(self, value: str) -> None:
         """
         L{headerValueAsText} passes through L{str}.
         """
@@ -148,8 +135,7 @@ class HeaderNameNormalizationTests(TestCase):
     Tests for header name normalization.
     """
 
-    def test_normalizeLowerCase(self):
-        # type: () -> None
+    def test_normalizeLowerCase(self) -> None:
         """
         L{normalizeHeaderName} normalizes header names to lower case.
         """
@@ -161,8 +147,7 @@ class RawHeadersConversionTests(TestCase):
     Tests for L{normalizeRawHeaders}.
     """
 
-    def test_pairWrongLength(self):
-        # type: () -> None
+    def test_pairWrongLength(self) -> None:
         """
         L{normalizeRawHeaders} raises L{ValueError} if the C{headerPairs}
         argument is not an iterable of 2-item iterables.
@@ -178,8 +163,7 @@ class RawHeadersConversionTests(TestCase):
             self.assertEqual(str(e), "header pair must be a 2-item iterable")
 
     @given(latin1_text())
-    def test_pairNameText(self, name):
-        # type: (str) -> None
+    def test_pairNameText(self, name: str) -> None:
         """
         L{normalizeRawHeaders} converts ISO-8859-1-encodable text names into
         bytes.
@@ -193,8 +177,7 @@ class RawHeadersConversionTests(TestCase):
         )
 
     @given(latin1_text())
-    def test_pairValueText(self, value):
-        # type: (str) -> None
+    def test_pairValueText(self, value: str) -> None:
         """
         L{normalizeRawHeaders} converts ISO-8859-1-encodable text values into
         bytes.
@@ -211,8 +194,9 @@ class GetValuesTestsMixIn(object):
     representation.
     """
 
-    def getValues(self, rawHeaders, name):
-        # type: (RawHeaders, AnyStr) -> Iterable[AnyStr]
+    def getValues(
+        self, rawHeaders: RawHeaders, name: AnyStr
+    ) -> Iterable[AnyStr]:
         """
         Look up the values for the given header name from the given raw
         headers.
@@ -225,8 +209,7 @@ class GetValuesTestsMixIn(object):
             "{} must implement getValues()".format(self.__class__)
         )
 
-    def test_getBytesName(self):
-        # type: () -> None
+    def test_getBytesName(self) -> None:
         """
         C{getValues} returns an iterable of L{bytes} values for the
         given L{bytes} header name.
@@ -244,8 +227,7 @@ class GetValuesTestsMixIn(object):
                 "header name: {!r}".format(name),
             )
 
-    def headerNormalize(self, value):
-        # type: (str) -> str
+    def headerNormalize(self, value: str) -> str:
         """
         Test hook for the normalization of header text values, which is a
         behavior Twisted has changed after version 18.9.0.
@@ -253,8 +235,7 @@ class GetValuesTestsMixIn(object):
         return value
 
     @given(iterables(tuples(ascii_text(min_size=1), latin1_text())))
-    def test_getTextName(self, textPairs):
-        # type: (Iterable[Tuple[str, str]]) -> None
+    def test_getTextName(self, textPairs: Iterable[Tuple[str, str]]) -> None:
         """
         C{getValues} returns an iterable of L{str} values for
         the given L{str} header name.
@@ -283,8 +264,9 @@ class GetValuesTestsMixIn(object):
             )
 
     @given(iterables(tuples(ascii_text(min_size=1), binary())))
-    def test_getTextNameBinaryValues(self, pairs):
-        # type: (Iterable[Tuple[str, bytes]]) -> None
+    def test_getTextNameBinaryValues(
+        self, pairs: Iterable[Tuple[str, bytes]]
+    ) -> None:
         """
         C{getValues} returns an iterable of L{str} values for
         the given L{str} header name.
@@ -316,8 +298,7 @@ class GetValuesTestsMixIn(object):
                 "header name: {!r}".format(textName),
             )
 
-    def test_getInvalidNameType(self):
-        # type: () -> None
+    def test_getInvalidNameType(self) -> None:
         """
         C{getValues} raises L{TypeError} when the given header name is of an
         unknown type.
@@ -336,8 +317,9 @@ class RawHeadersReadTests(GetValuesTestsMixIn, TestCase):
     representation.
     """
 
-    def getValues(self, rawHeaders, name):
-        # type: (RawHeaders, AnyStr) -> Iterable[AnyStr]
+    def getValues(
+        self, rawHeaders: RawHeaders, name: AnyStr
+    ) -> Iterable[AnyStr]:
         return getFromRawHeaders(normalizeRawHeadersFrozen(rawHeaders), name)
 
 
@@ -346,21 +328,20 @@ class FrozenHTTPHeadersTests(GetValuesTestsMixIn, TestCase):
     Tests for L{FrozenHTTPHeaders}.
     """
 
-    def getValues(self, rawHeaders, name):
-        # type: (RawHeaders, AnyStr) -> Iterable[AnyStr]
+    def getValues(
+        self, rawHeaders: RawHeaders, name: AnyStr
+    ) -> Iterable[AnyStr]:
         headers = FrozenHTTPHeaders(rawHeaders=rawHeaders)
         return headers.getValues(name=name)
 
-    def test_interface(self):
-        # type: () -> None
+    def test_interface(self) -> None:
         """
         L{FrozenHTTPHeaders} implements L{IHTTPHeaders}.
         """
         headers = FrozenHTTPHeaders(rawHeaders=())
         self.assertProvides(IHTTPHeaders, headers)
 
-    def test_defaultHeaders(self):
-        # type: () -> None
+    def test_defaultHeaders(self) -> None:
         """
         L{FrozenHTTPHeaders.rawHeaders} is empty by default.
         """
@@ -373,31 +354,30 @@ class MutableHTTPHeadersTestsMixIn(GetValuesTestsMixIn):
     Tests for L{IMutableHTTPHeaders} implementations.
     """
 
-    def assertRawHeadersEqual(self, rawHeaders1, rawHeaders2):
-        # type: (RawHeaders, RawHeaders) -> None
+    def assertRawHeadersEqual(
+        self, rawHeaders1: RawHeaders, rawHeaders2: RawHeaders
+    ) -> None:
         cast(TestCase, self).assertEqual(rawHeaders1, rawHeaders2)
 
-    def headers(self, rawHeaders):
-        # type: (RawHeaders) -> IMutableHTTPHeaders
+    def headers(self, rawHeaders: RawHeaders) -> IMutableHTTPHeaders:
         raise NotImplementedError(
             "{} must implement headers()".format(self.__class__)
         )
 
-    def getValues(self, rawHeaders, name):
-        # type: (RawHeaders, AnyStr) -> Iterable[AnyStr]
+    def getValues(
+        self, rawHeaders: RawHeaders, name: AnyStr
+    ) -> Iterable[AnyStr]:
         headers = self.headers(rawHeaders=rawHeaders)
         return headers.getValues(name=name)
 
-    def test_interface(self):
-        # type: () -> None
+    def test_interface(self) -> None:
         """
         Class implements L{IMutableHTTPHeaders}.
         """
         headers = self.headers(rawHeaders=())
         cast(TestCase, self).assertProvides(IMutableHTTPHeaders, headers)
 
-    def test_rawHeaders(self):
-        # type: () -> None
+    def test_rawHeaders(self) -> None:
         """
         L{IMutableHTTPHeaders.rawHeaders} equals the raw headers passed at init
         time as a tuple.
@@ -406,8 +386,7 @@ class MutableHTTPHeadersTestsMixIn(GetValuesTestsMixIn):
         headers = self.headers(rawHeaders=rawHeaders)
         self.assertRawHeadersEqual(headers.rawHeaders, tuple(rawHeaders))
 
-    def test_removeBytesName(self):
-        # type: () -> None
+    def test_removeBytesName(self) -> None:
         """
         L{IMutableHTTPHeaders.remove} removes all values for the given L{bytes}
         header name.
@@ -420,8 +399,7 @@ class MutableHTTPHeadersTestsMixIn(GetValuesTestsMixIn):
             headers.rawHeaders, ((b"a", b"1"), (b"c", b"3"))
         )
 
-    def test_removeTextName(self):
-        # type: () -> None
+    def test_removeTextName(self) -> None:
         """
         L{IMutableHTTPHeaders.remove} removes all values for the given L{str}
         header name.
@@ -434,8 +412,7 @@ class MutableHTTPHeadersTestsMixIn(GetValuesTestsMixIn):
             headers.rawHeaders, ((b"a", b"1"), (b"c", b"3"))
         )
 
-    def test_removeInvalidNameType(self):
-        # type: () -> None
+    def test_removeInvalidNameType(self) -> None:
         """
         L{IMutableHTTPHeaders.remove} raises L{TypeError} when the given header
         name is of an unknown type.
@@ -449,8 +426,7 @@ class MutableHTTPHeadersTestsMixIn(GetValuesTestsMixIn):
             str(e), "name <object object at 0x[0-9a-f]+> must be text or bytes"
         )
 
-    def test_addValueBytesName(self):
-        # type: () -> None
+    def test_addValueBytesName(self) -> None:
         """
         L{IMutableHTTPHeaders.addValue} adds the given L{bytes} value for the
         given L{bytes} header name.
@@ -463,8 +439,7 @@ class MutableHTTPHeadersTestsMixIn(GetValuesTestsMixIn):
             headers.rawHeaders, ((b"a", b"1"), (b"b", b"2a"), (b"b", b"2b"))
         )
 
-    def test_addValueTextName(self):
-        # type: () -> None
+    def test_addValueTextName(self) -> None:
         """
         L{IMutableHTTPHeaders.addValue} adds the given L{str} value for the
         given L{str} header name.
@@ -477,8 +452,7 @@ class MutableHTTPHeadersTestsMixIn(GetValuesTestsMixIn):
             headers.rawHeaders, ((b"a", b"1"), (b"b", b"2a"), (b"b", b"2b"))
         )
 
-    def test_addValueBytesNameTextValue(self):
-        # type: () -> None
+    def test_addValueBytesNameTextValue(self) -> None:
         """
         L{IMutableHTTPHeaders.addValue} raises L{TypeError} when the given
         header name is L{bytes} and the given value is L{str}.
@@ -492,8 +466,7 @@ class MutableHTTPHeadersTestsMixIn(GetValuesTestsMixIn):
             str(e), "value u?'1' must be bytes to match name b?'a'"
         )
 
-    def test_addValueTextNameBytesValue(self):
-        # type: () -> None
+    def test_addValueTextNameBytesValue(self) -> None:
         """
         L{IMutableHTTPHeaders.addValue} raises L{TypeError} when the given
         header name is L{str} and the given value is L{bytes}.
@@ -507,8 +480,7 @@ class MutableHTTPHeadersTestsMixIn(GetValuesTestsMixIn):
             str(e), "value b?'1' must be text to match name u?'a'"
         )
 
-    def test_addValueInvalidNameType(self):
-        # type: () -> None
+    def test_addValueInvalidNameType(self) -> None:
         """
         L{IMutableHTTPHeaders.addValue} raises L{TypeError} when the given
         header name is of an unknown type.
@@ -528,12 +500,10 @@ class MutableHTTPHeadersTests(MutableHTTPHeadersTestsMixIn, TestCase):
     Tests for L{MutableHTTPHeaders}.
     """
 
-    def headers(self, rawHeaders):
-        # type: (RawHeaders) -> IMutableHTTPHeaders
+    def headers(self, rawHeaders: RawHeaders) -> IMutableHTTPHeaders:
         return MutableHTTPHeaders(rawHeaders=rawHeaders)
 
-    def test_defaultHeaders(self):
-        # type: () -> None
+    def test_defaultHeaders(self) -> None:
         """
         L{MutableHTTPHeaders.rawHeaders} is empty by default.
         """

--- a/src/klein/test/test_headers.py
+++ b/src/klein/test/test_headers.py
@@ -216,7 +216,7 @@ class GetValuesTestsMixIn(object):
         """
         rawHeaders = ((b"a", b"1"), (b"b", b"2"), (b"c", b"3"), (b"B", b"TWO"))
 
-        normalized = defaultdict(list)  # type: Dict[bytes, List[bytes]]
+        normalized: Dict[bytes, List[bytes]] = defaultdict(list)
         for name, value in rawHeaders:
             normalized[normalizeHeaderName(name)].append(value)
 
@@ -247,7 +247,7 @@ class GetValuesTestsMixIn(object):
             (name, headerValueSanitize(value)) for name, value in textPairs
         )
 
-        textValues = defaultdict(list)  # type: Dict[str, List[str]]
+        textValues: Dict[str, List[str]] = defaultdict(list)
         for name, value in textHeaders:
             textValues[normalizeHeaderName(name)].append(value)
 
@@ -282,7 +282,7 @@ class GetValuesTestsMixIn(object):
             for name, value in pairs
         )
 
-        binaryValues = defaultdict(list)  # type: Dict[str, List[bytes]]
+        binaryValues: Dict[str, List[bytes]] = defaultdict(list)
         for name, value in rawHeaders:
             binaryValues[headerNameAsText(normalizeHeaderName(name))].append(
                 value

--- a/src/klein/test/test_headers.py
+++ b/src/klein/test/test_headers.py
@@ -307,7 +307,7 @@ class GetValuesTestsMixIn(object):
             TypeError, self.getValues, (), object()
         )
         cast(TestCase, self).assertRegex(
-            str(e), "name <object object at 0x[0-9a-f]+> must be text or bytes"
+            str(e), "name <object object at 0x[0-9a-f]+> must be str or bytes"
         )
 
 
@@ -423,7 +423,7 @@ class MutableHTTPHeadersTestsMixIn(GetValuesTestsMixIn):
             TypeError, headers.remove, object()
         )
         cast(TestCase, self).assertRegex(
-            str(e), "name <object object at 0x[0-9a-f]+> must be text or bytes"
+            str(e), "name <object object at 0x[0-9a-f]+> must be str or bytes"
         )
 
     def test_addValueBytesName(self) -> None:
@@ -477,7 +477,7 @@ class MutableHTTPHeadersTestsMixIn(GetValuesTestsMixIn):
             TypeError, headers.addValue, "a", b"1"
         )
         cast(TestCase, self).assertRegex(
-            str(e), "value b?'1' must be text to match name u?'a'"
+            str(e), "value b?'1' must be str to match name u?'a'"
         )
 
     def test_addValueInvalidNameType(self) -> None:
@@ -491,7 +491,7 @@ class MutableHTTPHeadersTestsMixIn(GetValuesTestsMixIn):
             TypeError, headers.addValue, object(), b"1"
         )
         cast(TestCase, self).assertRegex(
-            str(e), "name <object object at 0x[0-9a-f]+> must be text or bytes"
+            str(e), "name <object object at 0x[0-9a-f]+> must be str or bytes"
         )
 
 

--- a/src/klein/test/test_headers_compat.py
+++ b/src/klein/test/test_headers_compat.py
@@ -5,7 +5,7 @@
 Tests for L{klein._headers}.
 """
 
-from typing import Text, cast
+from typing import cast
 
 from twisted.web.http_headers import Headers
 
@@ -25,7 +25,7 @@ except ImportError:
 
 
 def _twistedHeaderNormalize(value):
-    # type: (Text) -> Text
+    # type: (str) -> str
     """
     Normalize the given header value according to the rules of the installed
     Twisted version.
@@ -34,7 +34,7 @@ def _twistedHeaderNormalize(value):
         return value
     else:
         return cast(
-            Text,
+            str,
             _sanitizeLinearWhitespace(value.encode("utf-8")).decode("utf-8"),
         )
 
@@ -54,7 +54,7 @@ class HTTPHeadersWrappingHeadersTests(MutableHTTPHeadersTestsMixIn, TestCase):
         )
 
     def headerNormalize(self, value):
-        # type: (Text) -> Text
+        # type: (str) -> str
         return _twistedHeaderNormalize(value)
 
     def headers(self, rawHeaders):

--- a/src/klein/test/test_headers_compat.py
+++ b/src/klein/test/test_headers_compat.py
@@ -24,8 +24,7 @@ except ImportError:
     _sanitizeLinearWhitespace = None
 
 
-def _twistedHeaderNormalize(value):
-    # type: (str) -> str
+def _twistedHeaderNormalize(value: str) -> str:
     """
     Normalize the given header value according to the rules of the installed
     Twisted version.
@@ -47,26 +46,24 @@ class HTTPHeadersWrappingHeadersTests(MutableHTTPHeadersTestsMixIn, TestCase):
     Tests for L{HTTPHeadersWrappingHeaders}.
     """
 
-    def assertRawHeadersEqual(self, rawHeaders1, rawHeaders2):
-        # type: (RawHeaders, RawHeaders) -> None
+    def assertRawHeadersEqual(
+        self, rawHeaders1: RawHeaders, rawHeaders2: RawHeaders
+    ) -> None:
         super(HTTPHeadersWrappingHeadersTests, self).assertRawHeadersEqual(
             sorted(rawHeaders1), sorted(rawHeaders2)
         )
 
-    def headerNormalize(self, value):
-        # type: (str) -> str
+    def headerNormalize(self, value: str) -> str:
         return _twistedHeaderNormalize(value)
 
-    def headers(self, rawHeaders):
-        # type: (RawHeaders) -> IMutableHTTPHeaders
+    def headers(self, rawHeaders: RawHeaders) -> IMutableHTTPHeaders:
         headers = Headers()
         for rawName, rawValue in rawHeaders:
             headers.addRawHeader(rawName, rawValue)
 
         return HTTPHeadersWrappingHeaders(headers=headers)
 
-    def test_rawHeaders(self):
-        # type: () -> None
+    def test_rawHeaders(self) -> None:
         """
         L{MutableHTTPHeaders.rawHeaders} equals raw headers matching the
         L{Headers} given at init time.

--- a/src/klein/test/test_memory.py
+++ b/src/klein/test/test_memory.py
@@ -26,8 +26,7 @@ class MemoryTests(SynchronousTestCase):
     Tests for memory-based session storage.
     """
 
-    def test_interfaceCompliance(self):
-        # type: () -> None
+    def test_interfaceCompliance(self) -> None:
         """
         Verify that the session store complies with the relevant interfaces.
         """
@@ -40,8 +39,7 @@ class MemoryTests(SynchronousTestCase):
             ),
         )
 
-    def test_noAuthorizers(self):
-        # type: () -> None
+    def test_noAuthorizers(self) -> None:
         """
         By default, L{MemorySessionStore} contains no authorizers and the
         sessions it returns will authorize any supplied interfaces as None.
@@ -54,8 +52,7 @@ class MemoryTests(SynchronousTestCase):
             self.successResultOf(session.authorize([IFoo, IBar])), {}
         )
 
-    def test_simpleAuthorization(self):
-        # type: () -> None
+    def test_simpleAuthorization(self) -> None:
         """
         L{MemorySessionStore.fromAuthorizers} takes a set of functions
         decorated with L{declareMemoryAuthorizer} and constructs a session
@@ -63,13 +60,11 @@ class MemoryTests(SynchronousTestCase):
         """
 
         @declareMemoryAuthorizer(IFoo)
-        def fooMe(interface, session, componentized):
-            # type: (Any, Any, Any) -> int
+        def fooMe(interface: Any, session: Any, componentized: Any) -> int:
             return 1
 
         @declareMemoryAuthorizer(IBar)
-        def barMe(interface, session, componentized):
-            # type: (Any, Any, Any) -> int
+        def barMe(interface: Any, session: Any, componentized: Any) -> int:
             return 2
 
         store = MemorySessionStore.fromAuthorizers([fooMe, barMe])

--- a/src/klein/test/test_message.py
+++ b/src/klein/test/test_message.py
@@ -24,8 +24,7 @@ class FrozenHTTPMessageTestsMixIn(object):
     """
 
     @classmethod
-    def messageFromBytes(cls, data=b""):
-        # type: (bytes) -> IHTTPMessage
+    def messageFromBytes(cls, data: bytes = b"") -> IHTTPMessage:
         """
         Return a new instance of an L{IHTTPMessage} implementation using the
         given bytes as the message body.
@@ -33,16 +32,14 @@ class FrozenHTTPMessageTestsMixIn(object):
         raise NotImplementedError("{} must implement getValues()".format(cls))
 
     @classmethod
-    def messageFromFountFromBytes(cls, data=b""):
-        # type: (bytes) -> IHTTPMessage
+    def messageFromFountFromBytes(cls, data: bytes = b"") -> IHTTPMessage:
         """
         Return a new instance of an L{IHTTPMessage} implementation using a
         fount containing the given bytes as the message body.
         """
         return cls.messageFromBytes(bytesToFount(data))
 
-    def test_interface_message(self):
-        # type: () -> None
+    def test_interface_message(self) -> None:
         """
         Message instance implements L{IHTTPMessage}.
         """
@@ -50,8 +47,7 @@ class FrozenHTTPMessageTestsMixIn(object):
         cast(TestCase, self).assertProvides(IHTTPMessage, message)
 
     @given(binary())
-    def test_bodyAsFountFromBytes(self, data):
-        # type: (bytes) -> None
+    def test_bodyAsFountFromBytes(self, data: bytes) -> None:
         """
         C{bodyAsFount} returns a fount with the same bytes given to
         C{__init__}.
@@ -63,8 +59,7 @@ class FrozenHTTPMessageTestsMixIn(object):
         cast(TestCase, self).assertEqual(body, data)
 
     @given(binary())
-    def test_bodyAsFountFromBytesTwice(self, data):
-        # type: (bytes) -> None
+    def test_bodyAsFountFromBytesTwice(self, data: bytes) -> None:
         """
         C{bodyAsFount} raises L{FountAlreadyAccessedError} if called more than
         once, when created from bytes.
@@ -76,8 +71,7 @@ class FrozenHTTPMessageTestsMixIn(object):
         )
 
     @given(binary())
-    def test_bodyAsFountFromFount(self, data):
-        # type: (bytes) -> None
+    def test_bodyAsFountFromFount(self, data: bytes) -> None:
         """
         C{bodyAsBytes} returns the bytes from the fount given to C{__init__}.
         """
@@ -88,8 +82,7 @@ class FrozenHTTPMessageTestsMixIn(object):
         cast(TestCase, self).assertEqual(body, data)
 
     @given(binary())
-    def test_bodyAsFountFromFountTwice(self, data):
-        # type: (bytes) -> None
+    def test_bodyAsFountFromFountTwice(self, data: bytes) -> None:
         """
         C{bodyAsFount} raises L{FountAlreadyAccessedError} if called more than
         once, when created from a fount.
@@ -101,8 +94,7 @@ class FrozenHTTPMessageTestsMixIn(object):
         )
 
     @given(binary())
-    def test_bodyAsBytesFromBytes(self, data):
-        # type: (bytes) -> None
+    def test_bodyAsBytesFromBytes(self, data: bytes) -> None:
         """
         C{bodyAsBytes} returns the same bytes given to C{__init__}.
         """
@@ -112,8 +104,7 @@ class FrozenHTTPMessageTestsMixIn(object):
         cast(TestCase, self).assertEqual(body, data)
 
     @given(binary())
-    def test_bodyAsBytesFromBytesCached(self, data):
-        # type: (bytes) -> None
+    def test_bodyAsBytesFromBytesCached(self, data: bytes) -> None:
         """
         C{bodyAsBytes} called twice returns the same object both times, when
         created from bytes.
@@ -125,8 +116,7 @@ class FrozenHTTPMessageTestsMixIn(object):
         cast(TestCase, self).assertIdentical(body1, body2)
 
     @given(binary())
-    def test_bodyAsBytesFromFount(self, data):
-        # type: (bytes) -> None
+    def test_bodyAsBytesFromFount(self, data: bytes) -> None:
         """
         C{bodyAsBytes} returns the bytes from the fount given to C{__init__}.
         """
@@ -135,8 +125,7 @@ class FrozenHTTPMessageTestsMixIn(object):
         cast(TestCase, self).assertEqual(body, data)
 
     @given(binary())
-    def test_bodyAsBytesFromFountCached(self, data):
-        # type: (bytes) -> None
+    def test_bodyAsBytesFromFountCached(self, data: bytes) -> None:
         """
         C{bodyAsBytes} called twice returns the same object both times, when
         created from a fount.

--- a/src/klein/test/test_plating.py
+++ b/src/klein/test/test_plating.py
@@ -11,6 +11,7 @@ from __future__ import (
 
 import json
 from string import printable
+from typing import Any
 
 import attr
 
@@ -108,8 +109,8 @@ class DeferredValue(object):
     @param deferred: The L{Deferred} representing the value.
     """
 
-    value = attr.ib()  # type: object
-    deferred = attr.ib(attr.Factory(Deferred))  # type: Deferred
+    value: Any = attr.ib()
+    deferred: Deferred = attr.ib(attr.Factory(Deferred))
 
     def resolve(self):
         """

--- a/src/klein/test/test_request.py
+++ b/src/klein/test/test_request.py
@@ -23,8 +23,7 @@ class FrozenHTTPRequestTests(FrozenHTTPMessageTestsMixIn, TestCase):
     """
 
     @staticmethod
-    def requestFromBytes(data=b""):
-        # type: (bytes) -> FrozenHTTPRequest
+    def requestFromBytes(data: bytes = b"") -> FrozenHTTPRequest:
         return FrozenHTTPRequest(
             method="GET",
             uri=DecodedURL.fromText("https://twistedmatrix.com/"),
@@ -33,20 +32,17 @@ class FrozenHTTPRequestTests(FrozenHTTPMessageTestsMixIn, TestCase):
         )
 
     @classmethod
-    def messageFromBytes(cls, data=b""):
-        # type: (bytes) -> IHTTPMessage
+    def messageFromBytes(cls, data: bytes = b"") -> IHTTPMessage:
         return cls.requestFromBytes(data)
 
-    def test_interface(self):
-        # type: () -> None
+    def test_interface(self) -> None:
         """
         L{FrozenHTTPRequest} implements L{IHTTPRequest}.
         """
         request = self.requestFromBytes()
         self.assertProvides(IHTTPRequest, request)
 
-    def test_initInvalidBodyType(self):
-        # type: () -> None
+    def test_initInvalidBodyType(self) -> None:
         """
         L{FrozenHTTPRequest} raises L{TypeError} when given a body of an
         unknown type.

--- a/src/klein/test/test_request_compat.py
+++ b/src/klein/test/test_request_compat.py
@@ -35,15 +35,14 @@ class HTTPRequestWrappingIRequestTests(TestCase):
 
     def legacyRequest(
         self,
-        path=b"/",  # type: bytes
-        method=b"GET",  # type: bytes
-        host=b"localhost",  # type: bytes
-        port=8080,  # type: int
-        isSecure=False,  # type: bool
-        body=None,  # type: Optional[bytes]
-        headers=None,  # type: Optional[Headers]
-    ):
-        # type: (...) -> IRequest
+        path: bytes = b"/",
+        method: bytes = b"GET",
+        host: bytes = b"localhost",
+        port: int = 8080,
+        isSecure: bool = False,
+        body: Optional[bytes] = None,
+        headers: Optional[Headers] = None,
+    ) -> IRequest:
         return requestMock(
             path=path,
             method=method,
@@ -54,8 +53,7 @@ class HTTPRequestWrappingIRequestTests(TestCase):
             headers=headers,
         )
 
-    def test_interface(self):
-        # type: () -> None
+    def test_interface(self) -> None:
         """
         L{HTTPRequestWrappingIRequest} implements L{IHTTPRequest}.
         """
@@ -63,8 +61,7 @@ class HTTPRequestWrappingIRequestTests(TestCase):
         self.assertProvides(IHTTPRequest, request)
 
     @given(text(alphabet=ascii_uppercase, min_size=1))
-    def test_method(self, methodText):
-        # type: (str) -> None
+    def test_method(self, methodText: str) -> None:
         """
         L{HTTPRequestWrappingIRequest.method} matches the underlying legacy
         request method.
@@ -74,8 +71,7 @@ class HTTPRequestWrappingIRequestTests(TestCase):
         self.assertEqual(request.method, methodText)
 
     @given(decoded_urls())
-    def test_uri(self, url):
-        # type: (DecodedURL) -> None
+    def test_uri(self, url: DecodedURL) -> None:
         """
         L{HTTPRequestWrappingIRequest.uri} matches the underlying legacy
         request URI.
@@ -99,8 +95,7 @@ class HTTPRequestWrappingIRequestTests(TestCase):
         requestURINormalized = request.uri.asURI()
 
         # Needed because non-equal URLs can render as the same strings
-        def strURL(url):
-            # type: (EncodedURL) -> str
+        def strURL(url: EncodedURL) -> str:
             return (
                 "URL(scheme={url.scheme!r}, "
                 "userinfo={url.userinfo!r}, "
@@ -120,8 +115,7 @@ class HTTPRequestWrappingIRequestTests(TestCase):
             ),
         )
 
-    def test_headers(self):
-        # type: () -> None
+    def test_headers(self) -> None:
         """
         L{HTTPRequestWrappingIRequest.headers} returns an
         L{HTTPRequestWrappingIRequest} containing the underlying legacy request
@@ -131,8 +125,7 @@ class HTTPRequestWrappingIRequestTests(TestCase):
         request = HTTPRequestWrappingIRequest(request=legacyRequest)
         self.assertProvides(IHTTPHeaders, request.headers)
 
-    def test_bodyAsFountTwice(self):
-        # type: () -> None
+    def test_bodyAsFountTwice(self) -> None:
         """
         L{HTTPRequestWrappingIRequest.bodyAsFount} raises
         L{FountAlreadyAccessedError} if called more than once.
@@ -143,8 +136,7 @@ class HTTPRequestWrappingIRequestTests(TestCase):
         self.assertRaises(FountAlreadyAccessedError, request.bodyAsFount)
 
     @given(binary())
-    def test_bodyAsBytes(self, data):
-        # type: (bytes) -> None
+    def test_bodyAsBytes(self, data: bytes) -> None:
         """
         L{HTTPRequestWrappingIRequest.bodyAsBytes} matches the underlying
         legacy request body.
@@ -155,8 +147,7 @@ class HTTPRequestWrappingIRequestTests(TestCase):
 
         self.assertEqual(body, data)
 
-    def test_bodyAsBytesCached(self):
-        # type: () -> None
+    def test_bodyAsBytesCached(self) -> None:
         """
         L{HTTPRequestWrappingIRequest.bodyAsBytes} called twice returns the
         same object both times.

--- a/src/klein/test/test_request_compat.py
+++ b/src/klein/test/test_request_compat.py
@@ -6,7 +6,7 @@ Tests for L{klein._irequest}.
 """
 
 from string import ascii_uppercase
-from typing import Optional, Text
+from typing import Optional
 
 from hyperlink import DecodedURL, EncodedURL
 
@@ -64,7 +64,7 @@ class HTTPRequestWrappingIRequestTests(TestCase):
 
     @given(text(alphabet=ascii_uppercase, min_size=1))
     def test_method(self, methodText):
-        # type: (Text) -> None
+        # type: (str) -> None
         """
         L{HTTPRequestWrappingIRequest.method} matches the underlying legacy
         request method.
@@ -100,7 +100,7 @@ class HTTPRequestWrappingIRequestTests(TestCase):
 
         # Needed because non-equal URLs can render as the same strings
         def strURL(url):
-            # type: (EncodedURL) -> Text
+            # type: (EncodedURL) -> str
             return (
                 "URL(scheme={url.scheme!r}, "
                 "userinfo={url.userinfo!r}, "

--- a/src/klein/test/test_requirer.py
+++ b/src/klein/test/test_requirer.py
@@ -1,4 +1,4 @@
-from typing import Iterable, List, Text, Tuple
+from typing import Iterable, List, Tuple
 
 from hyperlink import DecodedURL
 
@@ -37,11 +37,11 @@ requirer = Requirer()
     router.route("/hello/world", methods=["GET"]), url=RequestURL()
 )
 def requiresURL(url):
-    # type: (DecodedURL) -> Text
+    # type: (DecodedURL) -> str
     """
     This is a route that requires a URL.
     """
-    text = url.child("hello/ world").asText()  # type: Text
+    text = url.child("hello/ world").asText()  # type: str
     return text
 
 
@@ -65,7 +65,7 @@ def provideSample(request):
     component=RequestComponent(ISample),
 )
 def needsComponent(component):
-    # type: (Text) -> Text
+    # type: (str) -> str
     """
     This route requires and returns an L{ISample}.
     """

--- a/src/klein/test/test_requirer.py
+++ b/src/klein/test/test_requirer.py
@@ -19,8 +19,7 @@ class BadlyBehavedHeaders(Headers):
     getAllRequestHeaders.
     """
 
-    def getAllRawHeaders(self):
-        # type: () -> Iterable[Tuple[bytes, List[bytes]]]
+    def getAllRawHeaders(self) -> Iterable[Tuple[bytes, List[bytes]]]:
         """
         Don't return a host header.
         """
@@ -36,12 +35,11 @@ requirer = Requirer()
 @requirer.require(
     router.route("/hello/world", methods=["GET"]), url=RequestURL()
 )
-def requiresURL(url):
-    # type: (DecodedURL) -> str
+def requiresURL(url: DecodedURL) -> str:
     """
     This is a route that requires a URL.
     """
-    text = url.child("hello/ world").asText()  # type: str
+    text: str = url.child("hello/ world").asText()
     return text
 
 
@@ -52,8 +50,7 @@ class ISample(Interface):
 
 
 @requirer.prerequisite([ISample])
-def provideSample(request):
-    # type: (IRequest) -> None
+def provideSample(request: IRequest) -> None:
     """
     This requirer prerequisite installs a string as the provider of ISample.
     """
@@ -64,8 +61,7 @@ def provideSample(request):
     router.route("/retrieve/component", methods=["GET"]),
     component=RequestComponent(ISample),
 )
-def needsComponent(component):
-    # type: (str) -> str
+def needsComponent(component: str) -> str:
     """
     This route requires and returns an L{ISample}.
     """
@@ -73,8 +69,7 @@ def needsComponent(component):
 
 
 @requirer.require(router.route("/set/headers"))
-def someHeaders():
-    # type: () -> Response
+def someHeaders() -> Response:
     """
     Set some response attributes.
     """
@@ -90,8 +85,7 @@ class RequireURLTests(SynchronousTestCase):
     Tests for RequestURL() required parameter.
     """
 
-    def test_requiresURL(self):
-        # type: () -> None
+    def test_requiresURL(self) -> None:
         """
         When RequestURL is specified to a requirer, a DecodedURL object will be
         passed in to the decorated route.
@@ -108,8 +102,7 @@ class RequireURLTests(SynchronousTestCase):
             response, "https://example.com/hello/world/hello%2F%20world"
         )
 
-    def test_requiresURLNonStandardPort(self):
-        # type: () -> None
+    def test_requiresURLNonStandardPort(self) -> None:
         """
         When RequestURL is specified to a requirer, a DecodedURL object will be
         passed in to the decorated route.
@@ -126,8 +119,7 @@ class RequireURLTests(SynchronousTestCase):
             response, "http://example.com:8080/hello/world/hello%2F%20world"
         )
 
-    def test_requiresURLBadlyBehavedClient(self):
-        # type: () -> None
+    def test_requiresURLBadlyBehavedClient(self) -> None:
         """
         requiresURL will press on in the face of badly-behaved client code.
         """
@@ -151,8 +143,7 @@ class RequireComponentTests(SynchronousTestCase):
     Tests for RequestComponent.
     """
 
-    def test_requestComponent(self):
-        # type: () -> None
+    def test_requestComponent(self) -> None:
         """
         Test for requiring a component installed on the request.
         """
@@ -171,8 +162,7 @@ class ResponseTests(SynchronousTestCase):
     Tests for L{klein.Response}.
     """
 
-    def test_basicResponse(self):
-        # type: () -> None
+    def test_basicResponse(self) -> None:
         """
         Since methods decorated with C{@require} don't receive the request and
         can't access it to set headers and response codes, instead, they can

--- a/src/klein/test/test_resource.py
+++ b/src/klein/test/test_resource.py
@@ -221,8 +221,7 @@ class KleinResourceEqualityTests(SynchronousTestCase, EqualityTestsMixin):
         oneKlein = Klein()
 
         @oneKlein.route("/foo")
-        def foo(self, resource):
-            # type: (IRequest) -> KleinRenderable
+        def foo(self, resource: IRequest) -> KleinRenderable:
             pass
 
     _one = _One()

--- a/src/klein/test/test_resource.py
+++ b/src/klein/test/test_resource.py
@@ -9,7 +9,6 @@ from six.moves.urllib.parse import parse_qs
 from twisted.internet.defer import CancelledError, Deferred, fail, succeed
 from twisted.internet.error import ConnectionLost
 from twisted.internet.unix import Server
-from twisted.python.compat import unicode
 from twisted.trial.unittest import SynchronousTestCase
 from twisted.web import server
 from twisted.web.http_headers import Headers
@@ -1096,9 +1095,9 @@ class KleinResourceTests(SynchronousTestCase):
 
         _render(self.kr, request)
         kreq = IKleinRequest(request)
-        self.assertIsInstance(kreq.mapper.server_name, unicode)
-        self.assertIsInstance(kreq.mapper.path_info, unicode)
-        self.assertIsInstance(kreq.mapper.script_name, unicode)
+        self.assertIsInstance(kreq.mapper.server_name, str)
+        self.assertIsInstance(kreq.mapper.path_info, str)
+        self.assertIsInstance(kreq.mapper.script_name, str)
 
     def test_failedDecodePathInfo(self):
         """
@@ -1184,11 +1183,11 @@ class ExtractURLpartsTests(SynchronousTestCase):
             script_name,
         ) = _extractURLparts(requestMock(b"/f\xc3\xb6\xc3\xb6"))
 
-        self.assertIsInstance(url_scheme, unicode)
-        self.assertIsInstance(server_name, unicode)
+        self.assertIsInstance(url_scheme, str)
+        self.assertIsInstance(server_name, str)
         self.assertIsInstance(server_port, int)
-        self.assertIsInstance(path_info, unicode)
-        self.assertIsInstance(script_name, unicode)
+        self.assertIsInstance(path_info, str)
+        self.assertIsInstance(script_name, str)
 
     def assertDecodingFailure(self, exception, part):
         """
@@ -1256,11 +1255,11 @@ class ExtractURLpartsTests(SynchronousTestCase):
             script_name,
         ) = _extractURLparts(request)
 
-        self.assertIsInstance(url_scheme, unicode)
-        self.assertIsInstance(server_name, unicode)
+        self.assertIsInstance(url_scheme, str)
+        self.assertIsInstance(server_name, str)
         self.assertIsInstance(server_port, int)
-        self.assertIsInstance(path_info, unicode)
-        self.assertIsInstance(script_name, unicode)
+        self.assertIsInstance(path_info, str)
+        self.assertIsInstance(script_name, str)
 
 
 class GlobalAppTests(SynchronousTestCase):

--- a/src/klein/test/test_response.py
+++ b/src/klein/test/test_response.py
@@ -21,27 +21,23 @@ class FrozenHTTPResponseTests(FrozenHTTPMessageTestsMixIn, TestCase):
     """
 
     @staticmethod
-    def responseFromBytes(data=b""):
-        # type: (bytes) -> FrozenHTTPResponse
+    def responseFromBytes(data: bytes = b"") -> FrozenHTTPResponse:
         return FrozenHTTPResponse(
             status=200, headers=FrozenHTTPHeaders(rawHeaders=()), body=data,
         )
 
     @classmethod
-    def messageFromBytes(cls, data=b""):
-        # type: (bytes) -> IHTTPMessage
+    def messageFromBytes(cls, data: bytes = b"") -> IHTTPMessage:
         return cls.responseFromBytes(data)
 
-    def test_interface(self):
-        # type: () -> None
+    def test_interface(self) -> None:
         """
         L{FrozenHTTPResponse} implements L{IHTTPResponse}.
         """
         response = self.responseFromBytes()
         self.assertProvides(IHTTPResponse, response)
 
-    def test_initInvalidBodyType(self):
-        # type: () -> None
+    def test_initInvalidBodyType(self) -> None:
         """
         L{FrozenHTTPResponse} raises L{TypeError} when given a body of an
         unknown type.

--- a/src/klein/test/test_session.py
+++ b/src/klein/test/test_session.py
@@ -29,8 +29,7 @@ class ISimpleTest(Interface):
     """
 
     @ifmethod
-    def doTest():
-        # type: () -> None
+    def doTest() -> None:
         """
         Test method.
         """
@@ -48,8 +47,7 @@ class SimpleTest(object):
     Implementation of L{ISimpleTest} for testing.
     """
 
-    def doTest(self):
-        # type: () -> int
+    def doTest(self) -> int:
         """
         Implementation of L{ISimpleTest}.  Returns 3.
         """
@@ -57,16 +55,16 @@ class SimpleTest(object):
 
 
 @declareMemoryAuthorizer(ISimpleTest)
-def memoryAuthorizer(interface, session, data):
-    # type: (IInterface, ISession, Componentized) -> SimpleTest
+def memoryAuthorizer(
+    interface: IInterface, session: ISession, data: Componentized
+) -> SimpleTest:
     """
     Authorize the ISimpleTest interface; it always works.
     """
     return SimpleTest()
 
 
-def simpleSessionRouter():
-    # type: () -> Tuple[Sessions, Errors, str, str, StubTreq]
+def simpleSessionRouter() -> Tuple[Sessions, Errors, str, str, StubTreq]:
     """
     Construct a simple router.
     """
@@ -84,8 +82,7 @@ def simpleSessionRouter():
 
     @router.route("/")
     @inlineCallbacks
-    def route(request):
-        # type: (IRequest) -> Deferred
+    def route(request: IRequest) -> Deferred:
         try:
             sessions.append((yield sproc.procureSession(request)))
         except NoSuchSession as nss:
@@ -95,18 +92,15 @@ def simpleSessionRouter():
     requirer = Requirer()
 
     @requirer.prerequisite([ISession])
-    def procure(request):
-        # type: (IRequest) -> Deferred
+    def procure(request: IRequest) -> Deferred:
         return sproc.procureSession(request)
 
     @requirer.require(router.route("/test"), simple=Authorization(ISimpleTest))
-    def testRoute(simple):
-        # type: (SimpleTest) -> str
+    def testRoute(simple: SimpleTest) -> str:
         return "ok: " + str(simple.doTest() + 4)
 
     @requirer.require(router.route("/denied"), nope=Authorization(IDenyMe))
-    def testDenied(nope):
-        # type: (IDenyMe) -> str
+    def testDenied(nope: IDenyMe) -> str:
         return "bad"
 
     treq = StubTreq(router.resource())
@@ -118,8 +112,7 @@ class ProcurementTests(SynchronousTestCase):
     Tests for L{klein.SessionProcurer}.
     """
 
-    def test_procurementSecurity(self):
-        # type: () -> None
+    def test_procurementSecurity(self) -> None:
         """
         Once a session is negotiated, it should be the identical object to
         avoid duplicate work - unless we are using forceInsecure to retrieve
@@ -132,8 +125,7 @@ class ProcurementTests(SynchronousTestCase):
 
         @router.route("/")
         @inlineCallbacks
-        def route(request):
-            # type: (IRequest) -> Deferred
+        def route(request: IRequest) -> Deferred:
             sproc = SessionProcurer(mss)
             sessions.append((yield sproc.procureSession(request)))
             sessions.append((yield sproc.procureSession(request)))
@@ -150,8 +142,7 @@ class ProcurementTests(SynchronousTestCase):
         self.assertIs(sessions[3], sessions[4])
         self.assertIsNot(sessions[3], sessions[5])
 
-    def test_procuredTooLate(self):
-        # type: () -> None
+    def test_procuredTooLate(self) -> None:
         """
         If you start writing stuff to the response before procuring the
         session, when cookies need to be set, you will get a comprehensible
@@ -162,8 +153,7 @@ class ProcurementTests(SynchronousTestCase):
 
         @router.route("/")
         @inlineCallbacks
-        def route(request):
-            # type: (IRequest) -> Deferred
+        def route(request: IRequest) -> Deferred:
             sproc = SessionProcurer(mss)
             request.write(b"oops...")
             with self.assertRaises(TooLateForCookies):
@@ -175,8 +165,7 @@ class ProcurementTests(SynchronousTestCase):
         result = self.successResultOf(treq.get("http://unittest.example.com/"))
         self.assertEqual(self.successResultOf(result.content()), b"oops...bye")
 
-    def test_cookiesTurnedOff(self):
-        # type: () -> None
+    def test_cookiesTurnedOff(self) -> None:
         """
         If cookies can't be set, then C{procureSession} raises
         L{NoSuchSession}.
@@ -186,8 +175,7 @@ class ProcurementTests(SynchronousTestCase):
 
         @router.route("/")
         @inlineCallbacks
-        def route(request):
-            # type: (IRequest) -> Deferred
+        def route(request: IRequest) -> Deferred:
             sproc = SessionProcurer(mss, setCookieOnGET=False)
             with self.assertRaises(NoSuchSession):
                 yield sproc.procureSession(request)
@@ -197,8 +185,7 @@ class ProcurementTests(SynchronousTestCase):
         result = self.successResultOf(treq.get("http://unittest.example.com/"))
         self.assertEqual(self.successResultOf(result.content()), b"no session")
 
-    def test_unknownSessionHeader(self):
-        # type: () -> None
+    def test_unknownSessionHeader(self) -> None:
         """
         Unknown session IDs in auth headers will be immediately rejected with
         L{NoSuchSession}.
@@ -212,8 +199,7 @@ class ProcurementTests(SynchronousTestCase):
         self.assertEqual(len(sessions), 0)
         self.assertEqual(len(exceptions), 1)
 
-    def test_unknownSessionCookieGET(self):
-        # type: () -> None
+    def test_unknownSessionCookieGET(self) -> None:
         """
         Unknown session IDs in cookies will result in a new session being
         created.
@@ -230,8 +216,7 @@ class ProcurementTests(SynchronousTestCase):
         self.assertEqual(len(sessions), 1)
         self.assertNotEqual(sessions[0].identifier, badSessionID)
 
-    def test_unknownSessionCookiePOST(self):
-        # type: () -> None
+    def test_unknownSessionCookiePOST(self) -> None:
         """
         Unknown session IDs in cookies for POST requests will result in a
         NoSuchSession error.
@@ -247,8 +232,7 @@ class ProcurementTests(SynchronousTestCase):
         self.assertEqual(len(exceptions), 1)
         self.assertEqual(len(sessions), 0)
 
-    def test_authorization(self):
-        # type: () -> None
+    def test_authorization(self) -> None:
         """
         When L{Requirer.require} is used with L{Authorization} and the session
         knows how to supply that authorization, it is passed to the object.
@@ -259,8 +243,7 @@ class ProcurementTests(SynchronousTestCase):
         )
         self.assertEqual(self.successResultOf(response.content()), b"ok: 7")
 
-    def test_authorizationDenied(self):
-        # type: () -> None
+    def test_authorizationDenied(self) -> None:
         """
         When L{Requirer.require} is used with an L{Authorization} and the
         session does I{not} know how to supply that authorization, the callable

--- a/src/klein/test/test_trial.py
+++ b/src/klein/test/test_trial.py
@@ -24,8 +24,7 @@ class TestCaseTests(TestCase):
         """
 
         @ifmethod
-        def frob():
-            # type: () -> None
+        def frob() -> None:
             """
             Frob the object.
             """
@@ -36,8 +35,7 @@ class TestCaseTests(TestCase):
         Implements L{IFrobbable}.
         """
 
-        def frob(self):
-            # type: () -> None
+        def frob(self) -> None:
             pass
 
     @implementer(IFrobbable)
@@ -46,8 +44,7 @@ class TestCaseTests(TestCase):
         Does not implement L{IFrobbable}, despite declaring.
         """
 
-    def test_assertProvidesPass(self):
-        # type: () -> None
+    def test_assertProvidesPass(self) -> None:
         """
         L{TestCase.assertProvides} does not raise when C{interface} is provided
         by C{obj}.
@@ -56,8 +53,7 @@ class TestCaseTests(TestCase):
         self.assertProvides(self.IFrobbable, frobbable)
         frobbable.frob()  # Coverage
 
-    def test_assertProvidesFail(self):
-        # type: () -> None
+    def test_assertProvidesFail(self) -> None:
         """
         L{TestCase.assertProvides} does not raise when C{interface} is not
         provided by C{obj}.


### PR DESCRIPTION
Use inline type hint syntax
Replace `Text` with `str`.

Note that `_strategies.py` is intentionally excluded here because it's moving to `hyperlink` and keeping that diff smaller seems like a better move.

This is a very large diff, but the vast majority of it is mechanical conversation from comment-based type syntax to inline syntax, which is possible now that we require Python 3.6+.  There is some slightly more interesting change in `_isession.py` due to the fact that the inline syntax causes the interpreter to notice things at runtime that it didn't in the comments; that is noted in review comments.