### PR TITLE
Turn off allow_untyped_defs for klein.test._trial

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -35,9 +35,6 @@ allow_untyped_defs = True
 [mypy-klein._resource]
 allow_untyped_defs = True
 
-[mypy-klein.test._trial]
-allow_untyped_defs = True
-
 [mypy-klein.test.test_app]
 allow_untyped_defs = True
 


### PR DESCRIPTION
Turn off `allow_untyped_defs` for `klein.test._trial`.