### PR TITLE
raise minimum supported version of Twisted to 19.2 and prune tox

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -183,7 +183,7 @@ jobs:
     strategy:
       matrix:
         python: ["3.6", "3.7", "3.8", "3.9", "pypy3"]
-        twisted: ["18.4", "19.2", "current"]
+        twisted: ["19.2", "current"]
 
     steps:
 

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 
 envlist =
     flake8, black, mypy
-    coverage-py{36,37,38,39,310,py3}-tw{184,192,current,trunk}
+    coverage-py{36,37,38,39,310,py3}-tw{192,current,trunk}
     coverage_report
     docs, docs-linkcheck
     packaging
@@ -15,11 +15,6 @@ skip_missing_interpreters = {tty:True:False}
 basepython = python3.9
 
 deps =
-    tw166: Twisted==16.6.0
-    tw171: Twisted==17.1.0
-    tw175: Twisted==17.5.0
-    tw179: Twisted==17.9.0
-    tw184: Twisted==18.4.0
     tw187: Twisted==18.7.0
     tw189: Twisted==18.9.0
     tw192: Twisted==19.2.1


### PR DESCRIPTION
Looking at the huge test matrix on #401 and the number of times github actions CI has failed, apparently due to a timeout, I thought it might be nice to just drop some more irrelevant stuff.

I'd also love to raise our minimum supported Python version at some point, but that seems like it might be a bigger deal and interact with more things like distro-supplied interpreter versions.