### PR TITLE
development environment and CI configuration fixes

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -10,7 +10,7 @@ on:
   push:
     branches: ["trunk"]
   pull_request:
-    branches: ["trunk"]
+    branches: ["*"]
 
 
 jobs:

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@
 /htmlcov/
 /htmldocs/
 /src/*.egg-info
+coverage.xml

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -41,7 +41,6 @@ repos:
       - id: check-ast
       - id: check-builtin-literals
       - id: check-case-conflict
-      - id: check-docstring-first
       - id: check-executables-have-shebangs
       - id: check-json
       - id: check-merge-conflict

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -27,5 +27,4 @@ sphinx:
 python:
    install:
    - path: "."
-     extra_requirements:
-       - "docs"
+   - requirements: "requirements/sphinx.txt"

--- a/setup.py
+++ b/setup.py
@@ -38,12 +38,6 @@ if __name__ == "__main__":
             "Werkzeug",
             "zope.interface",
         ],
-        extras_require={
-            "docs": [
-                "Sphinx==3.5.1",
-                "sphinx-rtd-theme==0.5.1",
-            ]
-        },
         keywords="twisted flask werkzeug web",
         license="MIT",
         name="klein",

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ if __name__ == "__main__":
             "Werkzeug",
             "zope.interface",
         ],
-        extra_requires={
+        extras_require={
             "docs": [
                 "Sphinx==3.5.1",
                 "sphinx-rtd-theme==0.5.1",

--- a/tox.ini
+++ b/tox.ini
@@ -146,6 +146,7 @@ commands     = {[testenv:black]commands}
 ##
 
 [testenv:mypy]
+usedevelop = true
 
 description = run Mypy (static type checker)
 

--- a/tox.ini
+++ b/tox.ini
@@ -96,6 +96,7 @@ commands =
 ##
 
 [testenv:lint]
+usedevelop = true
 
 description = run all linters
 


### PR DESCRIPTION
an assorted set of small improvements to CI and development setup

- `mypy` and `lint` don't operate on an installed tarball, so save some time and use a develop install for those
- ~~`extras_require` is misspelled in `setup.py`, let's fix that~~ oh this is just for the doc-build process, which isn't really something that extras are for; we have a `requirements/sphinx.txt` for our readthedocs requirements, so let's just use that in the RTD config
- pydoctor supports attribute docstrings at module scope, but one of our pre-commit checks incorrectly believes that this is an error, so remove that
- enable CI to run on stacked branches