### PR TITLE
Use f-strings

### DIFF
--- a/src/klein/__init__.py
+++ b/src/klein/__init__.py
@@ -64,4 +64,4 @@ __version__ = _incremental_version.base()
 
 __author__ = "The Klein contributors (see AUTHORS)"
 __license__ = "MIT"
-__copyright__ = "Copyright 2011-2019 {0}".format(__author__)
+__copyright__ = f"Copyright 2011-2019 {__author__}"

--- a/src/klein/_app.py
+++ b/src/klein/_app.py
@@ -216,7 +216,7 @@ class Klein(object):
             else:
                 self._boundAs = "unknown_" + str(id(self))
 
-        boundName = "__klein_bound_{}__".format(self._boundAs)
+        boundName = f"__klein_bound_{self._boundAs}__"
         k = cast(
             Optional["Klein"], getattr(instance, boundName, lambda: None)()
         )
@@ -274,7 +274,7 @@ class Klein(object):
                 branchKwargs = kwargs.copy()
                 branchKwargs["endpoint"] = branchKwargs["endpoint"] + "_branch"
 
-                @modified("branch route '{url}' executor".format(url=url), f)
+                @modified(f"branch route '{url}' executor", f)
                 def branch_f(
                     instance: Any,
                     request: IRequest,
@@ -301,7 +301,7 @@ class Klein(object):
                     )
                 )
 
-            @modified("route '{url}' executor".format(url=url), f)
+            @modified(f"route '{url}' executor", f)
             def _f(
                 instance: Any,
                 request: IRequest,
@@ -500,9 +500,7 @@ class Klein(object):
         log.startLogging(logFile)
 
         if not endpoint_description:
-            endpoint_description = "tcp:port={0}:interface={1}".format(
-                port, host
-            )
+            endpoint_description = f"tcp:port={port}:interface={host}"
 
         endpoint = serverFromString(reactor, endpoint_description)
 

--- a/src/klein/_form.py
+++ b/src/klein/_form.py
@@ -624,9 +624,7 @@ def checkCSRF(request: IRequest) -> None:
             return
     # leak only the value passed, not the actual token, just in
     # case there's some additional threat vector there
-    raise EarlyExit(
-        CrossSiteRequestForgery("Invalid CSRF token: {!r}".format(token))
-    )
+    raise EarlyExit(CrossSiteRequestForgery(f"Invalid CSRF token: {token!r}"))
 
 
 @attr.s(hash=False)

--- a/src/klein/_headers.py
+++ b/src/klein/_headers.py
@@ -116,7 +116,7 @@ def getFromRawHeaders(rawHeaders: RawHeaders, name: AnyStr) -> Iterable[AnyStr]:
         rawName = headerNameAsBytes(normalizeHeaderName(name))
         return (headerValueAsText(v) for n, v in rawHeaders if rawName == n)
 
-    raise TypeError("name {!r} must be str or bytes".format(name))
+    raise TypeError(f"name {name!r} must be str or bytes")
 
 
 def rawHeaderName(name: String) -> bytes:
@@ -125,7 +125,7 @@ def rawHeaderName(name: String) -> bytes:
     elif isinstance(name, str):
         return headerNameAsBytes(name)
     else:
-        raise TypeError("name {!r} must be str or bytes".format(name))
+        raise TypeError(f"name {name!r} must be str or bytes")
 
 
 def rawHeaderNameAndValue(name: String, value: String) -> Tuple[bytes, bytes]:
@@ -141,12 +141,12 @@ def rawHeaderNameAndValue(name: String, value: String) -> Tuple[bytes, bytes]:
     elif isinstance(name, str):
         if not isinstance(value, str):
             raise TypeError(
-                "value {!r} must be str to match name {!r}".format(value, name)
+                f"value {value!r} must be str to match name {name!r}"
             )
         return (headerNameAsBytes(name), headerValueAsBytes(value))
 
     else:
-        raise TypeError("name {!r} must be str or bytes".format(name))
+        raise TypeError(f"name {name!r} must be str or bytes")
 
 
 # Implementation

--- a/src/klein/_headers_compat.py
+++ b/src/klein/_headers_compat.py
@@ -67,7 +67,7 @@ class HTTPHeadersWrappingHeaders(object):
                 )
             )
         else:
-            raise TypeError("name {!r} must be str or bytes".format(name))
+            raise TypeError(f"name {name!r} must be str or bytes")
 
         return values
 

--- a/src/klein/_plating.py
+++ b/src/klein/_plating.py
@@ -111,7 +111,7 @@ def resolveDeferredObjects(root: Any) -> Deferred:
         else:
             raise TypeError(
                 obj,
-                "{input} not JSON serializable".format(input=obj),
+                f"{obj} not JSON serializable",
             )
 
     returnValue(result[0])

--- a/src/klein/_request_compat.py
+++ b/src/klein/_request_compat.py
@@ -70,13 +70,13 @@ class HTTPRequestWrappingIRequest(object):
         else:
             default = 80
         if port != default:
-            netloc += ":{}".format(port)
+            netloc += f":{port}"
 
         path = nativeString(request.uri)
         if path and path[0] == "/":
             path = path[1:]
 
-        return DecodedURL.fromText("{}://{}/{}".format(scheme, netloc, path))
+        return DecodedURL.fromText(f"{scheme}://{netloc}/{path}")
 
     @property
     def headers(self) -> IHTTPHeaders:

--- a/src/klein/_resource.py
+++ b/src/klein/_resource.py
@@ -52,7 +52,7 @@ class _URLDecodeError(Exception):
         self.errors = errors
 
     def __repr__(self):
