### PR TITLE
Fix type hint for Klein._error_handlers.

### DIFF
--- a/src/klein/_app.py
+++ b/src/klein/_app.py
@@ -17,6 +17,8 @@ from typing import (
     List,
     Mapping,
     Optional,
+    Tuple,
+    Type,
     Union,
     cast,
 )
@@ -184,7 +186,9 @@ class Klein:
     def __init__(self) -> None:
         self._url_map = Map()
         self._endpoints: Dict[str, KleinRouteHandler] = {}
-        self._error_handlers: List[KleinErrorHandler] = []
+        self._error_handlers: List[
+            Tuple[List[Type[Exception]], KleinErrorHandler]
+        ] = []
         self._instance: Optional[Klein] = None
         self._boundAs: Optional[str] = None
 


### PR DESCRIPTION
Fix type hint for `Klein._error_handlers`.

The correct type is a list of 2-tuples, where the first element is a list of exception types to handle, and the second element is the handler for that list of exception types.

You can see where we add such a tuple to the list to `Klein._error_handlers` [here](https://github.com/twisted/klein/blob/9d81819cd9db5728ce9f7e477f62945806347563/src/klein/_app.py#L497).