### PR TITLE
Don't run coverage on pypy.

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -225,7 +225,13 @@ jobs:
         run: |
           py = "${{ matrix.python-version }}".replace(".", "").replace("pypy", "py")
           tw = "${{ matrix.twisted }}".replace(".", "")
-          print(f"::set-output name=value::coverage-py{py}-tw{tw}")
+          with_coverage = 'coverage-'
+          if 'py' in py:
+              # Coverage is disabled on PYPY as the run is slow and we
+              # don't have PYPY specific code.
+              with_coverage = ''
+          print(f"::set-output name=value::{with_coverage}py{py}-tw{tw}")
+          print(f"::set-output name=has_coverage::{with_coverage}")
 
       - name: Set up Tox environment
         run: |
@@ -253,17 +259,9 @@ jobs:
         with:
           python-version: "3.9"
 
-      - name: "Combine coverage"
-        run: |
-          set -eux
-          pip install coverage[toml];
-          coverage combine;
-          coverage xml;
-        env:
-          COVERAGE_FILE: .tox/coverage
-
       - name: "Upload coverage to Codecov"
         uses: "codecov/codecov-action@v1"
+        if: steps.tox_env.outputs.has_coverage
         with:
           env_vars: GITHUB_REF,GITHUB_COMMIT,GITHUB_USER,GITHUB_WORKFLOW
           fail_ci_if_error: true

--- a/tox.ini
+++ b/tox.ini
@@ -95,6 +95,7 @@ commands =
     coverage: coverage erase
     coverage: coverage run --source="{env:PY_MODULE}" "{envdir}/bin/trial" --random=0 {env:TRIAL_JOBS} --logfile="{envlogdir}/trial.log" --temp-directory="{envlogdir}/trial.d" {posargs:{env:PY_MODULE}}
     coverage: coverage combine
+    coverage: coverage xml
 
     # Run coverage reports, ignore exit status
     coverage: - coverage report --skip-covered


### PR DESCRIPTION
# Scope

To speed up the tests we can run pypy tests without coverage.

I have checked the source code and I don't see any specific pypy handling in klein.

The coverage run on pypy is slow as there is no extension to speed the run.

# Changes

Don't run coverage on pypy.
Move coverage combine and XML generation into tox.ini ... we already had combine... but no xml generate.
XML generate in tox can help with a future usage of local `diff_cover`


# Before

See for example a run with coverage enabled on pypy

![image](https://user-images.githubusercontent.com/204609/115113864-49f19280-9f84-11eb-98db-13e6fa6fffd0.png)

# After

With faster pypy and no coverage changes or decrease in coverage
  
![image](https://user-images.githubusercontent.com/204609/115114696-83c49800-9f88-11eb-999d-b2af0f870e6d.png)
