### PR TITLE
Run mypy with current Twisted

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,7 @@
+ci:
+  skip:
+    - check-manifest
+
 repos:
 
   - repo: https://gitlab.com/pycqa/flake8

--- a/src/klein/_app.py
+++ b/src/klein/_app.py
@@ -311,13 +311,9 @@ class Klein:
                 return "Hello"
 
         @param url: A werkzeug URL pattern given to C{werkzeug.routing.Rule}.
-        @type url: str
-
         @param branch: A bool indiciated if a branch endpoint should
             be added that allows all child path segments that don't
             match some other route to be consumed.  Default C{False}.
-        @type branch: bool
-
 
         @returns: decorated handler function.
         """
@@ -400,10 +396,8 @@ class Klein:
                 def foo_handler(request):
                     return 'I respond to /prefix/foo'
 
-        @type prefix: string
         @param prefix: The string that will be prepended to the paths of all
                        routes established during the with-block.
-        @return: Returns None.
         """
 
         _map_before_submount = self._url_map
@@ -492,11 +486,8 @@ class Klein:
 
         @param f_or_exception: An error handler function, or an C{Exception}
             subclass to scope the decorated handler to.
-        @type f_or_exception: C{function} or C{Exception}
-
         @param additional_exceptions: Additional C{Exception} subclasses to
             scope the decorated function to.
-        @type additional_exceptions: C{list} of C{Exception}s
 
         @returns: decorated error handler function.
         """

--- a/src/klein/_app.py
+++ b/src/klein/_app.py
@@ -123,7 +123,7 @@ def _call(
         args = (__klein_instance__,) + args
     result = __klein_f__(*args, **kwargs)
     if iscoroutine(result):
-        result = ensureDeferred(result)
+        result = ensureDeferred(result)  # type: ignore[arg-type]
     return result
 
 
@@ -228,7 +228,7 @@ class Klein:
         # taking *args, **kwargs (because they aren't required), but we're
         # going to pass them along here anyway.
         return endpoint_f(
-            self._instance, request, *args, **kwargs
+            self._instance, request, *args, **kwargs  # type: ignore[arg-type]
         )  # type: ignore[call-arg]
 
     def execute_error_handler(
@@ -602,7 +602,7 @@ class Klein:
         site.displayTracebacks = displayTracebacks
 
         endpoint.listen(site)
-        reactor.run()
+        reactor.run()  # type: ignore[attr-defined]
 
 
 _globalKleinApp = Klein()

--- a/src/klein/_dihttp.py
+++ b/src/klein/_dihttp.py
@@ -31,8 +31,9 @@ def urlFromRequest(request: IRequest) -> DecodedURL:
             host = sentHeader
             port = None
     else:
-        host = request.client.host
-        port = request.client.port
+        client = request.client  # type: ignore[attr-defined]
+        host = client.host
+        port = client.port
 
     url = DecodedURL.fromText(request.uri.decode("charmap"))
     url = url.replace(

--- a/src/klein/_dihttp.py
+++ b/src/klein/_dihttp.py
@@ -97,7 +97,10 @@ class RequestComponent:
     def injectValue(
         self, instance: Any, request: IRequest, routeParams: Dict[str, Any]
     ) -> DecodedURL:
-        return cast(DecodedURL, request.getComponent(self.interface))
+        return cast(
+            DecodedURL,
+            cast(Componentized, request).getComponent(self.interface),
+        )
 
     def finalize(cls) -> None:
         "Nothing to do upon finalization."

--- a/src/klein/_form.py
+++ b/src/klein/_form.py
@@ -167,7 +167,7 @@ class Field:
             yield tags.label(self.formLabel, ": ", input_tag, *error_tags)
         else:
             yield input_tag
-            yield error_tags  # type: ignore[misc]
+            yield from error_tags
 
     def extractValue(self, request: IRequest) -> Any:
         """

--- a/src/klein/_form.py
+++ b/src/klein/_form.py
@@ -189,7 +189,9 @@ class Field:
                 octets = request.content.read()
                 characters = octets.decode("utf-8")
                 parsed = json.loads(characters)
-                request.setComponent(IParsedJSONBody, parsed)
+                cast(Componentized, request).setComponent(
+                    IParsedJSONBody, parsed
+                )
             if fieldName not in parsed:
                 return None
             return parsed[fieldName]
@@ -738,7 +740,7 @@ class Form:
             injectionComponents,
         )
         yield values.validate(instance, request)
-        request.setComponent(IFieldValues, values)
+        cast(Componentized, request).setComponent(IFieldValues, values)
 
     @classmethod
     def rendererFor(

--- a/src/klein/_form.py
+++ b/src/klein/_form.py
@@ -552,13 +552,19 @@ class FieldValues:
         self, instance: Any, request: IRequest
     ) -> Generator[Any, object, None]:
         if self.validationErrors:
