### PR TITLE
fix the type annotations on `@route` to allow for signatures with parameters other than `request`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,7 +28,7 @@ repos:
     rev: "v3.3.2"
     hooks:
       - id: pyupgrade
-        args: ["--py36-plus"]
+        args: ["--py36-plus", "--keep-runtime-typing"]
 
   - repo: https://github.com/asottile/yesqa
     rev: "v1.4.0"

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ if __name__ == "__main__":
             "incremental",
             "Tubes",
             "Twisted>=16.6",  # 16.6 introduces ensureDeferred
-            "typing_extensions ; python_version<'3.8'",
+            "typing_extensions ; python_version<'3.10'",
             "Werkzeug",
             "zope.interface",
         ],

--- a/src/klein/_app.py
+++ b/src/klein/_app.py
@@ -182,7 +182,7 @@ ErrorHandlers = List[Tuple[List[Type[Exception]], KleinErrorHandler]]
 
 
 # begin argument-processing hack to copy all args from current installed
-# version of werkzeug.rule.Rule to @route's *args and **kwargs
+# version of Rule to @route's *args and **kwargs
 
 R = TypeVar("R", covariant=True)
 P = ParamSpec("P")
@@ -197,7 +197,9 @@ class _PartialRouteSignature(Protocol[R]):
         branch: bool = False,
         **kwargs: Any,
     ) -> R:
-        ...
+        """
+        This is the portion of the signature of C{route} which Klein owns.
+        """
 
 
 class _FullRouteSignature(Protocol[P, R]):
@@ -209,7 +211,9 @@ class _FullRouteSignature(Protocol[P, R]):
         branch: bool = False,
         **kwargs: P.kwargs,
     ) -> R:
-        ...
+        """
+        This integrates L{_PartialRouteSignature} with L{Rule}.
+        """
 
 
 def _removeStringArg(rule: Callable[Concatenate[str, P], R]) -> Callable[P, R]:

--- a/src/klein/_app.py
+++ b/src/klein/_app.py
@@ -67,7 +67,7 @@ class KleinErrorFunction(Protocol):
 class KleinErrorMethod(Protocol):
     def __call__(
         _self,
-        self: Optional[Klein],
+        self: Any,
         request: IRequest,
         failure: Failure,
     ) -> KleinRenderable:

--- a/src/klein/_app.py
+++ b/src/klein/_app.py
@@ -88,7 +88,7 @@ informative message for the user, not a type assertion; checking the parameter
 list will have to be handled at runtime.
 """
 
-SomeKleinHandler = TypeVar("SomeKleinHandler", bound=KleinRouteHandler)
+KleinRouteHandlerT = TypeVar("KleinRouteHandlerT", bound=KleinRouteHandler)
 """
 Let's make sure that we don't modify klein handlers' arg lists as we pass them
 through though.
@@ -379,7 +379,7 @@ class Klein:
         *args: Any,
         branch: bool = False,
         **kwargs: Any,
-    ) -> Callable[[SomeKleinHandler], SomeKleinHandler]:
+    ) -> Callable[[KleinRouteHandlerT], KleinRouteHandlerT]:
         """
         Add a new handler for C{url} passing C{args} and C{kwargs} directly to
         C{werkzeug.routing.Rule}.  The handler function will be passed at least
@@ -401,7 +401,7 @@ class Klein:
         segment_count = self._segments_in_url(url) + self._subroute_segments
 
         @named("router for '" + url + "'")
-        def deco(f: SomeKleinHandler) -> SomeKleinHandler:
+        def deco(f: KleinRouteHandlerT) -> KleinRouteHandlerT:
             metadata = route_metadata(f)
             kwargs.setdefault(
                 "endpoint",

--- a/src/klein/_plating.py
+++ b/src/klein/_plating.py
@@ -3,6 +3,7 @@
 """
 Templating wrapper support for Klein.
 """
+from __future__ import annotations
 
 from functools import partial
 from json import dumps
@@ -280,7 +281,7 @@ class Plating:
         L{PlatedElement}.
         """
 
