### PR TITLE
Pin Twisted for mypy

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -19,8 +19,10 @@ deps =
     tw197: Twisted==19.7.0
     tw1910: Twisted==19.10.0
     tw203: Twisted==20.3.0
+    tw212: Twisted==21.2.0
     twcurrent: Twisted
     twtrunk: https://github.com/twisted/twisted/tarball/trunk#egg=Twisted
+    mypy: Twisted==20.3.0
 
     attrs==20.3.0
     hyperlink==21.0.0


### PR DESCRIPTION
This fixes CI failures where the latest Twisted version (21.2.0) broke our mypy runs.

Will look at fixing that in a separate PR, but this is blocking all other PRs.