### PR TITLE
Release 21.8

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -13,3 +13,6 @@ line_length = 80
 # Twisted as a second party in the middle.
 known_secondparty = twisted
 sections = FUTURE,STDLIB,THIRDPARTY,SECONDPARTY,FIRSTPARTY,LOCALFOLDER
+
+# Skip generated files
+skip = _version.py

--- a/NEWS.rst
+++ b/NEWS.rst
@@ -6,7 +6,9 @@ NEXT
  * Python 2 is no longer supported by Klein.
  * Python 3.5 is no longer supported by Klein.
  * Python 3.9 is now supported by Klein. [`#412 <https://github.com/twisted/klein/pull/412>`_]
- * Klein now exports (incomplete, but growing) type hints. [`#379 <https://github.com/twisted/klein/pull/379>`_]
+ * Fixed a compatibility issue with Twisted versions greater than 20.3.0 in Klein's test suite. [`#383 <https://github.com/twisted/klein/pull/383>`]
+ * Fixed a compatibility issue with Werkzeug versions greater than 2.0 in Klein's test suite. [`#499 <https://github.com/twisted/klein/pull/499>`]
+ * Klein has incomplete, but growing type hints, but ``py.typed`` is not installed, as they might not work well for most clients yet.
  * ``Plating`` now sets the ``Content-Type`` header to ``application/json`` instead of ``text/json; charset=utf8``.
 
 20.6.0 - 2020-06-07

--- a/release.py
+++ b/release.py
@@ -307,8 +307,12 @@ def bump() -> None:
 
 
 @main.command()
-@commandOption("--test/--production")
-@commandOption("--final/--candidate")
+@commandOption(
+    "--test/--production", help="Use test (or production) PyPI server"
+)
+@commandOption(
+    "--final/--candidate", help="Publish a final (or candidate) release"
+)
 def publish(final: bool, test: bool) -> None:
     publishRelease(final=final, test=test)
 

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ if __name__ == "__main__":
         packages=["klein", "klein.storage", "klein.test"],
         package_dir={"": "src"},
         package_data=dict(
-            klein=["py.typed"],
+            klein=[],
         ),
         url="https://github.com/twisted/klein",
         maintainer="Twisted Matrix Laboratories",

--- a/src/klein/_version.py
+++ b/src/klein/_version.py
@@ -8,5 +8,5 @@ Provides klein version information.
 from incremental import Version
 
 
-__version__ = Version("klein", 20, 6, 0)
+__version__ = Version("klein", 21, 8, 0, release_candidate=1)
 __all__ = ["__version__"]

--- a/src/klein/_version.py
+++ b/src/klein/_version.py
@@ -7,6 +7,5 @@ Provides klein version information.
 
 from incremental import Version
 
-
 __version__ = Version("klein", 21, 8, 0, release_candidate=1)
 __all__ = ["__version__"]

--- a/src/klein/py.typed
+++ b/src/klein/py.typed
@@ -1,1 +1,0 @@
-# See: https://www.python.org/dev/peps/pep-0561/

--- a/tox.ini
+++ b/tox.ini
@@ -25,21 +25,21 @@ deps =
     twtrunk: --use-deprecated=legacy-resolver
     twtrunk: https://github.com/twisted/twisted/tarball/trunk#egg=Twisted
 
-    attrs==20.3.0
+    attrs==21.2.0
     Automat==20.2.0
     characteristic==14.3.0
     constantly==15.1.0
     hyperlink==21.0.0
     incremental==21.3.0
     PyHamcrest==2.0.2
-    six==1.15.0
+    six==1.16.0
     Tubes==0.2.0
     Werkzeug==2.0.1
-    zope.interface==5.2.0
+    zope.interface==5.4.0
 
-    {test,coverage}: treq==21.1.0
-    {test,coverage}: hypothesis==6.2.0
-    {test,coverage}: idna==3.1
+    {test,coverage}: treq==21.5.0
+    {test,coverage}: hypothesis==6.14.6
+    {test,coverage}: idna==3.2
 
     coverage: {[testenv:coverage_report]deps}
 
@@ -166,7 +166,7 @@ deps =
     # Note: mypy-zope pins the mypy version
     mypy==0.910
     mypy-zope==0.3.2
-    types-click==7.1.2
+    types-click==7.1.4
 
     {[default]deps}
 


### PR DESCRIPTION
This release excludes `py.typed`, as type hints aren't fully baked