-            result = yield _call(
-                instance,
-                IValidationFailureHandler(
-                    self._injectionComponents, defaultValidationFailureHandler
+            result = cast(
+                KleinRenderable,
+                (
+                    yield _call(
+                        instance,
+                        IValidationFailureHandler(
+                            self._injectionComponents,
+                            defaultValidationFailureHandler,
+                        ),
+                        request,
+                        self,
+                    )
                 ),
-                request,
-                self,
             )
             raise EarlyExit(result)
 

--- a/src/klein/_form.py
+++ b/src/klein/_form.py
@@ -370,7 +370,7 @@ class RenderableForm:
         """
         raise MissingRenderMethod(self, name)
 
-    def render(self, request: object) -> Tag:
+    def render(self, request: IRequest) -> Tag:
         """
         Render this form to the given request.
         """

--- a/src/klein/_form.py
+++ b/src/klein/_form.py
@@ -370,7 +370,7 @@ class RenderableForm:
         """
         raise MissingRenderMethod(self, name)
 
-    def render(self, request: IRequest) -> Tag:
+    def render(self, request: IRequest) -> Tag:  # type: ignore[override]
         """
         Render this form to the given request.
         """

--- a/src/klein/_form.py
+++ b/src/klein/_form.py
@@ -183,7 +183,7 @@ class Field:
             b"application/json"
         ):
             # TODO: parse only once, please.
-            parsed = request.getComponent(IParsedJSONBody)
+            parsed = cast(Componentized, request).getComponent(IParsedJSONBody)
             if parsed is None:
                 request.content.seek(0)
                 octets = request.content.read()
@@ -424,7 +424,7 @@ def defaultValidationFailureHandler(
 
     @return: Any object acceptable from a Klein route.
     """
-    session = request.getComponent(ISession)
+    session = cast(Componentized, request).getComponent(ISession)
     request.setResponseCode(400)
     enctype = (
         (

--- a/src/klein/_form.py
+++ b/src/klein/_form.py
@@ -123,7 +123,6 @@ class Field:
         values filled in.
 
         @param name: the name.
-        @type name: a native L{str}
         """
 
         def maybe(
@@ -146,7 +145,6 @@ class Field:
         L{twisted.web.template}.
 
         @return: A new set of tags to include in a template.
-        @rtype: iterable of L{twisted.web.template.Tag}
         """
         value = self.value
         if value is None:
@@ -398,7 +396,6 @@ class RenderableForm:
 
         @return: some HTML elements in the form of renderable objects for
             L{twisted.web.template}
-        @rtype: L{twisted.web.template.Tag}, or L{list} thereof.
         """
         return list(self._fieldForCSRF().asTags())
 
@@ -420,11 +417,7 @@ def defaultValidationFailureHandler(
 
     @param instance: The instance associated with the router that the form
         handler was handled on.
-    @type instance: L{object}
-
     @param request: The request including the form submission.
-    @type request: L{twisted.web.iweb.IRequest}
-
     @return: Any object acceptable from a Klein route.
     """
     session = cast(Componentized, request).getComponent(ISession)

--- a/src/klein/_headers_compat.py
+++ b/src/klein/_headers_compat.py
@@ -60,12 +60,17 @@ class HTTPHeadersWrappingHeaders:
                 Iterable[AnyStr], self._headers.getRawHeaders(name, default=())
             )
         elif isinstance(name, str):
-            values = (
-                headerValueAsText(value)
-                for value in self._headers.getRawHeaders(
+            # type note: getRawHeaders is typed to return an optional even if
+            # default is not None. We could assert not None, but are casting
+            # here so that if the hints for getRawHeaders are fixed later,
+            # mypy will tell us to remove the useless cast.
+            values = cast(
+                Iterable[str],
+                self._headers.getRawHeaders(
                     headerNameAsBytes(name), default=()
-                )
+                ),
             )
+            values = (headerValueAsText(value) for value in values)
         else:
             raise TypeError(f"name {name!r} must be str or bytes")
 

--- a/src/klein/_iform.py
+++ b/src/klein/_iform.py
@@ -3,7 +3,7 @@ class ValidationError(Exception):
     A L{ValidationError} is raised by L{Field.extractValue}.
     """
 
-    def __init__(self, message: str) -> None:
+    def __init__(self, message: object) -> None:
         """
         Initialize a L{ValidationError} with a message to show to the user.
         """

--- a/src/klein/_imessage.py
+++ b/src/klein/_imessage.py
@@ -17,8 +17,6 @@ from hyperlink import DecodedURL
 
 from tubes.itube import IFount
 
-from twisted.internet.defer import Deferred
-
 from zope.interface import Attribute, Interface
 
 
@@ -142,7 +140,7 @@ class IHTTPMessage(Interface):
             accessed.
         """
 
-    def bodyAsBytes() -> Deferred:
+    async def bodyAsBytes() -> bytes:
         """
         The entity body, as bytes.
 

--- a/src/klein/_isession.py
+++ b/src/klein/_isession.py
@@ -10,6 +10,8 @@ from twisted.web.iweb import IRequest
 
 from zope.interface import Attribute, Interface
 
+from ._app import KleinRenderable
+
 
 class NoSuchSession(Exception):
     """
@@ -370,4 +372,4 @@ class EarlyExit(Exception):
         Klein route.
     """
 
-    alternateReturnValue = attr.ib(type=Any)
+    alternateReturnValue = attr.ib(type=KleinRenderable)

--- a/src/klein/_isession.py
+++ b/src/klein/_isession.py
@@ -353,7 +353,7 @@ class IRequiredParameter(Interface):
         """
 
 
-@attr.s
+@attr.s(auto_attribs=True)
 class EarlyExit(Exception):
     """
     An L{EarlyExit} may be raised by any of the code that runs in the
@@ -364,4 +364,4 @@ class EarlyExit(Exception):
         supplied as the route's response.
     """
 
-    alternateReturnValue = attr.ib(type=KleinRenderable)
+    alternateReturnValue: "KleinRenderable"

--- a/src/klein/_isession.py
+++ b/src/klein/_isession.py
@@ -100,8 +100,6 @@ class ISession(Interface):
         L{ISessionStore} implementation you're using.
 
         @param interfaces: A list of interfaces.
-        @type interfaces: L{iterable} of
-            L{zope.interface.interfaces.IInterface}
 
         @return: all of the providers that could be retrieved from the session.
         @rtype: L{Deferred} firing with L{dict} mapping
@@ -239,14 +237,11 @@ class ISessionProcurer(Interface):
         retrieve it.  If not, create a new session and retrieve that.
 
         @param request: The request to procure a session from.
-        @type request: L{twisted.web.server.Request}
-
         @param forceInsecure: Even if the request was transmitted securely
             (i.e. over HTTPS), retrieve the session that would be used by the
             same browser if it were sending an insecure (i.e. over HTTP)
             request; by default, this is False, and the session's security will
             match that of the request.
-        @type forceInsecure: L{bool}
 
         @return: a L{Deferred} that:
 
@@ -266,8 +261,6 @@ class ISessionProcurer(Interface):
                 - fails with L{TooLateForCookies} if the request bound to this
                   procurer has already sent the headers and therefore we can no
                   longer set a cookie, and we need to set a cookie.
-
-        @rtype: L{Session}
         """
 
 
@@ -368,8 +361,6 @@ class EarlyExit(Exception):
 
     @ivar alternateReturnValue: The return value which should instead be
         supplied as the route's response.
-    @type alternateReturnValue: Any type that's acceptable to return from a
-        Klein route.
     """
 
     alternateReturnValue = attr.ib(type=KleinRenderable)

--- a/src/klein/_isession.py
+++ b/src/klein/_isession.py
@@ -1,4 +1,4 @@
-from typing import Any, Callable, Dict, Iterable, Sequence, Type
+from typing import Any, Callable, Dict, Iterable, Sequence, TYPE_CHECKING, Type
 
 import attr
 
@@ -10,7 +10,8 @@ from twisted.web.iweb import IRequest
 
 from zope.interface import Attribute, Interface
 
-from ._app import KleinRenderable
+if TYPE_CHECKING:
+    from ._app import KleinRenderable
 
 
 class NoSuchSession(Exception):

--- a/src/klein/_plating.py
+++ b/src/klein/_plating.py
@@ -202,7 +202,7 @@ class Plating:
     CONTENT = "klein:plating:content"
 
     def __init__(self, defaults=None, tags=None, presentation_slots=()):
-        """"""
+        """ """
         self._defaults = {} if defaults is None else defaults
         self._loader = TagLoader(tags)
         self._presentationSlots = {self.CONTENT} | set(presentation_slots)
@@ -220,7 +220,7 @@ class Plating:
         return renderer
 
     def routed(self, routing, tags):
-        """"""
+        """ """
 
         def mydecorator(method):
             loader = TagLoader(tags)

--- a/src/klein/_plating.py
+++ b/src/klein/_plating.py
@@ -7,11 +7,11 @@ Templating wrapper support for Klein.
 from functools import partial
 from json import dumps
 from operator import setitem
-from typing import Any, Callable, List, Tuple, cast
+from typing import Any, Callable, Generator, List, Tuple, cast
 
 import attr
 
-from twisted.internet.defer import Deferred, inlineCallbacks, returnValue
+from twisted.internet.defer import inlineCallbacks, returnValue
 from twisted.web.error import MissingRenderMethod
 from twisted.web.iweb import IRequest
 from twisted.web.template import Element, Tag, TagLoader
@@ -38,7 +38,7 @@ def _should_return_json(request: IRequest) -> bool:
 
 
 @inlineCallbacks
-def resolveDeferredObjects(root: Any) -> Deferred:
+def resolveDeferredObjects(root: Any) -> Generator[Any, object, Any]:
     """
     Wait on possibly nested L{Deferred}s that represent a JSON
     serializable object.
@@ -112,7 +112,7 @@ def resolveDeferredObjects(root: Any) -> Deferred:
                 f"{obj} not JSON serializable",
             )
 
-    returnValue(result[0])
+    return result[0]
 
 
 def _extra_types(input):
@@ -259,7 +259,7 @@ class Plating:
         slot_data = self._defaults.copy()
         slot_data.update(to_fill_with)
         [loaded] = self._loader.load()
-        loaded = loaded.clone()
+        loaded = loaded.clone()  # type: ignore[union-attr]
         return PlatedElement(
             slot_data=slot_data,
             preloaded=loaded,

--- a/src/klein/_request.py
+++ b/src/klein/_request.py
@@ -14,8 +14,6 @@ from hyperlink import DecodedURL
 
 from tubes.itube import IFount
 
-from twisted.internet.defer import Deferred
-
 from zope.interface import implementer
 
 from ._imessage import IHTTPHeaders, IHTTPRequest
@@ -43,5 +41,5 @@ class FrozenHTTPRequest:
     def bodyAsFount(self) -> IFount:
         return bodyAsFount(self._body, self._state)
 
-    def bodyAsBytes(self) -> Deferred:
-        return bodyAsBytes(self._body, self._state)
+    async def bodyAsBytes(self) -> bytes:
+        return await bodyAsBytes(self._body, self._state)

--- a/src/klein/_request_compat.py
+++ b/src/klein/_request_compat.py
@@ -94,7 +94,7 @@ class HTTPRequestWrappingIRequest:
 
     async def bodyAsBytes(self) -> bytes:
         if self._state.cachedBody is not None:
-            return self._state.cachedBody
+            return self._state.cachedBody  # pragma: no cover
 
         fount = self.bodyAsFount()
         self._state.cachedBody = await fountToBytes(fount)

--- a/src/klein/_request_compat.py
+++ b/src/klein/_request_compat.py
@@ -15,7 +15,6 @@ from hyperlink import DecodedURL
 
 from tubes.itube import IFount
 
-from twisted.internet.defer import Deferred, succeed
 from twisted.python.compat import nativeString
 from twisted.web.iweb import IRequest
 
@@ -93,15 +92,10 @@ class HTTPRequestWrappingIRequest:
 
         return fount
 
-    def bodyAsBytes(self) -> Deferred:
+    async def bodyAsBytes(self) -> bytes:
         if self._state.cachedBody is not None:
-            return succeed(self._state.cachedBody)
-
-        def cache(bodyBytes: bytes) -> bytes:
-            self._state.cachedBody = bodyBytes
-            return bodyBytes
+            return self._state.cachedBody
 
         fount = self.bodyAsFount()
-        d = fountToBytes(fount)
-        d.addCallback(cache)
-        return d
+        self._state.cachedBody = await fountToBytes(fount)
+        return self._state.cachedBody

--- a/src/klein/_requirer.py
+++ b/src/klein/_requirer.py
@@ -1,8 +1,8 @@
-from typing import Any, Callable, Dict, List, Sequence, Type
+from typing import Any, Callable, Dict, Generator, List, Sequence, Type
 
 import attr
 
-from twisted.internet.defer import Deferred, inlineCallbacks, returnValue
+from twisted.internet.defer import inlineCallbacks, returnValue
 from twisted.python.components import Componentized
 from twisted.web.iweb import IRequest
 
@@ -37,7 +37,9 @@ class RequestLifecycle:
         self._prepareHooks.append(beforeHook)
 
     @inlineCallbacks
-    def runPrepareHooks(self, instance: Any, request: IRequest) -> Deferred:
+    def runPrepareHooks(
+        self, instance: Any, request: IRequest
+    ) -> Generator[Any, object, None]:
         """
         Execute all the hooks added with L{RequestLifecycle.addPrepareHook}.
         This is invoked by the L{requires} route machinery.

--- a/src/klein/_resource.py
+++ b/src/klein/_resource.py
@@ -44,7 +44,7 @@ class _StandInResource:
 StandInResource = cast("KleinResource", _StandInResource())
 
 
-class _URLDecodeError(Exception):
+class URLDecodeError(Exception):
     """
     Raised if one or more string parts of the URL could not be decoded.
     """
@@ -62,7 +62,7 @@ class _URLDecodeError(Exception):
         return f"<URLDecodeError(errors={self.errors!r})>"
 
 
-def _extractURLparts(request: IRequest) -> Tuple[str, str, int, str, str]:
+def extractURLparts(request: IRequest) -> Tuple[str, str, int, str, str]:
     """
     Extracts and decodes URI parts from C{request}.
 
@@ -119,7 +119,7 @@ def _extractURLparts(request: IRequest) -> Tuple[str, str, int, str, str]:
         utf8Failures.append(("SCRIPT_NAME", Failure()))
 
     if utf8Failures:
-        raise _URLDecodeError(utf8Failures)
+        raise URLDecodeError(utf8Failures)
 
     return url_scheme, server_name, server_port, path_text, script_text
 
@@ -155,8 +155,8 @@ class KleinResource(Resource):
                 server_port,
                 path_info,
                 script_name,
-            ) = _extractURLparts(request)
-        except _URLDecodeError as e:
+            ) = extractURLparts(request)
+        except URLDecodeError as e:
             for what, fail in e.errors:
                 log.err(fail, f"Invalid encoding in {what}.")
             request.setResponseCode(400)

--- a/src/klein/_resource.py
+++ b/src/klein/_resource.py
@@ -1,6 +1,6 @@
 # -*- test-case-name: klein.test.test_resource -*-
 
-from typing import Any, List, TYPE_CHECKING, Tuple, Union, cast
+from typing import Any, Sequence, TYPE_CHECKING, Tuple, Union, cast
 
 from twisted.internet import defer
 from twisted.internet.defer import Deferred, maybeDeferred
@@ -51,9 +51,10 @@ class _URLDecodeError(Exception):
 
     __slots__ = ["errors"]
 
-    def __init__(self, errors: List[Tuple[str, Failure]]) -> None:
+    def __init__(self, errors: Sequence[Tuple[str, Failure]]) -> None:
         """
-        @param errors: List of decoding errors.
+        @param errors: Sequence of decoding errors, expressed as tuples
+            of names and an associated failure.
         """
         self.errors = errors
 

--- a/src/klein/_response.py
+++ b/src/klein/_response.py
@@ -12,8 +12,6 @@ from attr.validators import instance_of, provides
 
 from tubes.itube import IFount
 
-from twisted.internet.defer import Deferred
-
 from zope.interface import implementer
 
 from ._imessage import IHTTPHeaders, IHTTPResponse
@@ -41,5 +39,5 @@ class FrozenHTTPResponse:
     def bodyAsFount(self) -> IFount:
         return bodyAsFount(self._body, self._state)
 
-    def bodyAsBytes(self) -> Deferred:
-        return bodyAsBytes(self._body, self._state)
+    async def bodyAsBytes(self) -> bytes:
+        return await bodyAsBytes(self._body, self._state)

--- a/src/klein/_session.py
+++ b/src/klein/_session.py
@@ -34,40 +34,23 @@ class SessionProcurer:
     A L{SessionProcurer} procures a session from a request and a store.
 
     @ivar _store: The session store to procure a session from.
-    @type _store: L{klein.interfaces.ISessionStore}
-
     @ivar _maxAge: The maximum age (in seconds) of the session cookie.
-    @type _maxAge: L{int}
-
     @ivar _secureCookie: The name of the cookie to use for sessions protected
         with TLS (i.e. HTTPS).
-    @type _secureCookie: L{bytes}
-
     @ivar _insecureCookie: The name of the cookie to use for sessions I{not}
         protected with TLS (i.e. HTTP).
-    @type _insecureCookie: L{bytes}
-
     @ivar _cookieDomain: If set, the domain name to restrict the session cookie
         to.
-    @type _cookieDomain: L{None} or L{bytes}
-
     @ivar _cookiePath: If set, the URL path to restrict the session cookie to.
-    @type _cookiePath: L{bytes}
-
     @ivar _secureTokenHeader: The name of the HTTPS header to try to extract a
         session token from; API clients should use this header, rather than a
         cookie.
-    @type _secureTokenHeader: L{bytes}
-
     @ivar _insecureTokenHeader: The name of the HTTP header to try to extract a
         session token from; API clients should use this header, rather than a
         cookie.
-    @type _insecureTokenHeader: L{bytes}
-
     @ivar _setCookieOnGET: Automatically request that the session store create
         a session if one is not already associated with the request and the
         request is a GET.
-    @type _setCookieOnGET: L{bool}
     """
 
     _store = attr.ib(type=ISessionStore)

--- a/src/klein/_session.py
+++ b/src/klein/_session.py
@@ -86,7 +86,7 @@ class SessionProcurer:
     def procureSession(
         self, request: IRequest, forceInsecure: bool = False
     ) -> Any:
-        alreadyProcured = request.getComponent(ISession)
+        alreadyProcured = cast(Componentized, request).getComponent(ISession)
         if alreadyProcured is not None:
             if not forceInsecure or not request.isSecure():
                 returnValue(alreadyProcured)

--- a/src/klein/_session.py
+++ b/src/klein/_session.py
@@ -1,6 +1,6 @@
 # -*- test-case-name: klein.test.test_session -*-
 
-from typing import Any, Callable, Dict, Optional, Sequence, Type, Union
+from typing import Any, Callable, Dict, Optional, Sequence, Type, Union, cast
 
 import attr
 
@@ -193,7 +193,7 @@ class SessionProcurer:
             )
         if sentSecurely or not request.isSecure():
             # Do not cache the insecure session on the secure request, thanks.
-            request.setComponent(ISession, session)
+            cast(Componentized, request).setComponent(ISession, session)
         returnValue(session)
 
 

--- a/src/klein/_session.py
+++ b/src/klein/_session.py
@@ -151,7 +151,7 @@ class SessionProcurer:
             session is None or session.identifier != sentCookie
         ):
             if session is None:
-                if request.startedWriting:
+                if request.startedWriting:  # type: ignore[attr-defined]
                     # At this point, if the mechanism is Header, we either have
                     # a valid session or we bailed after NoSuchSession above.
                     raise TooLateForCookies(
@@ -182,7 +182,7 @@ class SessionProcurer:
                 identifierInCookie = identifierInCookie.encode("ascii")
             if not isinstance(cookieName, str):
                 cookieName = cookieName.decode("ascii")
-            request.addCookie(
+            request.addCookie(  # type: ignore[call-arg]
                 cookieName,
                 identifierInCookie,
                 max_age=str(self._maxAge),

--- a/src/klein/_tubes.py
+++ b/src/klein/_tubes.py
@@ -5,7 +5,7 @@ Extensions to Tubes.
 """
 
 from io import BytesIO
-from typing import Any, BinaryIO, Iterable
+from typing import Any, BinaryIO
 
 from attr import attrib, attrs
 from attr.validators import instance_of, optional, provides
@@ -14,7 +14,6 @@ from tubes.itube import IDrain, IFount, ISegment
 from tubes.kit import Pauser, beginFlowingTo
 from tubes.undefer import fountToDeferred
 
-from twisted.internet.defer import Deferred
 from twisted.python.failure import Failure
 
 from zope.interface import implementer
@@ -24,13 +23,9 @@ __all__ = ()
 
 
 # See https://github.com/twisted/tubes/issues/60
-def fountToBytes(fount: IFount) -> Deferred:
-    def collect(chunks: Iterable[bytes]) -> bytes:
-        return b"".join(chunks)
-
-    d = fountToDeferred(fount)
-    d.addCallback(collect)
-    return d
+async def fountToBytes(fount: IFount) -> bytes:
+    chunks = await fountToDeferred(fount)
+    return b"".join(chunks)
 
 
 # See https://github.com/twisted/tubes/issues/60

--- a/src/klein/test/test_app.py
+++ b/src/klein/test/test_app.py
@@ -1,8 +1,12 @@
-import sys
+from sys import stdout
+from typing import cast
 from unittest.mock import Mock, patch
 
 from twisted.python.components import registerAdapter
 from twisted.trial import unittest
+from twisted.web.iweb import IRequest
+
+from zope.interface import implementer
 
 from .test_resource import requestMock
 from .util import EqualityTestsMixin
@@ -12,7 +16,8 @@ from .._decorators import bindable, modified, originalName
 from .._interfaces import IKleinRequest
 
 
-class DummyRequest:
+@implementer(IRequest)
+class DummyRequest:  # type: ignore[misc]  # incomplete interface
     def __init__(self, n):
         self.n = n
 
@@ -274,7 +279,7 @@ class KleinTestCase(unittest.TestCase):
             calls.append(args)
             return 7
 
-        req = object()
+        req = cast(IRequest, object())
         k.execute_endpoint("method", req)
 
         class BoundTo:
@@ -435,7 +440,7 @@ class KleinTestCase(unittest.TestCase):
 
         mock_site.assert_called_with(mock_kr.return_value)
         mock_kr.assert_called_with(app)
-        mock_log.startLogging.assert_called_with(sys.stdout)
+        mock_log.startLogging.assert_called_with(stdout)
 
     @patch("klein._app.KleinResource")
     @patch("klein._app.Site")
@@ -474,7 +479,7 @@ class KleinTestCase(unittest.TestCase):
         app.run(endpoint_description=spec)
         reactor.run.assert_called_with()
         mock_sfs.assert_called_with(reactor, spec)
-        mock_log.startLogging.assert_called_with(sys.stdout)
+        mock_log.startLogging.assert_called_with(stdout)
         mock_kr.assert_called_with(app)
 
     @patch("klein._app.KleinResource")
@@ -494,7 +499,7 @@ class KleinTestCase(unittest.TestCase):
         app.run(endpoint_description=spec)
         reactor.run.assert_called_with()
         mock_sfs.assert_called_with(reactor, spec)
-        mock_log.startLogging.assert_called_with(sys.stdout)
+        mock_log.startLogging.assert_called_with(stdout)
         mock_kr.assert_called_with(app)
 
     @patch("klein._app.KleinResource")

--- a/src/klein/test/test_app.py
+++ b/src/klein/test/test_app.py
@@ -8,7 +8,7 @@ from twisted.web.iweb import IRequest
 
 from zope.interface import implementer
 
-from .test_resource import requestMock
+from .test_resource import MockRequest
 from .util import EqualityTestsMixin
 from .. import Klein
 from .._app import KleinRequest
@@ -526,20 +526,20 @@ class KleinTestCase(unittest.TestCase):
         def foo(req, postid):
             return str(postid)
 
-        request = requestMock(b"/user/john")
+        request = MockRequest(b"/user/john")
         self.assertEqual(
             app.execute_endpoint("userpage", request, "john"), "john"
         )
         self.assertEqual(
-            app.execute_endpoint("bar", requestMock(b"/post/123"), 123), "123"
+            app.execute_endpoint("bar", MockRequest(b"/post/123"), 123), "123"
         )
 
-        request = requestMock(b"/addr")
+        request = MockRequest(b"/addr")
         self.assertEqual(
             app.urlFor(request, "userpage", {"name": "john"}), "/user/john"
         )
 
-        request = requestMock(b"/addr")
+        request = MockRequest(b"/addr")
         self.assertEqual(
             app.urlFor(
                 request, "userpage", {"name": "john"}, force_external=True
@@ -547,7 +547,7 @@ class KleinTestCase(unittest.TestCase):
             "http://localhost:8080/user/john",
         )
 
-        request = requestMock(b"/addr", host=b"example.com", port=4321)
+        request = MockRequest(b"/addr", host=b"example.com", port=4321)
         self.assertEqual(
             app.urlFor(
                 request, "userpage", {"name": "john"}, force_external=True
@@ -555,7 +555,7 @@ class KleinTestCase(unittest.TestCase):
             "http://example.com:4321/user/john",
         )
 
-        request = requestMock(b"/addr")
+        request = MockRequest(b"/addr")
         url = app.urlFor(
             request,
             "userpage",
@@ -564,18 +564,18 @@ class KleinTestCase(unittest.TestCase):
         )
         self.assertEqual(url, "/user/john?age=29")
 
-        request = requestMock(b"/addr")
+        request = MockRequest(b"/addr")
         self.assertEqual(
             app.urlFor(request, "bar", {"postid": 123}), "/post/123"
         )
 
-        request = requestMock(b"/addr")
+        request = MockRequest(b"/addr")
         request.requestHeaders.removeHeader(b"host")
         self.assertEqual(
             app.urlFor(request, "bar", {"postid": 123}), "/post/123"
         )
 
-        request = requestMock(b"/addr")
+        request = MockRequest(b"/addr")
         request.requestHeaders.removeHeader(b"host")
         with self.assertRaises(ValueError):
             app.urlFor(request, "bar", {"postid": 123}, force_external=True)

--- a/src/klein/test/test_form.py
+++ b/src/klein/test/test_form.py
@@ -137,7 +137,7 @@ class TestObject:
         router.route("/render-cascade", methods=["GET"]),
         form=Form.rendererFor(handler, action="/handle"),
     )
-    def cascadeRenderer(self, form: RenderableForm) -> RenderableForm:
+    def cascadeRenderer(self, form: RenderableForm) -> Element:
         class CustomElement(Element):
             @renderer
             def customize(self, request: IRequest, tag: Any) -> Any:

--- a/src/klein/test/test_headers_compat.py
+++ b/src/klein/test/test_headers_compat.py
@@ -18,7 +18,7 @@ from .._headers_compat import HTTPHeadersWrappingHeaders
 
 try:
     from twisted.web.http_headers import _sanitizeLinearWhitespace
-except ImportError:
+except ImportError:  # pragma: no cover
     _sanitizeLinearWhitespace = None  # type: ignore[assignment]
 
 
@@ -27,7 +27,7 @@ def _twistedHeaderNormalize(value: str) -> str:
     Normalize the given header value according to the rules of the installed
     Twisted version.
     """
-    if _sanitizeLinearWhitespace is None:
+    if _sanitizeLinearWhitespace is None:  # pragma: no cover
         return value  # type: ignore[unreachable]
     else:
         return _sanitizeLinearWhitespace(value.encode("utf-8")).decode("utf-8")

--- a/src/klein/test/test_headers_compat.py
+++ b/src/klein/test/test_headers_compat.py
@@ -5,8 +5,6 @@
 Tests for L{klein._headers}.
 """
 
-from typing import cast
-
 from twisted.web.http_headers import Headers
 
 from ._trial import TestCase
@@ -21,7 +19,7 @@ from .._headers_compat import HTTPHeadersWrappingHeaders
 try:
     from twisted.web.http_headers import _sanitizeLinearWhitespace
 except ImportError:
-    _sanitizeLinearWhitespace = None
+    _sanitizeLinearWhitespace = None  # type: ignore[assignment]
 
 
 def _twistedHeaderNormalize(value: str) -> str:
@@ -30,12 +28,9 @@ def _twistedHeaderNormalize(value: str) -> str:
     Twisted version.
     """
     if _sanitizeLinearWhitespace is None:
-        return value
+        return value  # type: ignore[unreachable]
     else:
-        return cast(
-            str,
-            _sanitizeLinearWhitespace(value.encode("utf-8")).decode("utf-8"),
-        )
+        return _sanitizeLinearWhitespace(value.encode("utf-8")).decode("utf-8")
 
 
 __all__ = ()

--- a/src/klein/test/test_message.py
+++ b/src/klein/test/test_message.py
@@ -11,6 +11,8 @@ from typing import cast
 from hypothesis import given
 from hypothesis.strategies import binary
 
+from twisted.internet.defer import ensureDeferred
+
 from ._trial import TestCase
 from .._imessage import IHTTPMessage
 from .._message import FountAlreadyAccessedError, bytesToFount, fountToBytes
@@ -55,7 +57,9 @@ class FrozenHTTPMessageTestsMixIn(ABC):
         """
         message = self.messageFromBytes(data)
         fount = message.bodyAsFount()
-        body = cast(TestCase, self).successResultOf(fountToBytes(fount))
+        body = cast(TestCase, self).successResultOf(
+            ensureDeferred(fountToBytes(fount))
+        )
 
         cast(TestCase, self).assertEqual(body, data)
 
@@ -78,8 +82,9 @@ class FrozenHTTPMessageTestsMixIn(ABC):
         """
         message = self.messageFromFountFromBytes(data)
         fount = message.bodyAsFount()
-        body = cast(TestCase, self).successResultOf(fountToBytes(fount))
-
+        body = cast(TestCase, self).successResultOf(
+            ensureDeferred(fountToBytes(fount))
+        )
         cast(TestCase, self).assertEqual(body, data)
 
     @given(binary())
@@ -100,8 +105,9 @@ class FrozenHTTPMessageTestsMixIn(ABC):
         C{bodyAsBytes} returns the same bytes given to C{__init__}.
         """
         message = self.messageFromBytes(data)
-        body = cast(TestCase, self).successResultOf(message.bodyAsBytes())
-
+        body = cast(TestCase, self).successResultOf(
+            ensureDeferred(message.bodyAsBytes())
+        )
         cast(TestCase, self).assertEqual(body, data)
 
     @given(binary())
@@ -111,9 +117,12 @@ class FrozenHTTPMessageTestsMixIn(ABC):
         created from bytes.
         """
         message = self.messageFromBytes(data)
-        body1 = cast(TestCase, self).successResultOf(message.bodyAsBytes())
-        body2 = cast(TestCase, self).successResultOf(message.bodyAsBytes())
-
+        body1 = cast(TestCase, self).successResultOf(
+            ensureDeferred(message.bodyAsBytes())
+        )
+        body2 = cast(TestCase, self).successResultOf(
+            ensureDeferred(message.bodyAsBytes())
+        )
         cast(TestCase, self).assertIdentical(body1, body2)
 
     @given(binary())
@@ -122,7 +131,9 @@ class FrozenHTTPMessageTestsMixIn(ABC):
         C{bodyAsBytes} returns the bytes from the fount given to C{__init__}.
         """
         message = self.messageFromFountFromBytes(data)
-        body = cast(TestCase, self).successResultOf(message.bodyAsBytes())
+        body = cast(TestCase, self).successResultOf(
+            ensureDeferred(message.bodyAsBytes())
+        )
         cast(TestCase, self).assertEqual(body, data)
 
     @given(binary())
@@ -132,7 +143,10 @@ class FrozenHTTPMessageTestsMixIn(ABC):
         created from a fount.
         """
         message = self.messageFromFountFromBytes(data)
-        body1 = cast(TestCase, self).successResultOf(message.bodyAsBytes())
-        body2 = cast(TestCase, self).successResultOf(message.bodyAsBytes())
-
+        body1 = cast(TestCase, self).successResultOf(
+            ensureDeferred(message.bodyAsBytes())
+        )
+        body2 = cast(TestCase, self).successResultOf(
+            ensureDeferred(message.bodyAsBytes())
+        )
         cast(TestCase, self).assertIdentical(body1, body2)

--- a/src/klein/test/test_plating.py
+++ b/src/klein/test/test_plating.py
@@ -268,7 +268,7 @@ class ResolveDeferredObjectsTests(SynchronousTestCase):
             maybeWrapInDeferred,
         )
 
-        resolved = resolveDeferredObjects(deferredJSONObject)
+        resolved: Deferred[Any] = resolveDeferredObjects(deferredJSONObject)
 
         for value in deferredValues:
             value.resolve()
@@ -303,7 +303,7 @@ class ResolveDeferredObjectsTests(SynchronousTestCase):
             injectPlatingElements,
         )
 
-        resolved = resolveDeferredObjects(withPlatingElements)
+        resolved: Deferred[Any] = resolveDeferredObjects(withPlatingElements)
 
         self.assertEqual(self.successResultOf(resolved), jsonObject)
 

--- a/src/klein/test/test_plating.py
+++ b/src/klein/test/test_plating.py
@@ -19,7 +19,7 @@ from twisted.trial.unittest import (
 from twisted.web.error import FlattenerError, MissingRenderMethod
 from twisted.web.template import slot, tags
 
-from .test_resource import _render, requestMock
+from .test_resource import MockRequest, _render
 from .. import Klein, Plating
 from .._plating import ATOM_TYPES, PlatedElement, resolveDeferredObjects
 
@@ -345,7 +345,7 @@ class PlatingTests(AsynchronousTestCase):
         succeed synchronously, and return the generated request object and
         written bytes.
         """
-        request = requestMock(uri)
+        request = MockRequest(uri)
         d = _render(self.kr, request)
         self.successResultOf(d)
         return request, request.getWrittenData()

--- a/src/klein/test/test_plating.py
+++ b/src/klein/test/test_plating.py
@@ -268,7 +268,7 @@ class ResolveDeferredObjectsTests(SynchronousTestCase):
             maybeWrapInDeferred,
         )
 
-        resolved: Deferred[Any] = resolveDeferredObjects(deferredJSONObject)
+        resolved: "Deferred[Any]" = resolveDeferredObjects(deferredJSONObject)
 
         for value in deferredValues:
             value.resolve()
@@ -303,7 +303,7 @@ class ResolveDeferredObjectsTests(SynchronousTestCase):
             injectPlatingElements,
         )
 
-        resolved: Deferred[Any] = resolveDeferredObjects(withPlatingElements)
+        resolved: "Deferred[Any]" = resolveDeferredObjects(withPlatingElements)
 
         self.assertEqual(self.successResultOf(resolved), jsonObject)
 

--- a/src/klein/test/test_request_compat.py
+++ b/src/klein/test/test_request_compat.py
@@ -6,7 +6,8 @@ Tests for L{klein._irequest}.
 """
 
 from string import ascii_uppercase
-from typing import Optional
+from types import MappingProxyType
+from typing import Any, Mapping, Sequence
 
 from hyperlink import DecodedURL, EncodedURL
 from hyperlink.hypothesis import decoded_urls
@@ -14,7 +15,6 @@ from hyperlink.hypothesis import decoded_urls
 from hypothesis import given
 from hypothesis.strategies import binary, text
 
-from twisted.web.http_headers import Headers
 from twisted.web.iweb import IRequest
 
 from ._trial import TestCase
@@ -26,6 +26,9 @@ from .._request_compat import HTTPRequestWrappingIRequest
 
 
 __all__ = ()
+
+
+emptyMapping: Mapping[Any, Any] = MappingProxyType({})
 
 
 class HTTPRequestWrappingIRequestTests(TestCase):
@@ -41,7 +44,7 @@ class HTTPRequestWrappingIRequestTests(TestCase):
         port: int = 8080,
         isSecure: bool = False,
         body: bytes = b"",
-        headers: Optional[Headers] = None,
+        headers: Mapping[bytes, Sequence[bytes]] = emptyMapping,
     ) -> IRequest:
         return MockRequest(
             path=path,

--- a/src/klein/test/test_request_compat.py
+++ b/src/klein/test/test_request_compat.py
@@ -147,7 +147,7 @@ class HTTPRequestWrappingIRequestTests(TestCase):
 
         self.assertEqual(body, data)
 
-    def test_bodyAsBytesCached(self) -> None:
+    async def test_bodyAsBytesCached(self) -> None:
         """
         L{HTTPRequestWrappingIRequest.bodyAsBytes} called twice returns the
         same object both times.
@@ -155,7 +155,7 @@ class HTTPRequestWrappingIRequestTests(TestCase):
         data = b"some data"
         legacyRequest = self.legacyRequest(body=data)
         request = HTTPRequestWrappingIRequest(request=legacyRequest)
-        body1 = self.successResultOf(request.bodyAsBytes())
-        body2 = self.successResultOf(request.bodyAsBytes())
+        body1 = await request.bodyAsBytes()
+        body2 = await request.bodyAsBytes()
 
         self.assertIdentical(body1, body2)

--- a/src/klein/test/test_request_compat.py
+++ b/src/klein/test/test_request_compat.py
@@ -18,7 +18,7 @@ from twisted.web.http_headers import Headers
 from twisted.web.iweb import IRequest
 
 from ._trial import TestCase
-from .test_resource import requestMock
+from .test_resource import MockRequest
 from .._headers import IHTTPHeaders
 from .._message import FountAlreadyAccessedError
 from .._request import IHTTPRequest
@@ -43,7 +43,7 @@ class HTTPRequestWrappingIRequestTests(TestCase):
         body: bytes = b"",
         headers: Optional[Headers] = None,
     ) -> IRequest:
