### PR TITLE
Fix links, port POST example to Python 3

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -12,7 +12,7 @@ Klein, a Web Micro-Framework
     :target: https://requires.io/github/twisted/klein/requirements/?branch=master
     :alt: Requirements Status
 .. image:: https://img.shields.io/pypi/pyversions/klein.svg
-    :target: https://pypi.python.org/pypi/klein
+    :target: https://pypi.org/project/klein
     :alt: Python Version Compatibility
 
 Klein is a micro-framework for developing production-ready web services with Python.

--- a/docs/examples/handlingpost.rst
+++ b/docs/examples/handlingpost.rst
@@ -18,18 +18,18 @@ So the ``POST`` handler must be defined before the handler with no ``methods``.
     from twisted.internet.defer import succeed
     from klein import run, route
 
-    name='world'
+    name = b"world"
 
-    @route('/', methods=['POST'])
+    @route("/", methods=["POST"])
     def setname(request):
         global name
-        name = request.args.get('name', ['world'])[0]
+        name = request.args.get(b'name', [b'world'])[0]
         request.redirect('/')
         return succeed(None)
 
     @route('/')
     def hello(request):
-        return "Hello, {0}!".format(name)
+        return b"Hello, %s!" % (name,)
 
     run("localhost", 8080)
 

--- a/docs/examples/handlingpost.rst
+++ b/docs/examples/handlingpost.rst
@@ -43,22 +43,22 @@ Accessing the request content
 =============================
 
 To read the content of the request use the ``read`` method of
-:api:`twisted.web.iweb.IRequest.content <IRequest.content>`
+:api:`twisted.web.iweb.IRequest <IRequest.content>`
 
 .. code-block:: python
 
     from klein import run, route
     import json
-    
+
     @route('/', methods=['POST'])
     def do_post(request):
         content = json.loads(request.content.read())
         response = json.dumps(dict(the_data=content), indent=4)
         return response
-    
+
     run("localhost", 8080)
- 
- 
+
+
 The following curl command can be used to test this behaviour::
- 
-	 curl -XPOST -v -H 'Content-Type: appliction/json' -d '{"name":"bob"}'  http://localhost:8080/
+
+     curl -XPOST -v -H 'Content-Type: appliction/json' -d '{"name":"bob"}'  http://localhost:8080/

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -2,8 +2,6 @@
 Klein, a Web Micro-Framework
 ============================
 
-.. image:: https://travis-ci.org/twisted/klein.png?branch=master
-
 Klein is a micro-framework for developing production-ready web services with Python.
 It's built on widely used and well tested components like Werkzeug and Twisted, and has near-complete test coverage.
 


### PR DESCRIPTION
This fixes a dead link that I noticed while looking at #478, updates a PyPI link, and removes a living-dead link to Travis.

I also ported one of the examples to Python 3 since I noticed it was using the wrong types in `request.args` while fixing an adjacent link.