### PR TITLE
Upgrade mypy to 1.0.1

### DIFF
--- a/requirements/mypy.txt
+++ b/requirements/mypy.txt
@@ -1,3 +1,3 @@
-mypy==1.2.0
+mypy==1.0.1
 mypy-zope==0.9.1
 types-click==7.1.8

--- a/requirements/mypy.txt
+++ b/requirements/mypy.txt
@@ -1,3 +1,3 @@
-mypy==0.961
-mypy-zope==0.3.8
+mypy==1.2.0
+mypy-zope==0.9.1
 types-click==7.1.8

--- a/src/klein/_app.py
+++ b/src/klein/_app.py
@@ -25,12 +25,6 @@ from typing import (
 )
 from weakref import ref
 
-
-try:
-    from typing import Protocol
-except ImportError:
-    from typing_extensions import Protocol  # type: ignore[misc]
-
 from werkzeug.routing import Map, MapAdapter, Rule, Submount
 from zope.interface import implementer
 
@@ -47,9 +41,10 @@ from twisted.web.server import Request, Site
 from ._decorators import modified, named
 from ._interfaces import IKleinRequest, KleinQueryValue
 from ._resource import KleinResource
+from ._typing_compat import Protocol
 
 
-KleinSynchronousRenderable = Union[str, bytes, IResource, IRenderable]
+KleinSynchronousRenderable = Union[str, bytes, IResource, IRenderable, None]
 KleinRenderable = Union[
     KleinSynchronousRenderable, Awaitable[KleinSynchronousRenderable]
 ]

--- a/src/klein/_typing_compat.py
+++ b/src/klein/_typing_compat.py
@@ -1,0 +1,12 @@
+from typing import TYPE_CHECKING
+
+
+try:
+    from typing import Protocol
+except ImportError:
+    if not TYPE_CHECKING:
+        from typing_extensions import Protocol
+
+__all__ = [
+    "Protocol",
+]

--- a/src/klein/_typing_compat.py
+++ b/src/klein/_typing_compat.py
@@ -1,3 +1,9 @@
+"""
+Since we support a range of Python and Mypy versions where certain features are
+available across L{typing} and L{typing_extensions}, we put those aliases here
+to avoid repeating conditional import logic.
+"""
+
 from typing import TYPE_CHECKING
 
 

--- a/src/klein/test/test_form.py
+++ b/src/klein/test/test_form.py
@@ -11,7 +11,15 @@ from twisted.trial.unittest import SynchronousTestCase
 from twisted.web.iweb import IRequest
 from twisted.web.template import Element, TagLoader, renderer, tags
 
-from klein import Field, Form, Klein, RenderableForm, Requirer, SessionProcurer
+from klein import (
+    Field,
+    Form,
+    Klein,
+    KleinRenderable,
+    RenderableForm,
+    Requirer,
+    SessionProcurer,
+)
 from klein.interfaces import (
     ISession,
     ISessionStore,
@@ -168,7 +176,7 @@ class TestObject:
     @requirer.require(
         router.route("/handle-empty", methods=["POST"]),
     )
-    def emptyHandler(self) -> bytes:
+    def emptyHandler(self) -> KleinRenderable:
         """
         Empty form handler; just for testing rendering.
         """

--- a/src/klein/test/test_resource.py
+++ b/src/klein/test/test_resource.py
@@ -562,7 +562,7 @@ class KleinResourceTests(SynchronousTestCase):
 
         @app.route("/None")
         def none(request: IRequest) -> KleinRenderable:
-            return None  # type: ignore[return-value]
+            return None
 
         d = _render(self.kr, request)
 

--- a/src/klein/test/test_session.py
+++ b/src/klein/test/test_session.py
@@ -150,7 +150,7 @@ class ProcurementTests(SynchronousTestCase):
         mss = MemorySessionStore()
         router = Klein()
 
-        @router.route("/")  # type: ignore[arg-type]
+        @router.route("/")
         @inlineCallbacks
         def route(request: IRequest) -> Generator[Any, object, None]:
             sproc = SessionProcurer(mss)


### PR DESCRIPTION
Unfortunately mypy-zope keeps us from upgrading further (see https://github.com/Shoobx/mypy-zope/issues/99 ) but there's lots of good stuff in 1.0+ that we should get.  Not to mention that we're on an old version of mypy-zope itself right now.