### PR TITLE
[#572] Get the GitHub Action CI green.

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -277,3 +277,31 @@ jobs:
           GITHUB_COMMIT: ${{ github.sha }}
           GITHUB_USER: ${{ github.actor }}
           GITHUB_WORKFLOW: ${{ github.workflow }}
+
+  # Helper so that on GitHub repo settings we can configure to single job.
+  # Then required jobs can be updated directly form the code,
+  # without having to go the GitHub repo setting -> Protected branch
+  # and all the clicking.
+  klein-required:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    if: always()
+    # Add here the jobs that should block the merge of a PR.
+    needs:
+      - lint
+      - mypy
+      - docs
+      - docs-linkcheck
+      - packaging
+      - unit
+    steps:
+      - name: Require all successes
+        shell: python3 {0}
+        env:
+          RESULTS: ${{ toJSON(needs.*.result) }}
+        run: |
+          import json
+          import os
+          import sys
+          results = json.loads(os.environ["RESULTS"])
+          sys.exit(0 if all(result == "success" for result in results) else 1)

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -37,8 +37,8 @@ jobs:
 
       - name: Set up Tox environment
         run: |
-          pip install tox;
-          tox -e lint --notest;
+          pip install 'tox<4'
+          tox -e lint --notest
 
       - name: Tox Python Information
         uses: twisted/python-info-action@v1
@@ -46,7 +46,7 @@ jobs:
           python-path: .tox/lint/*/python
 
       - name: Run Linters
-        run: tox -e lint;
+        run: tox -e lint
 
 
   mypy:
@@ -71,8 +71,8 @@ jobs:
 
       - name: Set up Tox environment
         run: |
-          pip install tox;
-          tox -e mypy --notest;
+          pip install 'tox<4'
+          tox -e mypy --notest
 
       - name: Tox Python Information
         uses: twisted/python-info-action@v1
@@ -80,7 +80,7 @@ jobs:
           python-path: .tox/mypy/*/python
 
       - name: Run Mypy
-        run: tox -e mypy;
+        run: tox -e mypy
 
 
   docs:
@@ -105,8 +105,8 @@ jobs:
 
       - name: Set up Tox environment
         run: |
-          pip install tox;
-          tox -e docs --notest;
+          pip install 'tox<4'
+          tox -e docs --notest
 
       - name: Tox Python Information
         uses: twisted/python-info-action@v1
@@ -114,7 +114,7 @@ jobs:
           python-path: .tox/docs/*/python
 
       - name: Build documentation
-        run: tox -e docs;
+        run: tox -e docs
 
 
   docs-linkcheck:
@@ -139,8 +139,8 @@ jobs:
 
       - name: Set up Tox environment
         run: |
-          pip install tox;
-          tox -e docs-linkcheck --notest;
+          pip install 'tox<4'
+          tox -e docs-linkcheck --notest
 
       - name: Tox Python Information
         uses: twisted/python-info-action@v1
@@ -172,8 +172,8 @@ jobs:
 
       - name: Set up Tox environment
         run: |
-          pip install tox;
-          tox -e packaging --notest;
+          pip install 'tox<4'
+          tox -e packaging --notest
 
       - name: Tox Python Information
         uses: twisted/python-info-action@v1
@@ -244,7 +244,7 @@ jobs:
 
       - name: Set up Tox environment
         run: |
-          pip install tox;
+          pip install 'tox<4'
           tox -e ${{ steps.tox_env.outputs.value }} --notest;
 
       - name: Tox Python Information

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -187,8 +187,6 @@ jobs:
   unit:
     name: "Py:${{ matrix.python-version }} - Tw:${{ matrix.twisted }} - ${{ matrix.os }}"
 
-    needs: [lint, mypy, docs, packaging]
-
     runs-on: ${{ matrix.os }}
     timeout-minutes: 30
     continue-on-error: ${{ matrix.optional }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,7 +5,7 @@ ci:
 repos:
 
   - repo: https://github.com/PyCQA/flake8
-    rev: 4.0.1
+    rev: "4.0.1"
     hooks:
       - id: flake8
         additional_dependencies:
@@ -19,7 +19,7 @@ repos:
           - pyflakes==2.4.0
 
   - repo: https://github.com/PyCQA/isort
-    rev: 5.12.0
+    rev: "5.12.0"
     hooks:
     - id: isort
       args: ["--filter-files"]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,7 +19,7 @@ repos:
           - pyflakes==2.4.0
 
   - repo: https://github.com/PyCQA/isort
-    rev: 5.10.1
+    rev: 5.12.0
     hooks:
     - id: isort
       args: ["--filter-files"]

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -34,15 +34,15 @@ Here are some suggestions to make the contributing process easier for everyone:
 Code
 ----
 
-- Use `Twisted's coding standards <https://twistedmatrix.com/documents/current/core/development/policy/coding-standard.html>`_ as a guideline for code changes you make.
+- Use `Twisted's coding standards <https://docs.twistedmatrix.com/en/stable/development/coding-standard.html>`_ as a guideline for code changes you make.
   Some parts of Klein (eg. ``klein.resource.ensure_utf8_bytes``) do not adhere to the Twisted style guide, but changing that would break public APIs, which is worse than breaking the style guidelines.
   Similarly, if you change existing code, following the Twisted style guide is good, but is less important than not breaking public APIs.
-- Compatibility across versions is important: here are `Twisted's compatibility guidelines <https://twistedmatrix.com/trac/wiki/CompatibilityPolicy>`_, which Klein shares.
+- Compatibility across versions is important: here are `Twisted's compatibility guidelines <https://docs.twistedmatrix.com/en/stable/development/compatibility-policy.html>`_, which Klein shares.
 - If you're adding a new feature, please add a file with an example and some explanation to the `examples directory <https://github.com/twisted/klein/tree/master/docs/examples>`_, then add your example to ``/docs/index.rst``.
 - Please run ``tox -e flake8`` to check for style issues in changed code.
   Flake8 and similar tools expose many small-but-common errors early enough that it's easy to remedy the problem.
 - Code changes should have tests: untested code is buggy code.
-  Klein uses `Twisted Trial <https://twistedmatrix.com/documents/current/api/twisted.trial.html>`_ and `tox <https://tox.readthedocs.io/en/latest/>`_ for its tests.
+  Klein uses `Twisted Trial <https://docs.twistedmatrix.com/en/stable/api/twisted.trial.html>`_ and `tox <https://tox.readthedocs.io/en/latest/>`_ for its tests.
   The command to run the full test suite is ``tox`` with no arguments.
   This will run tests against several versions of Python and Twisted, which can be time-consuming.
   To run tests against only one or a few versions, pass a ``-e`` argument with an environment from the envlist in ``tox.ini``: for example, ``tox -e py38-twcurrent`` will run tests with Python 3.8 and the current released version of Twisted.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -55,4 +55,4 @@ texinfo_documents = [
 
 # API links extension, stolen from Twisted's Sphinx setup
 extensions.append("apilinks")
-apilinks_base_url = "https://twistedmatrix.com/documents/current/api/"
+apilinks_base_url = "https://docs.twisted.org/en/stable/api/"

--- a/docs/examples/alternativerunning.rst
+++ b/docs/examples/alternativerunning.rst
@@ -16,7 +16,7 @@ The ``endpoint_description`` parameter uses Twisted Endpoints, which enable
 very neat things, like out-of-the-box TLS and IPv6 support.
 
 For more information check (specially the Servers section)
-https://twistedmatrix.com/documents/current/core/howto/endpoints.html
+https://docs.twisted.org/en/stable/core/howto/endpoints.html
 
 .. code-block:: python
 
@@ -60,7 +60,7 @@ and manually start the reactor when it is convenient.
 Notice that, since ``Klein.run`` sets up logging to stdout for you,
 you will need to set that up manually as well.
 Read more about logging with Twisted here:
-https://twistedmatrix.com/documents/current/core/howto/logger.html
+https://docs.twisted.org/en/stable/core/howto/logger.html
 
 .. code-block:: python
 

--- a/docs/examples/disablingtracebacks.rst
+++ b/docs/examples/disablingtracebacks.rst
@@ -54,7 +54,7 @@ Under the hood, Klein uses ``twisted.web.server.Site``, which has an
 instance variable ``displayTracebacks`` that defaults to ``True``.
 
 For the rationale behind that, check
-https://twistedmatrix.com/trac/ticket/135
+https://github.com/twisted/twisted/issues/7452
 
 .. code-block:: python
 

--- a/docs/examples/twistd.rst
+++ b/docs/examples/twistd.rst
@@ -2,7 +2,7 @@
 Example -- Using ``twistd``
 ===========================
 
-Another important integration point with Twisted is the `twistd application runner <https://twistedmatrix.com/documents/current/core/howto/tap.html>`_.
+Another important integration point with Twisted is the `twistd application runner <https://docs.twisted.org/en/stable/core/howto/tap.html>`_.
 It provides rich logging support, daemonization, reactor selection, profiler integration, and many more useful features.
 
 To provide access to these features (and others like HTTPS) klein provides the ``resource`` function which returns a valid :api:`twisted.web.resource.IResource <IResource>` for your application.

--- a/src/klein/_resource.py
+++ b/src/klein/_resource.py
@@ -279,7 +279,7 @@ class KleinResource(Resource):
             if failure.check(*error_handler[0]):
                 d = maybeDeferred(
                     self._app.execute_error_handler,
-                    error_handler[1],
+                    error_handler[1],  # type: ignore[arg-type]
                     request,
                     failure,
                 )


### PR DESCRIPTION
Fixes #572

Try to get the CI workflow green

Changes
-------

* Update isort in pre-commit
* Pin tox to pre v4
* Fix links in docs
* Update GitHub action branch protection to only require "klein-required". In this way, we can control branch protection from the source code, without having to go to https://github.com/twisted/klein/settings/branch_protection_rules/512098 to update the rules