### PR TITLE
Remove --ignore-errors when building coverage XML.

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -272,7 +272,7 @@ setenv =
 commands =
     # Note documentation for CI variables in passenv above
     coverage combine
-    coverage xml --ignore-errors -o "{env:COVERAGE_XML}"
+    coverage xml -o "{env:COVERAGE_XML}"
     codecov --file="{env:COVERAGE_XML}" --env                 \
         GITHUB_REF GITHUB_COMMIT GITHUB_USER GITHUB_WORKFLOW  \
         TRAVIS_BRANCH TRAVIS_BUILD_WEB_URL                    \


### PR DESCRIPTION
`--ignore-errors` was added when building coverage XML due to `async`/`await` syntax confusing older python versions.

I think it may no longer be necessary.