### PR TITLE
Hyperlink ships with type hints now

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -55,9 +55,6 @@ ignore_missing_imports = True
 [mypy-git.*]
 ignore_missing_imports = True
 
-[mypy-hyperlink]
-ignore_missing_imports = True
-
 [mypy-incremental]
 ignore_missing_imports = True
 


### PR DESCRIPTION
Hyperlink ships with type hints now, so we can stop ignoring missing type hints for it