### PR TITLE
`Field.number(kind=...)` supports any function that returns a number

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -15,3 +15,4 @@ source=
 exclude_lines =
     pragma: no cover
     if TYPE_CHECKING:
+    \s*\.\.\.$

--- a/src/klein/_form.py
+++ b/src/klein/_form.py
@@ -43,7 +43,6 @@ from .interfaces import (
 )
 
 
-_T = TypeVar("_T", contravariant=True)
 _Self = TypeVar("_Self")
 
 

--- a/src/klein/_form.py
+++ b/src/klein/_form.py
@@ -12,7 +12,7 @@ from typing import (
     NoReturn,
     Optional,
     Sequence,
-    Type,
+    TypeVar,
     cast,
 )
 
@@ -29,6 +29,7 @@ from twisted.web.template import Element, Tag, TagLoader, tags
 
 from ._app import KleinRenderable, _call
 from ._decorators import bindable
+from ._typing_compat import Protocol
 from .interfaces import (
     EarlyExit,
     IDependencyInjector,
@@ -39,6 +40,20 @@ from .interfaces import (
     ValidationError,
     ValueAbsent,
 )
+
+
+_T = TypeVar("_T", contravariant=True)
+
+
+class _Numeric(Protocol[_T]):
+    def __float__(self) -> float:
+        ...
+
+    def __lt__(self, other: _T) -> bool:
+        ...
+
+    def __gt__(self, other: _T) -> bool:
+        ...
 
 
 class CrossSiteRequestForgery(Resource):
@@ -258,9 +273,9 @@ class Field:
     @classmethod
     def number(
         cls,
-        minimum: Optional[int] = None,
-        maximum: Optional[int] = None,
-        kind: Type = float,
+        minimum: Optional[_Numeric] = None,
+        maximum: Optional[_Numeric] = None,
+        kind: Callable[[str], _Numeric] = float,
         **kw: Any,
     ) -> "Field":
         """

--- a/src/klein/_form.py
+++ b/src/klein/_form.py
@@ -14,6 +14,7 @@ from typing import (
     Sequence,
     TypeVar,
     cast,
+    overload,
 )
 
 import attr
@@ -43,17 +44,21 @@ from .interfaces import (
 
 
 _T = TypeVar("_T", contravariant=True)
+_Self = TypeVar("_Self")
 
 
-class _Numeric(Protocol[_T]):
+class _Numeric(Protocol):
     def __float__(self) -> float:
         ...
 
-    def __lt__(self, other: _T) -> bool:
+    def __lt__(self: _Self, other: _Self) -> bool:
         ...
 
-    def __gt__(self, other: _T) -> bool:
+    def __gt__(self: _Self, other: _Self) -> bool:
         ...
+
+
+_N = TypeVar("_N", bound=_Numeric)
 
 
 class CrossSiteRequestForgery(Resource):
@@ -270,12 +275,46 @@ class Field:
             **kw,
         ).maybeNamed(name)
 
+    @overload
     @classmethod
     def number(
         cls,
-        minimum: Optional[_Numeric] = None,
-        maximum: Optional[_Numeric] = None,
-        kind: Callable[[str], _Numeric] = float,
+        minimum: Optional[float] = None,
+        maximum: Optional[float] = None,
+        kind: Callable[[str], float] = float,
+        **kw: Any,
+    ) -> "Field":
+        ...
+
+    @overload
+    @classmethod
+    def number(
+        cls,
+        minimum: Optional[_N] = None,
+        maximum: Optional[_N] = None,
+        *,
+        kind: Callable[[str], _N],
+        **kw: Any,
+    ) -> "Field":
+        ...
+
+    @overload
+    @classmethod
+    def number(
+        cls,
+        minimum: _N,
+        maximum: _N,
+        kind: Callable[[str], _N],
+        **kw: Any,
+    ) -> "Field":
+        ...
+
+    @classmethod
+    def number(
+        cls,
+        minimum: Optional[_N] = None,
+        maximum: Optional[_N] = None,
+        kind: Callable[[str], _N] = float,  # type:ignore[assignment]
         **kw: Any,
     ) -> "Field":
         """


### PR DESCRIPTION
For example, in our internal codebase, we have a function:

```python
def decimal_from_str(value: str, parens_negate: bool = False) -> Decimal:
    ...

amount = Field.number(kind=decimal_from_str)
```
