### PR TITLE
Avoid bytes/int comparison

### DIFF
--- a/src/klein/_resource.py
+++ b/src/klein/_resource.py
@@ -304,16 +304,18 @@ class KleinResource(Resource):
 
         d.addErrback(processing_failed, self._app._error_handlers)
 
-        def write_response(r: object) -> None:
-            if r is not StandInResource:
-                if isinstance(r, str):
-                    r = r.encode("utf-8")
+        def write_response(r: Union[StandInResource, str, bytes, int, None]) -> None:
+            if r is StandInResource:
+                return
 
-                if (r is not None) and (r != NOT_DONE_YET):
-                    request.write(r)
+            if isinstance(r, str):
+                r = r.encode("utf-8")
 
-                if not request_finished[0]:
-                    request.finish()
+            if isinstance(r, bytes):
+                request.write(r)
+
+            if not request_finished[0]:
+                request.finish()
 
         d.addCallback(write_response)
         d.addErrback(log.err, _why="Unhandled Error writing response")

--- a/src/klein/_resource.py
+++ b/src/klein/_resource.py
@@ -12,7 +12,6 @@ from twisted.python.failure import Failure
 from twisted.web import server
 from twisted.web.iweb import IRenderable, IRequest
 from twisted.web.resource import IResource, Resource, getChildForRequest
-from twisted.web.server import NOT_DONE_YET
 from twisted.web.template import renderElement
 
 from ._dihttp import Response
@@ -304,7 +303,9 @@ class KleinResource(Resource):
 
         d.addErrback(processing_failed, self._app._error_handlers)
 
-        def write_response(r: Union[StandInResource, str, bytes, int, None]) -> None:
+        def write_response(
+            r: Union[StandInResource, str, bytes, int, None]
+        ) -> None:
             if r is StandInResource:
                 return
 

--- a/src/klein/_resource.py
+++ b/src/klein/_resource.py
@@ -304,7 +304,7 @@ class KleinResource(Resource):
 
         d.addErrback(processing_failed, self._app._error_handlers)
 
-        def write_response(r: Union[StandInResource, str, bytes, int, None]) -> None:
+        def write_response(r: Union[_StandInResource, str, bytes, int, None]) -> None:
             if r is StandInResource:
                 return
 

--- a/tox.ini
+++ b/tox.ini
@@ -66,7 +66,7 @@ setenv =
 
 commands =
     # Run trial without coverage
-    test: trial --random=0 {env:TRIAL_JOBS} --temp-directory="{envlogdir}/trial.d" {posargs:{env:PY_MODULE}}
+    test: python -b "{envdir}/bin/trial" --random=0 {env:TRIAL_JOBS} --temp-directory="{envlogdir}/trial.d" {posargs:{env:PY_MODULE}}
 
     # Run trial with coverage
     # Notes:

--- a/tox.ini
+++ b/tox.ini
@@ -62,11 +62,11 @@ setenv =
     coverage: COVERAGE_FILE={toxworkdir}/coverage.{envname}
     coverage: COVERAGE_PROCESS_START={toxinidir}/.coveragerc
 
-    TRIAL_JOBS={env:TRIAL_JOBS:}
+    TRIAL_ARGS={env:TRIAL_ARGS:}
 
 commands =
     # Run trial without coverage
-    test: python -b "{envdir}/bin/trial" --random=0 {env:TRIAL_JOBS} --temp-directory="{envlogdir}/trial.d" {posargs:{env:PY_MODULE}}
+    test: python -b "{envdir}/bin/trial" --random=0 {env:TRIAL_ARGS} --temp-directory="{envlogdir}/trial.d" {posargs:{env:PY_MODULE}}
 
     # Run trial with coverage
     # Notes:
@@ -79,7 +79,7 @@ commands =
     #  - Use `tox -e coverage_report` to generate a report for all environments.
     coverage: python -c 'f=open("{envsitepackagesdir}/zz_coverage.pth", "w"); f.write("import coverage; coverage.process_startup()\n")'
     coverage: coverage erase
-    coverage: python -b -m coverage run --source="{env:PY_MODULE}" "{envdir}/bin/trial" --random=0 {env:TRIAL_JOBS} --temp-directory="{envlogdir}/trial.d" {posargs:{env:PY_MODULE}}
+    coverage: python -b -m coverage run --source="{env:PY_MODULE}" "{envdir}/bin/trial" --random=0 {env:TRIAL_ARGS} --temp-directory="{envlogdir}/trial.d" {posargs:{env:PY_MODULE}}
     coverage: coverage combine
     coverage: coverage xml
 

--- a/tox.ini
+++ b/tox.ini
@@ -62,7 +62,7 @@ setenv =
     coverage: COVERAGE_FILE={toxworkdir}/coverage.{envname}
     coverage: COVERAGE_PROCESS_START={toxinidir}/.coveragerc
 
-    TRIAL_JOBS={env:TRIAL_JOBS:--jobs=2}
+    TRIAL_JOBS={env:TRIAL_JOBS:}
 
 commands =
     # Run trial without coverage
@@ -79,7 +79,7 @@ commands =
     #  - Use `tox -e coverage_report` to generate a report for all environments.
     coverage: python -c 'f=open("{envsitepackagesdir}/zz_coverage.pth", "w"); f.write("import coverage; coverage.process_startup()\n")'
     coverage: coverage erase
-    coverage: coverage run --source="{env:PY_MODULE}" "{envdir}/bin/trial" --random=0 {env:TRIAL_JOBS} --temp-directory="{envlogdir}/trial.d" {posargs:{env:PY_MODULE}}
+    coverage: python -b -m coverage run --source="{env:PY_MODULE}" "{envdir}/bin/trial" --random=0 {env:TRIAL_JOBS} --temp-directory="{envlogdir}/trial.d" {posargs:{env:PY_MODULE}}
     coverage: coverage combine
     coverage: coverage xml
 


### PR DESCRIPTION
Fixes #296 

This removes the default behavior of using disttrial with two workers because there's no way to get the BytesWarning behavior when using disttrial (it can only be enabled by passing `-b` on the Python command line and there's no way to make disttrial do this).  On my system, the coverage-py310-tw221 environment takes 8 seconds whether we use disttrial or not so this doesn't seem like an issue to me.

