### PR TITLE
Don't bring in typing_extensions for Python 3.8+

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ if __name__ == "__main__":
             "incremental",
             "Tubes",
             "Twisted>=16.6",  # 16.6 introduces ensureDeferred
-            "typing_extensions",
+            "typing_extensions ; python_version<'3.8'",
             "Werkzeug",
             "zope.interface",
         ],


### PR DESCRIPTION
`typing_extensions` is only needed for Python < 3.8