### PR TITLE
Tag is a valid KleinSynchronousRenderable

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -15,4 +15,4 @@ coverage:
         target: 100%
 
 ignore:
-  - "test/typing_*.py"
+  - "src/klein/test/typing_*.py"

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -13,3 +13,6 @@ coverage:
       default:
         informational: false
         target: 100%
+
+ignore:
+  - "test/typing_*.py"

--- a/.coveragerc
+++ b/.coveragerc
@@ -2,6 +2,7 @@
 branch = True
 parallel = True
 source = klein
+omit = test/typing_*.py
 
 [paths]
 source=

--- a/.coveragerc
+++ b/.coveragerc
@@ -2,7 +2,7 @@
 branch = True
 parallel = True
 source = klein
-omit = test/typing_*.py
+omit = src/klein/test/typing_*.py
 
 [paths]
 source=

--- a/src/klein/_app.py
+++ b/src/klein/_app.py
@@ -39,6 +39,7 @@ from twisted.python.failure import Failure
 from twisted.web.iweb import IRenderable, IRequest
 from twisted.web.resource import IResource
 from twisted.web.server import Request, Site
+from twisted.web.template import Tag
 
 from ._decorators import modified, named
 from ._interfaces import IKleinRequest, KleinQueryValue
@@ -46,7 +47,9 @@ from ._resource import KleinResource, route_metadata
 from ._typing_compat import Concatenate, ParamSpec, Protocol
 
 
-KleinSynchronousRenderable = Union[str, bytes, IResource, IRenderable, None]
+KleinSynchronousRenderable = Union[
+    str, bytes, IResource, IRenderable, Tag, None
+]
 KleinRenderable = Union[
     KleinSynchronousRenderable, Awaitable[KleinSynchronousRenderable]
 ]

--- a/src/klein/_app.py
+++ b/src/klein/_app.py
@@ -14,6 +14,7 @@ from typing import (
     Awaitable,
     Callable,
     Dict,
+    Iterable,
     Iterator,
     List,
     Mapping,
@@ -47,8 +48,11 @@ from ._resource import KleinResource, route_metadata
 from ._typing_compat import Concatenate, ParamSpec, Protocol
 
 
-KleinSynchronousRenderable = Union[
+_KleinSynchronousRenderable = Union[
     str, bytes, IResource, IRenderable, Tag, None
+]
+KleinSynchronousRenderable = Union[
+    _KleinSynchronousRenderable, Iterable[_KleinSynchronousRenderable]
 ]
 KleinRenderable = Union[
     KleinSynchronousRenderable, Awaitable[KleinSynchronousRenderable]

--- a/src/klein/test/typing_app.py
+++ b/src/klein/test/typing_app.py
@@ -5,7 +5,7 @@ are correct.
 
 from twisted.internet.defer import succeed
 from twisted.web.iweb import IRequest
-from twisted.web.resource import IResource, Resource
+from twisted.web.resource import Resource
 from twisted.web.template import Element, Tag
 
 from klein import Klein, KleinRenderable

--- a/src/klein/test/typing_app.py
+++ b/src/klein/test/typing_app.py
@@ -1,6 +1,8 @@
 """
 This file contains code that should validate with type checking if type hints
 are correct.
+
+The code is not executed, it is here just to be checked by mypy.
 """
 
 from twisted.internet.defer import succeed

--- a/src/klein/test/typing_app.py
+++ b/src/klein/test/typing_app.py
@@ -1,0 +1,71 @@
+"""
+This file contains code that should validate with type checking if type hints
+are correct.
+"""
+
+from twisted.internet.defer import succeed
+from twisted.web.iweb import IRequest
+from twisted.web.resource import IResource, Resource
+from twisted.web.template import Element, Tag
+
+from klein import Klein, KleinRenderable
+
+
+class Application:
+    router = Klein()
+
+    @router.route("/object")
+    def returnsObject(self, request: IRequest) -> KleinRenderable:
+        return object()  # type: ignore[return-value]
+
+    @router.route("/str")
+    def returnsStr(self, request: IRequest) -> KleinRenderable:
+        return ""
+
+    @router.route("/bytes")
+    def returnsBytes(self, request: IRequest) -> KleinRenderable:
+        return b""
+
+    @router.route("/iresource")
+    def returnsIResource(self, request: IRequest) -> KleinRenderable:
+        return Resource()
+
+    @router.route("/irenderable")
+    def returnsIRenderable(self, request: IRequest) -> KleinRenderable:
+        return Element()
+
+    @router.route("/tag")
+    def returnsTag(self, request: IRequest) -> KleinRenderable:
+        return Tag("")
+
+    @router.route("/none")
+    def returnsNone(self, request: IRequest) -> KleinRenderable:
+        return None
+
+    @router.route("/deferred-object")
+    def returnsDeferredObject(self, request: IRequest) -> KleinRenderable:
+        return succeed(object())  # type: ignore[arg-type]
+
+    @router.route("/deferred-str")
+    def returnsDeferredStr(self, request: IRequest) -> KleinRenderable:
+        return succeed("")
+
+    @router.route("/deferred-bytes")
+    def returnsDeferredBytes(self, request: IRequest) -> KleinRenderable:
+        return succeed(b"")
+
+    @router.route("/deferred-iresource")
+    def returnsDeferredIResource(self, request: IRequest) -> KleinRenderable:
+        return succeed(Resource())
+
+    @router.route("/deferred-irenderable")
+    def returnsDeferredIRenderable(self, request: IRequest) -> KleinRenderable:
+        return succeed(Element())
+
+    @router.route("/deferred-tag")
+    def returnsDeferredTag(self, request: IRequest) -> KleinRenderable:
+        return succeed(Tag(""))
+
+    @router.route("/deferred-none")
+    def returnsDeferredNone(self, request: IRequest) -> KleinRenderable:
+        return succeed(None)


### PR DESCRIPTION
I'm getting a mypy error when pointing at trunk:

```console
error: Incompatible return value type (got "Tag", expected "Union[Union[str, bytes, IResource, IRenderable, None], Awaitable[Union[str, bytes, IResource, IRenderable, None]]]")  [return-value]
```

`Tag` is a valid return type for a route method, so should be included in `KleinSynchronousRenderable`.

Iterables of renderables are also valid.

This adds a file `typing_app.py` to test verify that type hints in `_app.y` are correct.