### PR TITLE
Turn on strict_equality in Mypy.

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -1,12 +1,13 @@
 [mypy]
 
-# Global settings
+# Increase our expectations
 
 disallow_incomplete_defs = True
 disallow_untyped_defs    = True
 no_implicit_optional     = True
 show_column_numbers      = True
 show_error_codes         = True
+strict_equality          = True
 strict_optional          = True
 warn_no_return           = True
 warn_redundant_casts     = True
@@ -14,7 +15,7 @@ warn_return_any          = True
 warn_unreachable         = True
 warn_unused_ignores      = True
 
-# Enable these over time
+# These are too strict for us at the moment
 
 check_untyped_defs       = False
 


### PR DESCRIPTION
Turn on `strict_equality` in Mypy.

No code changes required; we already comply.