### PR TITLE
Upgrade Werkzeug to 2.x and fix affected tests

### DIFF
--- a/src/klein/_app.py
+++ b/src/klein/_app.py
@@ -137,9 +137,8 @@ def buildURL(
     force_external: bool = False,
     append_unknown: bool = True,
 ) -> str:
-    return cast(
-        str,
-        mapper.build(endpoint, values, method, force_external, append_unknown),
+    return mapper.build(
+        endpoint, values, method, force_external, append_unknown
     )
 
 

--- a/src/klein/test/test_resource.py
+++ b/src/klein/test/test_resource.py
@@ -621,7 +621,7 @@ class KleinResourceTests(SynchronousTestCase):
         request.setHeader.assert_has_calls(
             [
                 call(b"Content-Type", b"text/html; charset=utf-8"),
-                call(b"Content-Length", b"259"),
+                call(b"Content-Length", b"258"),
                 call(b"Location", b"http://localhost:8080/foo/"),
             ]
         )

--- a/tox.ini
+++ b/tox.ini
@@ -35,7 +35,7 @@ deps =
     PyHamcrest==2.0.2
     six==1.15.0
     Tubes==0.2.0
-    Werkzeug==1.0.1
+    Werkzeug==2.0.1
     zope.interface==5.2.0
 
     {test,coverage}: treq==21.1.0


### PR DESCRIPTION
* A redundant space before the word "If" is remove in Werkzeug 2.0
https://github.com/pallets/werkzeug/commit/5fd13860d7f649fbe592601b1dea728050daffa5#diff-b9d6906a0da8b5a9877b17ac5ea491161a660ce7e513921738d3e284bd9e9c96L528

* A `cast()` is no longer needed as Werkzeug 2.x is properly
  type-annotated: https://github.com/pallets/werkzeug/commit/967b2dabed79c4a999cfb0e6d5bf01437b246dee

I noticed this when I was testing klein with the latest Python packages. Someone Werkzeug is not automatically upgraded via requires.io, and several others (e.g., attrs, six) are already out-dated before the last requires.io pull request (https://github.com/twisted/klein/pull/498), too. I guess something was wrong at their end.