### PR TITLE
Fix the type hint for `Field.converter`

### DIFF
--- a/src/klein/_form.py
+++ b/src/klein/_form.py
@@ -267,7 +267,7 @@ class Field:
         An integer within the range [minimum, maximum].
         """
 
-        def bounded_number(text: AnyStr) -> Any:
+        def bounded_number(text: str) -> Any:
             try:
                 value = kind(text)
             except (ValueError, ArithmeticError):

--- a/src/klein/_form.py
+++ b/src/klein/_form.py
@@ -89,7 +89,7 @@ class Field:
     @ivar converter: The converter.
     """
 
-    converter: Callable[[AnyStr], Any]
+    converter: Callable[[str], Any]
     formInputType: str
     pythonArgumentName: Optional[str] = None
     formFieldName: Optional[str] = None


### PR DESCRIPTION
`Field.converter` is called in `Field.validateValue()` on the result of `Field.extractValue()`, which will return either a string, JSON-serializable objects, or None, but not bytes.
