### PR TITLE
Add type hints for handle_errors.

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -21,9 +21,6 @@ check_untyped_defs       = False
 
 # Disable some checks until effected files fully adopt mypy
 
-[mypy-klein._app]
-allow_untyped_defs = True
-
 [mypy-klein._plating]
 allow_untyped_defs = True
 

--- a/src/klein/_app.py
+++ b/src/klein/_app.py
@@ -436,7 +436,7 @@ class Klein:
         f_or_exception: KleinErrorHandler,
         *additional_exceptions: Type[Exception],
     ) -> Callable[[KleinErrorHandler], Callable]:
-        ...
+        ...  # pragma: no cover
 
     @overload
     def handle_errors(
@@ -444,7 +444,7 @@ class Klein:
         f_or_exception: Type[Exception],
         *additional_exceptions: Type[Exception],
     ) -> Callable[[KleinErrorHandler], Callable]:
-        ...
+        ...  # pragma: no cover
 
     def handle_errors(
         self,

--- a/src/klein/_app.py
+++ b/src/klein/_app.py
@@ -435,13 +435,17 @@ class Klein:
         self,
         f_or_exception: KleinErrorHandler,
         *additional_exceptions: Type[Exception],
-    ) -> Callable[[KleinErrorHandler], Callable]: ...
+    ) -> Callable[[KleinErrorHandler], Callable]:
+        ...
+
     @overload
     def handle_errors(
         self,
         f_or_exception: Type[Exception],
         *additional_exceptions: Type[Exception],
-    ) -> Callable[[KleinErrorHandler], Callable]: ...
+    ) -> Callable[[KleinErrorHandler], Callable]:
+        ...
+
     def handle_errors(
         self,
         f_or_exception: Union[KleinErrorHandler, Type[Exception]],


### PR DESCRIPTION
Add type hints for `handle_errors`.

This rounds out the type hints for `klein._app`.

This one was a bit tricky, and took me a few tries, but was nicely covered by using `@overload`.