### PR TITLE
Remove Deferred cancellation on client reset

### DIFF
--- a/src/klein/_resource.py
+++ b/src/klein/_resource.py
@@ -205,11 +205,6 @@ class KleinResource(Resource):
             d = maybeDeferred(
                 self._app.execute_endpoint, endpoint, request, **kwargs
             )
-
-            request.notifyFinish().addErrback(  # type: ignore[attr-defined]
-                lambda _: d.cancel(),
-            )
-
             return d
 
         d = maybeDeferred(_execute)


### PR DESCRIPTION
See https://github.com/twisted/klein/issues/546.

We have been running a similar patch on our enterprise production systems for about 6 months with no issues, and critically we have stopped getting issues on client resets.