### PR TITLE
Treq dependabot fix

### DIFF
--- a/requirements/tox-tests.txt
+++ b/requirements/tox-tests.txt
@@ -1,3 +1,3 @@
 idna==3.11
-treq==24.9.1; python_version >= '3.13'
+treq==25.5.0; python_version >= '3.13'
 treq==22.2.0; python_version < '3.13'

--- a/requirements/tox-tests.txt
+++ b/requirements/tox-tests.txt
@@ -1,3 +1,3 @@
 idna==3.11
-treq==22.2.0; python_version < '3.13'
 treq==24.9.1; python_version >= '3.13'
+treq==22.2.0; python_version < '3.13'


### PR DESCRIPTION
put dependency pins in the order that dependabot reads them in