### PR TITLE
Revert "Don't install py.typed"

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ if __name__ == "__main__":
         packages=["klein", "klein.storage", "klein.test"],
         package_dir={"": "src"},
         package_data=dict(
-            klein=[],
+            klein=["py.typed"],
         ),
         url="https://github.com/twisted/klein",
         maintainer="Twisted Matrix Laboratories",

--- a/src/klein/py.typed
+++ b/src/klein/py.typed
@@ -1,0 +1,1 @@
+# See: https://www.python.org/dev/peps/pep-0561/


### PR DESCRIPTION
This reverts commit 3149dc985ca09418c86beccd618c881e6decc246.