-        _plating: "Plating"
+        _plating: Plating
         _function: Callable[..., Any]
         _instance: object
 

--- a/src/klein/_resource.py
+++ b/src/klein/_resource.py
@@ -1,4 +1,5 @@
 # -*- test-case-name: klein.test.test_resource -*-
+from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any, Optional, Sequence, Tuple, Union, cast
 
@@ -142,7 +143,7 @@ class KleinResource(Resource):
 
     isLeaf = True
 
-    def __init__(self, app: "Klein") -> None:
+    def __init__(self, app: Klein) -> None:
         super().__init__()
         self._app = app
 
@@ -157,7 +158,7 @@ class KleinResource(Resource):
             return result
         return not result
 
-    def render(self, request: IRequest) -> "KleinRenderable":
+    def render(self, request: IRequest) -> KleinRenderable:
         # Stuff we need to know for the mapper.
         try:
             (
@@ -250,7 +251,7 @@ class KleinResource(Resource):
         d.addCallback(process)
 
         def processing_failed(
-            failure: Failure, error_handlers: "ErrorHandlers"
+            failure: Failure, error_handlers: ErrorHandlers
         ) -> Optional[Deferred]:
             # The failure processor writes to the request.  If the
             # request is already finished we should suppress failure

--- a/src/klein/_resource.py
+++ b/src/klein/_resource.py
@@ -19,7 +19,18 @@ from ._interfaces import IKleinRequest
 
 
 if TYPE_CHECKING:
-    from ._app import ErrorHandlers, Klein, KleinRenderable
+    # NB: circular import, must not be imported at runtime.
+    from ._app import (
+        ErrorHandlers,
+        Klein,
+        KleinRenderable,
+        KleinRouteHandler,
+        RouteMetadata,
+    )
+
+
+def route_metadata(handler: KleinRouteHandler) -> RouteMetadata:
+    return handler  # type:ignore[return-value]
 
 
 def ensure_utf8_bytes(v: Union[str, bytes]) -> bytes:
@@ -189,9 +200,9 @@ class KleinResource(Resource):
             endpoint = rule.endpoint
 
             # Try pretty hard to fix up prepath and postpath.
-            segment_count = self._app.endpoints[
-                endpoint
-            ].segment_count  # type: ignore[union-attr]
+            segment_count = route_metadata(
+                self._app.endpoints[endpoint]
+            ).segment_count
             request.prepath.extend(request.postpath[:segment_count])
             request.postpath = request.postpath[segment_count:]
 

--- a/src/klein/_typing_compat.py
+++ b/src/klein/_typing_compat.py
@@ -12,13 +12,12 @@ try:
 except ImportError:
     if not TYPE_CHECKING:
         from typing_extensions import Protocol
-try:
-    from typing import ParamSpec
-except ImportError:
-    if not TYPE_CHECKING:
-        from typing_extensions import ParamSpec
+
+from typing_extensions import Concatenate, ParamSpec
+
 
 __all__ = [
     "Protocol",
     "ParamSpec",
+    "Concatenate",
 ]

--- a/src/klein/_typing_compat.py
+++ b/src/klein/_typing_compat.py
@@ -3,17 +3,19 @@ Since we support a range of Python and Mypy versions where certain features are
 available across L{typing} and L{typing_extensions}, we put those aliases here
 to avoid repeating conditional import logic.
 """
+import sys
 
-from typing import TYPE_CHECKING
 
-
-try:
+if sys.version_info > (3, 8):
     from typing import Protocol
-except ImportError:
-    if not TYPE_CHECKING:
-        from typing_extensions import Protocol
+else:
+    from typing_extensions import Protocol
 
-from typing_extensions import Concatenate, ParamSpec
+
+if sys.version_info > (3, 10):
+    from typing import Concatenate, ParamSpec
+else:
+    from typing_extensions import Concatenate, ParamSpec
 
 
 __all__ = [

--- a/src/klein/_typing_compat.py
+++ b/src/klein/_typing_compat.py
@@ -12,7 +12,13 @@ try:
 except ImportError:
     if not TYPE_CHECKING:
         from typing_extensions import Protocol
+try:
+    from typing import ParamSpec
+except ImportError:
+    if not TYPE_CHECKING:
+        from typing_extensions import ParamSpec
 
 __all__ = [
     "Protocol",
+    "ParamSpec",
 ]

--- a/src/klein/test/test_app.py
+++ b/src/klein/test/test_app.py
@@ -248,13 +248,11 @@ class KleinTestCase(unittest.TestCase):
         )
 
         self.assertEqual(
-            app.endpoints["branchfunc"].__name__,  # type: ignore[union-attr]
+            app.endpoints["branchfunc"].__name__,
             "route '/foo/' executor for branchfunc",
         )
         self.assertEqual(
-            app.endpoints[
-                "branchfunc_branch"
-            ].__name__,  # type: ignore[union-attr]
+            app.endpoints["branchfunc_branch"].__name__,
             "branch route '/foo/' executor for branchfunc",
         )
         self.assertEqual(

--- a/src/klein/test/test_resource.py
+++ b/src/klein/test/test_resource.py
@@ -410,8 +410,8 @@ class KleinResourceTests(SynchronousTestCase):
 
         request = MockRequest(b"/resource/leaf")
 
-        @app.route("/resource/leaf")  # type: ignore[arg-type]
-        async def leaf(request: IRequest) -> KleinRenderable:
+        @app.route("/resource/leaf")
+        async def leaf(request: IRequest) -> LeafResource:
             return LeafResource()
 
         self.assertFired(_render(resource, request))
@@ -421,7 +421,7 @@ class KleinResourceTests(SynchronousTestCase):
     def test_elementRendering(self) -> None:
         app = self.app
 
-        @app.route("/element/<string:name>")  # type: ignore[arg-type]
+        @app.route("/element/<string:name>")
         def element(request: IRequest, name: str) -> KleinRenderable:
             return SimpleElement(name)
 
@@ -439,7 +439,7 @@ class KleinResourceTests(SynchronousTestCase):
 
         elements = []
 
-        @app.route("/element/<string:name>")  # type: ignore[arg-type]
+        @app.route("/element/<string:name>")
         def element(request: IRequest, name: str) -> KleinRenderable:
             it = DeferredElement(name)
             elements.append(it)
@@ -1075,7 +1075,7 @@ class KleinResourceTests(SynchronousTestCase):
 
         relative_url: List[str] = ["** ROUTE NOT CALLED **"]
 
-        @app.route("/foo/<int:bar>")  # type: ignore[arg-type]
+        @app.route("/foo/<int:bar>")
         def foo(request: IRequest, bar: int) -> KleinRenderable:
             krequest = IKleinRequest(request)
             relative_url[0] = krequest.url_for("foo", {"bar": bar + 1})
@@ -1109,7 +1109,7 @@ class KleinResourceTests(SynchronousTestCase):
 
         relative_url: List[Optional[str]] = [None]
 
-        @app.route("/foo/<int:bar>")  # type: ignore[arg-type]
+        @app.route("/foo/<int:bar>")
         def foo(request: IRequest, bar: int) -> KleinRenderable:
             krequest = IKleinRequest(request)
             relative_url[0] = krequest.url_for(


### PR DESCRIPTION
23.5.0 released with some overly aggressive type annotations on routes that incorrectly prohibited them from taking other parameters.  Let's fix that, and at the same time correctly copy the `werkzeug.rule.Rule` args & kwargs signature so that mypy will correctly report errors if it's invoked with the wrong arguments. (This also type-checks the `branch` argument cleanly.)

(This requires #590 so I will unmark it as a draft once that is landed)