-        return "<URLDecodeError(errors={0!r})>".format(self.errors)
+        return f"<URLDecodeError(errors={self.errors!r})>"
 
 
 def _extractURLparts(request):
@@ -153,7 +153,7 @@ class KleinResource(Resource):
             ) = _extractURLparts(request)
         except _URLDecodeError as e:
             for what, fail in e.errors:
-                log.err(fail, "Invalid encoding in {what}.".format(what=what))
+                log.err(fail, f"Invalid encoding in {what}.")
             request.setResponseCode(400)
             return b"Non-UTF-8 encoding in URL."
 

--- a/src/klein/test/_trial.py
+++ b/src/klein/test/_trial.py
@@ -31,4 +31,4 @@ class TestCase(SynchronousTestCase):
         try:
             self.assertTrue(verifyObject(interface, obj))
         except Invalid:
-            self.fail("{} does not provide {}".format(obj, interface))
+            self.fail(f"{obj} does not provide {interface}")

--- a/src/klein/test/test_app.py
+++ b/src/klein/test/test_app.py
@@ -473,7 +473,7 @@ class KleinTestCase(unittest.TestCase):
         """
         app = Klein()
         interface = "2001\\:0DB8\\:f00e\\:eb00\\:\\:1"
-        spec = "tcp6:8080:interface={0}".format(interface)
+        spec = f"tcp6:8080:interface={interface}"
         app.run(endpoint_description=spec)
         reactor.run.assert_called_with()
         mock_sfs.assert_called_with(reactor, spec)

--- a/src/klein/test/test_form.py
+++ b/src/klein/test/test_form.py
@@ -690,7 +690,7 @@ class TestForms(SynchronousTestCase):
         response = self.successResultOf(stub.get("https://localhost/render"))
         self.assertEqual(response.code, 200)
         setCookie = response.cookies()["Klein-Secure-Session"]
-        expected = 'value="{}"'.format(setCookie)
+        expected = f'value="{setCookie}"'
         actual = self.successResultOf(content(response))
         if not isinstance(expected, bytes):  # type: ignore[unreachable]
             actual = actual.decode("utf-8")

--- a/src/klein/test/test_headers.py
+++ b/src/klein/test/test_headers.py
@@ -206,7 +206,7 @@ class GetValuesTestsMixIn(object):
         implementation being tested.
         """
         raise NotImplementedError(
-            "{} must implement getValues()".format(self.__class__)
+            f"{self.__class__} must implement getValues()"
         )
 
     def test_getBytesName(self) -> None:
@@ -224,7 +224,7 @@ class GetValuesTestsMixIn(object):
             cast(TestCase, self).assertEqual(
                 list(self.getValues(rawHeaders, name)),
                 values,
-                "header name: {!r}".format(name),
+                f"header name: {name!r}",
             )
 
     def headerNormalize(self, value: str) -> str:
@@ -260,7 +260,7 @@ class GetValuesTestsMixIn(object):
             cast(TestCase, self).assertEqual(
                 list(self.getValues(rawHeaders, name)),
                 [self.headerNormalize(value) for value in _values],
-                "header name: {!r}".format(name),
+                f"header name: {name!r}",
             )
 
     @given(iterables(tuples(ascii_text(min_size=1), binary())))
@@ -295,7 +295,7 @@ class GetValuesTestsMixIn(object):
                     self.headerNormalize(headerValueAsText(value))
                     for value in values
                 ),
-                "header name: {!r}".format(textName),
+                f"header name: {textName!r}",
             )
 
     def test_getInvalidNameType(self) -> None:
@@ -360,9 +360,7 @@ class MutableHTTPHeadersTestsMixIn(GetValuesTestsMixIn):
         cast(TestCase, self).assertEqual(rawHeaders1, rawHeaders2)
 
     def headers(self, rawHeaders: RawHeaders) -> IMutableHTTPHeaders:
-        raise NotImplementedError(
-            "{} must implement headers()".format(self.__class__)
-        )
+        raise NotImplementedError(f"{self.__class__} must implement headers()")
 
     def getValues(
         self, rawHeaders: RawHeaders, name: AnyStr

--- a/src/klein/test/test_message.py
+++ b/src/klein/test/test_message.py
@@ -29,7 +29,7 @@ class FrozenHTTPMessageTestsMixIn(object):
         Return a new instance of an L{IHTTPMessage} implementation using the
         given bytes as the message body.
         """
-        raise NotImplementedError("{} must implement getValues()".format(cls))
+        raise NotImplementedError(f"{cls} must implement getValues()")
 
     @classmethod
     def messageFromFountFromBytes(cls, data: bytes = b"") -> IHTTPMessage:

--- a/src/klein/test/test_plating.py
+++ b/src/klein/test/test_plating.py
@@ -182,7 +182,7 @@ def transformJSONObject(jsonObject, transformer):
         elif isinstance(obj, dict):
             return {transformer(k): transformer(v) for k, v in obj.items()}
         else:
-            raise AssertionError("Object of unknown type {!r}".format(obj))
+            raise AssertionError(f"Object of unknown type {obj!r}")
 
     return visit(jsonObject)
 

--- a/src/klein/test/test_resource.py
+++ b/src/klein/test/test_resource.py
@@ -129,7 +129,7 @@ def _render(resource, request, notifyFinish=True):
         else:
             return request.notifyFinish()
     else:
-        raise ValueError("Unexpected return value: {!r}".format(result))
+        raise ValueError(f"Unexpected return value: {result!r}")
 
 
 class SimpleElement(Element):


### PR DESCRIPTION
Replace `"{}".format()` with `f"{}"`.

This is both more concise and, word has it, faster.

Subset of #384.
