### PR TITLE
change version matrix. don't ever test sliding 'current' twisted, test 3.12 final

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -194,24 +194,24 @@ jobs:
       matrix:
         os: ["ubuntu-latest"]
         python-version: ["3.7", "3.9", "3.10", "3.11"]
-        twisted-version: ["21.2", "22.1", "current"]
+        twisted-version: ["21.2", "22.1", "23.8.0"]
         tox-prefix: ["coverage"]
         optional: [false]
         include:
           - os: "ubuntu-latest"
             python-version: "pypy-3.8"
-            twisted-version: "current"
+            twisted-version: "23.8.0"
             tox-prefix: "test"
             optional: false
           - os: "ubuntu-latest"
             python-version: "pypy-3.9"
-            twisted-version: "current"
+            twisted-version: "23.8.0"
             tox-prefix: "test"
             optional: false
           # Test Python 3.12 but allow it to fail
           - os: "ubuntu-latest"
-            python-version: "3.12.0-alpha.7"
-            twisted-version: "current"
+            python-version: "3.12.0"
+            twisted-version: "23.8.0"
             tox-prefix: "test"
             optional: true
 

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -194,24 +194,24 @@ jobs:
       matrix:
         os: ["ubuntu-latest"]
         python-version: ["3.7", "3.9", "3.10", "3.11"]
-        twisted-version: ["21.2", "22.1", "23.8.0"]
+        twisted-version: ["21.2", "22.1", "23.8"]
         tox-prefix: ["coverage"]
         optional: [false]
         include:
           - os: "ubuntu-latest"
             python-version: "pypy-3.8"
-            twisted-version: "23.8.0"
+            twisted-version: "23.8"
             tox-prefix: "test"
             optional: false
           - os: "ubuntu-latest"
             python-version: "pypy-3.9"
-            twisted-version: "23.8.0"
+            twisted-version: "23.8"
             tox-prefix: "test"
             optional: false
           # Test Python 3.12 but allow it to fail
           - os: "ubuntu-latest"
             python-version: "3.12.0"
-            twisted-version: "23.8.0"
+            twisted-version: "23.8"
             tox-prefix: "test"
             optional: true
 

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -13,12 +13,12 @@ Klein is an open source project that welcomes contributions of all kinds coming 
 Getting started
 ===============
 
-Here is a list of shell commands that will install the dependencies of Klein, run the test suite with Python 3.8 and the current version of Twisted, compile the documentation, and check for coding style issues with flake8.
+Here is a list of shell commands that will install the dependencies of Klein, run the test suite with Python 3.8 and Twisted 23.8, compile the documentation, and check for coding style issues with flake8.
 
 .. code-block:: shell
 
    pip install --user tox
-   tox -e py38-twcurrent
+   tox -e py312-tw238
    tox -e docs
    tox -e flake8
 
@@ -45,7 +45,7 @@ Code
   Klein uses `Twisted Trial <https://docs.twisted.org/en/stable/api/twisted.trial.html>`_ and `tox <https://tox.readthedocs.io/en/latest/>`_ for its tests.
   The command to run the full test suite is ``tox`` with no arguments.
   This will run tests against several versions of Python and Twisted, which can be time-consuming.
-  To run tests against only one or a few versions, pass a ``-e`` argument with an environment from the envlist in ``tox.ini``: for example, ``tox -e py38-twcurrent`` will run tests with Python 3.8 and the current released version of Twisted.
+  To run tests against only one or a few versions, pass a ``-e`` argument with an environment from the envlist in ``tox.ini``: for example, ``tox -e py38-tw238`` will run tests with Python 3.8 and Twisted 23.8.
   To run only one or a few specific tests in the suite, add a filename or fully-qualified Python path to the end of the test invocation: for example, ``tox klein.test.test_app.KleinTestCase.test_foo`` will run only the ``test_foo()`` method of the ``KleinTestCase`` class in ``klein/test/test_app.py``.
   These two test shortcuts can be combined to give you a quick feedback cycle, but make sure to check on the full test suite from time to time to make sure changes haven't had unexpected side effects.
 - Show us your code changes through pull requests sent to `Klein's GitHub repo <https://github.com/twisted/klein>`_.

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 
 envlist =
     lint, mypy
-    coverage-py{37,38,39,310,311,py3}-tw{212,221,current,trunk}
+    coverage-py{37,38,39,310,311,312,py3}-tw{212,221,238,trunk}
     coverage_report
     docs, docs-linkcheck
     packaging
@@ -139,8 +139,8 @@ commands =
 description = generate coverage report
 
 depends =
-    coverage-py{37,38,39,310,311,py3}-tw{1,2}{0,1,2,3,4,5,6,7,8,9}{0,1,2,3,4,5,6,7,8,9}
-    coverage-py{37,38,39,310,311,py3}-tw{current,trunk}
+    coverage-py{37,38,39,310,311,312,py3}-tw{1,2}{0,1,2,3,4,5,6,7,8,9}{0,1,2,3,4,5,6,7,8,9}
+    coverage-py{37,38,39,310,311,312,py3}-tw{current,trunk}
 
 basepython = {[default]basepython}
 


### PR DESCRIPTION
3.12 alpha7 is failing by segfaulting, hopefully the final release won't have that issue.

also, letting the twisted version float in CI is not a great idea. if we want to do that, it should be in a cron build not a PR build