### PR TITLE
workaround for `trial -j` bug with log paths

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -69,7 +69,7 @@ setenv =
 
 commands =
     # Run trial without coverage
-    test: trial --random=0 {env:TRIAL_JOBS} --logfile="{envlogdir}/trial.log" --temp-directory="{envlogdir}/trial.d" {posargs:{env:PY_MODULE}}
+    test: trial --random=0 {env:TRIAL_JOBS} --temp-directory="{envlogdir}/trial.d" {posargs:{env:PY_MODULE}}
 
     # Run trial with coverage
     # Notes:
@@ -82,7 +82,7 @@ commands =
     #  - Use `tox -e coverage_report` to generate a report for all environments.
     coverage: python -c 'f=open("{envsitepackagesdir}/zz_coverage.pth", "w"); f.write("import coverage; coverage.process_startup()\n")'
     coverage: coverage erase
-    coverage: coverage run --source="{env:PY_MODULE}" "{envdir}/bin/trial" --random=0 {env:TRIAL_JOBS} --logfile="{envlogdir}/trial.log" --temp-directory="{envlogdir}/trial.d" {posargs:{env:PY_MODULE}}
+    coverage: coverage run --source="{env:PY_MODULE}" "{envdir}/bin/trial" --random=0 {env:TRIAL_JOBS} --temp-directory="{envlogdir}/trial.d" {posargs:{env:PY_MODULE}}
     coverage: coverage combine
     coverage: coverage xml
 


### PR DESCRIPTION
the bug in question: https://github.com/twisted/twisted/issues/11580

fixes #486

the `--logfile` option is intended to be a *relative* path from the temp dir
anyway, so even after this bug is fixed we should not put this back; I have no
idea how we ended up with this in the first place.