-        return requestMock(
+        return MockRequest(
             path=path,
             method=method,
             host=host,

--- a/src/klein/test/test_request_compat.py
+++ b/src/klein/test/test_request_compat.py
@@ -15,6 +15,7 @@ from hyperlink.hypothesis import decoded_urls
 from hypothesis import given
 from hypothesis.strategies import binary, text
 
+from twisted.internet.defer import ensureDeferred
 from twisted.web.iweb import IRequest
 
 from ._trial import TestCase
@@ -146,7 +147,7 @@ class HTTPRequestWrappingIRequestTests(TestCase):
         """
         legacyRequest = self.legacyRequest(body=data)
         request = HTTPRequestWrappingIRequest(request=legacyRequest)
-        body = self.successResultOf(request.bodyAsBytes())
+        body = self.successResultOf(ensureDeferred(request.bodyAsBytes()))
 
         self.assertEqual(body, data)
 

--- a/src/klein/test/test_requirer.py
+++ b/src/klein/test/test_requirer.py
@@ -1,4 +1,4 @@
-from typing import Iterable, List, Tuple, cast
+from typing import Iterator, List, Tuple, cast
 
 from hyperlink import DecodedURL
 
@@ -21,7 +21,7 @@ class BadlyBehavedHeaders(Headers):
     getAllRequestHeaders.
     """
 
-    def getAllRawHeaders(self) -> Iterable[Tuple[bytes, List[bytes]]]:
+    def getAllRawHeaders(self) -> Iterator[Tuple[bytes, List[bytes]]]:
         """
         Don't return a host header.
         """

--- a/src/klein/test/test_requirer.py
+++ b/src/klein/test/test_requirer.py
@@ -1,4 +1,4 @@
-from typing import Iterator, List, Tuple, cast
+from typing import Iterator, Sequence, Tuple, cast
 
 from hyperlink import DecodedURL
 
@@ -21,7 +21,7 @@ class BadlyBehavedHeaders(Headers):
     getAllRequestHeaders.
     """
 
-    def getAllRawHeaders(self) -> Iterator[Tuple[bytes, List[bytes]]]:
+    def getAllRawHeaders(self) -> Iterator[Tuple[bytes, Sequence[bytes]]]:
         """
         Don't return a host header.
         """

--- a/src/klein/test/test_requirer.py
+++ b/src/klein/test/test_requirer.py
@@ -4,6 +4,7 @@ from hyperlink import DecodedURL
 
 from treq.testing import StubTreq
 
+from twisted.python.components import Componentized
 from twisted.trial.unittest import SynchronousTestCase
 from twisted.web.http_headers import Headers
 from twisted.web.iweb import IRequest
@@ -57,7 +58,7 @@ def provideSample(request: IRequest) -> None:
     """
     This requirer prerequisite installs a string as the provider of ISample.
     """
-    request.setComponent(ISample, "sample component")
+    cast(Componentized, request).setComponent(ISample, "sample component")
 
 
 @requirer.require(

--- a/src/klein/test/test_resource.py
+++ b/src/klein/test/test_resource.py
@@ -135,7 +135,7 @@ def _render(
         return succeed(None)
 
     if result is not NOT_DONE_YET:  # type: ignore[comparison-overlap]
-        raise AssertionError("unreachable")
+        raise AssertionError("unreachable")  # pragma: no cover
 
     if request.finished or not notifyFinish:  # type: ignore[attr-defined]
         return succeed(None)

--- a/src/klein/test/test_resource.py
+++ b/src/klein/test/test_resource.py
@@ -1166,19 +1166,22 @@ class KleinResourceTests(SynchronousTestCase):
         URLDecodeError.__repr__ formats properly.
         """
         try:
-            raise ValueError()
+            raise ValueError("value")
         except ValueError:
             valueFailure = Failure()
 
         try:
-            raise TypeError()
+            raise TypeError("type")
         except TypeError:
             typeFailure = Failure()
 
         error = URLDecodeError([("VALUE", valueFailure), ("TYPE", typeFailure)])
         self.assertEqual(
-            "<URLDecodeError(errors=[('VALUE', <class 'ValueError'>), "
-            "('TYPE', <class 'TypeError'>)])>",
+            "<URLDecodeError(errors=["
+            "('VALUE', "
+            "<twisted.python.failure.Failure builtins.ValueError: value>), "
+            "('TYPE', "
+            "<twisted.python.failure.Failure builtins.TypeError: type>)])>",
             repr(error),
         )
 

--- a/src/klein/test/test_resource.py
+++ b/src/klein/test/test_resource.py
@@ -1,6 +1,7 @@
 import os
 from io import BytesIO
-from typing import List, Mapping, Optional, Sequence
+from types import MappingProxyType
+from typing import Any, List, Mapping, Optional, Sequence
 from unittest.mock import Mock, call
 from urllib.parse import parse_qs
 
@@ -31,6 +32,9 @@ from .._resource import (
 )
 
 
+emptyMapping: Mapping[Any, Any] = MappingProxyType({})
+
+
 class MockRequest(server.Request):
     def __init__(
         self,
@@ -40,7 +44,7 @@ class MockRequest(server.Request):
         port: int = 8080,
         isSecure: bool = False,
         body: bytes = b"",
-        headers: Optional[Mapping[bytes, Sequence[bytes]]] = None,
+        headers: Mapping[bytes, Sequence[bytes]] = emptyMapping,
     ):
         super().__init__(DummyChannel(), False)
 

--- a/src/klein/test/test_resource.py
+++ b/src/klein/test/test_resource.py
@@ -158,11 +158,11 @@ class SimpleElement(Element):
 
 
 class DeferredElement(SimpleElement):
-    deferred: Deferred[None]
+    deferred: "Deferred[None]"
 
     @renderer
-    def name(self, request: IRequest, tag: Tag) -> Deferred[None]:
-        self.deferred: Deferred[None] = Deferred()
+    def name(self, request: IRequest, tag: Tag) -> "Deferred[None]":
+        self.deferred: "Deferred[None]" = Deferred()
         self.deferred.addCallback(lambda ignored: tag(self._name))
         return self.deferred
 
@@ -387,7 +387,7 @@ class KleinResourceTests(SynchronousTestCase):
     def test_deferredRendering(self) -> None:
         app = self.app
 
-        deferredResponse: Deferred[bytes] = Deferred()
+        deferredResponse: "Deferred[bytes]" = Deferred()
 
         @app.route("/deferred")
         def deferred(request: IRequest) -> KleinRenderable:
@@ -1009,7 +1009,7 @@ class KleinResourceTests(SynchronousTestCase):
         app = self.app
         request = MockRequest(b"/")
 
-        finished: Deferred[bytes] = Deferred()
+        finished: "Deferred[bytes]" = Deferred()
 
         @app.route("/")
         def root(request: IRequest) -> KleinRenderable:
@@ -1048,7 +1048,7 @@ class KleinResourceTests(SynchronousTestCase):
         @app.route("/")
         def root(request: IRequest) -> KleinRenderable:
             assert isinstance(request, Request)
-            _d: Deferred[bytes] = Deferred()
+            _d: "Deferred[bytes]" = Deferred()
             _d.addErrback(cancelled.append)
             request.notifyFinish().addCallback(lambda _: _d.cancel())
             return _d
@@ -1088,7 +1088,7 @@ class KleinResourceTests(SynchronousTestCase):
         app = self.app
         request = MockRequest(b"/")
 
-        inner_d: Deferred[bytes] = Deferred()
+        inner_d: "Deferred[bytes]" = Deferred()
 
         @app.route("/")
         def root(request: IRequest) -> KleinRenderable:
@@ -1126,7 +1126,7 @@ class KleinResourceTests(SynchronousTestCase):
 
         @app.route("/")
         def root(request: IRequest) -> KleinRenderable:
-            _d: Deferred[bytes] = Deferred()
+            _d: "Deferred[bytes]" = Deferred()
             assert isinstance(request, Request)
             request.notifyFinish().addErrback(lambda _: _d.cancel())
             return _d
@@ -1152,7 +1152,7 @@ class KleinResourceTests(SynchronousTestCase):
         app = self.app
         request = MockRequest(b"/")
 
-        handler_d: Deferred[bytes] = Deferred()
+        handler_d: "Deferred[bytes]" = Deferred()
 
         @app.route("/")
         def root(request: IRequest) -> KleinRenderable:

--- a/src/klein/test/test_session.py
+++ b/src/klein/test/test_session.py
@@ -2,7 +2,7 @@
 Tests for L{klein._session}.
 """
 
-from typing import List, Tuple, Type
+from typing import Any, Generator, List, Tuple, Type
 
 from treq.testing import StubTreq
 
@@ -65,8 +65,8 @@ def simpleSessionRouter() -> Tuple[Sessions, Errors, str, str, StubTreq]:
     """
     Construct a simple router.
     """
-    sessions = []
-    exceptions = []
+    sessions: Sessions = []
+    exceptions: Errors = []
     mss = MemorySessionStore.fromAuthorizers([memoryAuthorizer])
     router = Klein()
     token = "X-Test-Session-Token"
@@ -79,12 +79,14 @@ def simpleSessionRouter() -> Tuple[Sessions, Errors, str, str, StubTreq]:
 
     @router.route("/")
     @inlineCallbacks
-    def route(request: IRequest) -> Deferred:
+    def route(request: IRequest) -> Generator[Any, object, bytes]:
         try:
-            sessions.append((yield sproc.procureSession(request)))
+            sessions.append(
+                (yield sproc.procureSession(request)),  # type: ignore[arg-type]
+            )
         except NoSuchSession as nss:
             exceptions.append(nss)
-        returnValue(b"ok")
+        return b"ok"
 
     requirer = Requirer()
 
@@ -122,14 +124,14 @@ class ProcurementTests(SynchronousTestCase):
 
         @router.route("/")
         @inlineCallbacks
-        def route(request: IRequest) -> Deferred:
+        def route(request: IRequest) -> Generator[Any, object, bytes]:
             sproc = SessionProcurer(mss)
             sessions.append((yield sproc.procureSession(request)))
             sessions.append((yield sproc.procureSession(request)))
             sessions.append(
                 (yield sproc.procureSession(request, forceInsecure=True))
             )
-            returnValue(b"sessioned")
+            return b"sessioned"
 
         treq = StubTreq(router.resource())
         self.successResultOf(treq.get("http://unittest.example.com/"))
@@ -148,9 +150,9 @@ class ProcurementTests(SynchronousTestCase):
         mss = MemorySessionStore()
         router = Klein()
 
-        @router.route("/")
+        @router.route("/")  # type: ignore[arg-type]
         @inlineCallbacks
-        def route(request: IRequest) -> Deferred:
+        def route(request: IRequest) -> Generator[Any, object, None]:
             sproc = SessionProcurer(mss)
             request.write(b"oops...")
             with self.assertRaises(TooLateForCookies):
@@ -172,7 +174,7 @@ class ProcurementTests(SynchronousTestCase):
 
         @router.route("/")
         @inlineCallbacks
-        def route(request: IRequest) -> Deferred:
+        def route(request: IRequest) -> Generator[Any, object, bytes]:
             sproc = SessionProcurer(mss, setCookieOnGET=False)
             with self.assertRaises(NoSuchSession):
                 yield sproc.procureSession(request)

--- a/src/klein/test/util.py
+++ b/src/klein/test/util.py
@@ -3,8 +3,9 @@ Shared tools for Klein's test suite.
 """
 
 from abc import ABC, abstractmethod
-from typing import cast
+from typing import Type, TypeVar, cast
 
+from twisted.internet.defer import Deferred
 from twisted.trial.unittest import SynchronousTestCase
 
 
@@ -127,3 +128,12 @@ class EqualityTestsMixin(ABC):
         a = self.anInstance()
         b = Delegate()
         cast(SynchronousTestCase, self).assertEqual(a != b, [b])
+
+
+_T = TypeVar("_T")
+
+
+def recover(d: Deferred[_T], exc_type: Type[Exception]) -> Deferred[_T]:
+    return d.addErrback(
+        lambda f: f.trap(exc_type)  # type: ignore[no-any-return]
+    )

--- a/src/klein/test/util.py
+++ b/src/klein/test/util.py
@@ -133,7 +133,7 @@ class EqualityTestsMixin(ABC):
 _T = TypeVar("_T")
 
 
-def recover(d: Deferred[_T], exc_type: Type[Exception]) -> Deferred[_T]:
+def recover(d: "Deferred[_T]", exc_type: Type[Exception]) -> "Deferred[_T]":
     return d.addErrback(
         lambda f: f.trap(exc_type)  # type: ignore[no-any-return]
     )

--- a/tox.ini
+++ b/tox.ini
@@ -22,7 +22,6 @@ deps =
     tw212: Twisted==21.2.0
     twcurrent: Twisted
     twtrunk: https://github.com/twisted/twisted/tarball/trunk#egg=Twisted
-    mypy: Twisted==20.3.0
 
     attrs==20.3.0
     Automat==20.2.0


### PR DESCRIPTION
Un-pin Twisted when running Mypy.

It's pinned right now because with Twisted 21, we have numerous new errors.