### PR TITLE
Fill in pinned dependencies in Tox config.

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -23,8 +23,13 @@ deps =
     twtrunk: https://github.com/twisted/twisted/tarball/trunk#egg=Twisted
 
     attrs==20.3.0
+    Automat==20.2.0
+    characteristic==14.3.0
+    constantly==15.1.0
     hyperlink==21.0.0
     incremental==17.5.0
+    PyHamcrest==2.0.2
+    six==1.15.0
     Tubes==0.2.0
     Werkzeug==1.0.1
     zope.interface==5.2.0
@@ -369,11 +374,12 @@ basepython = {[default]basepython}
 
 recreate = true
 
-deps = pipdeptree
+deps =
+    pipdeptree
 
 commands =
     python -c 'print()'
-    pip freeze --exclude="{env:PY_MODULE}"
+    pip freeze --exclude="{env:PY_MODULE}" --exclude=pipdeptree
 
     python -c 'print()'
     pipdeptree


### PR DESCRIPTION
This adds some indirect dependencies that were not pinned in Tox before.