### PR TITLE
The first argument to urlFor is an IRequest.

### DIFF
--- a/src/klein/_app.py
+++ b/src/klein/_app.py
@@ -503,7 +503,7 @@ class Klein:
 
     def urlFor(
         self,
-        request: IKleinRequest,
+        request: IRequest,
         endpoint: str,
         values: Optional[Mapping[str, KleinQueryValue]] = None,
         method: Optional[str] = None,


### PR DESCRIPTION
The first argument to `urlFor` is an `IRequest`, not an `IKleinRequest`.

To confirm this, note that the [tests are passing in the result of calling `requestMock()`](https://github.com/twisted/klein/blob/f34a62f4db173aba6ec4ed0106a43898a7af8d25/src/klein/test/test_app.py#L532) and that [`requestMock`](https://github.com/twisted/klein/blob/f34a62f4db173aba6ec4ed0106a43898a7af8d25/src/klein/test/test_resource.py#L32) builds a `twisted.web.server.Request` up and returns it, and `twisted.web.server.Request` is an `IRequest`, not an `IKleinRequest`.