### PR TITLE
Create pth file to start coverage in subprocesses

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,5 +1,6 @@
 [run]
 branch = True
+parallel = True
 source = klein
 
 [paths]

--- a/tox.ini
+++ b/tox.ini
@@ -74,14 +74,17 @@ setenv =
 
     coverage: COVERAGE_FILE={toxworkdir}/coverage.{envname}
 
+    TRIAL_JOBS={env:TRIAL_JOBS:"--jobs=2"}
     HYPOTHESIS_STORAGE_DIRECTORY={toxworkdir}/hypothesis
 
 commands =
     # Run trial without coverage
-    test: trial --random=0 --jobs=2 --logfile="{envlogdir}/trial.log" --temp-directory="{envlogdir}/trial.d" {posargs:{env:PY_MODULE}}
+    test: trial --random=0 {env:TRIAL_JOBS} --logfile="{envlogdir}/trial.log" --temp-directory="{envlogdir}/trial.d" {posargs:{env:PY_MODULE}}
 
+    # See https://coverage.readthedocs.io/en/coverage-5.5/subprocess.html
+    coverage: python -c 'f=open("{envsitepackagesdir}/zz_coverage.pth", "w"); f.write("import coverage; coverage.process_startup()")'
     # Run trial with coverage
-    coverage: coverage run --source {env:PY_MODULE} "{envdir}/bin/trial" --random=0 --jobs=2 --logfile="{envlogdir}/trial.log" --temp-directory="{envlogdir}/trial.d" {posargs:{env:PY_MODULE}}
+    coverage: coverage run --source="{env:PY_MODULE}" "{envdir}/bin/trial" --random=0 {env:TRIAL_JOBS} --logfile="{envlogdir}/trial.log" --temp-directory="{envlogdir}/trial.d" {posargs:{env:PY_MODULE}}
 
     # Run coverage reports, ignore exit status
     coverage: - coverage report --skip-covered

--- a/tox.ini
+++ b/tox.ini
@@ -73,18 +73,28 @@ setenv =
     {[default]setenv}
 
     coverage: COVERAGE_FILE={toxworkdir}/coverage.{envname}
+    coverage: COVERAGE_PROCESS_START={toxinidir}/.coveragerc
 
-    TRIAL_JOBS={env:TRIAL_JOBS:"--jobs=2"}
+    TRIAL_JOBS={env:TRIAL_JOBS:--jobs=2}
     HYPOTHESIS_STORAGE_DIRECTORY={toxworkdir}/hypothesis
 
 commands =
     # Run trial without coverage
     test: trial --random=0 {env:TRIAL_JOBS} --logfile="{envlogdir}/trial.log" --temp-directory="{envlogdir}/trial.d" {posargs:{env:PY_MODULE}}
 
-    # See https://coverage.readthedocs.io/en/coverage-5.5/subprocess.html
-    coverage: python -c 'f=open("{envsitepackagesdir}/zz_coverage.pth", "w"); f.write("import coverage; coverage.process_startup()")'
     # Run trial with coverage
+    # Notes:
+    #  - Because we run tests in parallel, which uses multiple subprocesses,
+    #      we need to drop in a .pth file that causes coverage to start when
+    #      Python starts. See:
+    #      https://coverage.readthedocs.io/en/coverage-5.5/subprocess.html
+    #  - We use coverage in parallel mode, then combine here to get the results
+    #      to get a unified result for the current test environment.
+    #  - Use `tox -e coverage_report` to generate a report for all environments.
+    coverage: python -c 'f=open("{envsitepackagesdir}/zz_coverage.pth", "w"); f.write("import coverage; coverage.process_startup()\n")'
+    coverage: coverage erase
     coverage: coverage run --source="{env:PY_MODULE}" "{envdir}/bin/trial" --random=0 {env:TRIAL_JOBS} --logfile="{envlogdir}/trial.log" --temp-directory="{envlogdir}/trial.d" {posargs:{env:PY_MODULE}}
+    coverage: coverage combine
 
     # Run coverage reports, ignore exit status
     coverage: - coverage report --skip-covered
@@ -206,8 +216,8 @@ commands =
 description = generate coverage report
 
 depends =
-    coverage-py{36,37,38,39,py3}-tw{1,2}{0,1,2,3,4,5,6,7,8,9}{0,1,2,3,4,5,6,7,8,9}
-    coverage-py{36,37,38,39,py3}-tw{current,trunk}
+    coverage-py{36,37,38,39,310,py3}-tw{1,2}{0,1,2,3,4,5,6,7,8,9}{0,1,2,3,4,5,6,7,8,9}
+    coverage-py{36,37,38,39,310,py3}-tw{current,trunk}
 
 basepython = {[default]basepython}
 


### PR DESCRIPTION
This is to address the giant (60%) coverage drop after we added the `--jobs=2` argument to `trial`.