### PR TITLE
Upgrade to black's 2026 stable style

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,1 +1,4 @@
+# pyupgrade --py310-plus
 f4376978cb326477589777965e5a8b123bedff0a
+# black 2026 stable style
+fe181f6eabba5aa1433c1f0245fc1ce7516d5875

--- a/.isort.cfg
+++ b/.isort.cfg
@@ -3,9 +3,6 @@
 # Play nice with Black
 profile = black
 
-# Put two blank lines after imports
-lines_after_imports = 2
-
 # Match max-line-length in Flake8 config
 line_length = 80
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,7 +11,7 @@ repos:
         args: ["--py310-plus", "--keep-runtime-typing"]
 
   - repo: https://github.com/psf/black
-    rev: "25.1.0"
+    rev: "26.5.1"
     hooks:
       - id: black
 

--- a/docs/_extensions/apilinks.py
+++ b/docs/_extensions/apilinks.py
@@ -12,7 +12,6 @@ for example::
 
 from types import MappingProxyType
 
-
 apilinks_base_url = "https://docs.twisted.org/en/stable/api/"
 
 emptyMapping = MappingProxyType({})

--- a/docs/introduction/codeexamples/foodwiki.py
+++ b/docs/introduction/codeexamples/foodwiki.py
@@ -8,7 +8,6 @@ from klein import Field, Form, Klein, Plating, Requirer, SessionProcurer
 from klein.interfaces import ISession
 from klein.storage.memory import MemorySessionStore
 
-
 app = Klein()
 
 sessions = MemorySessionStore()

--- a/docs/introduction/codeexamples/foodwiki/anon/foodwiki_config.py
+++ b/docs/introduction/codeexamples/foodwiki/anon/foodwiki_config.py
@@ -11,7 +11,6 @@ from klein import Klein, Requirer
 from klein.interfaces import ISession
 from klein.storage.sql import SQLSessionProcurer
 
-
 DB_FILE = "food-wiki.sqlite"
 
 

--- a/docs/introduction/codeexamples/foodwiki/anon/foodwiki_db.py
+++ b/docs/introduction/codeexamples/foodwiki/anon/foodwiki_db.py
@@ -12,7 +12,6 @@ from dbxs.async_dbapi import transaction
 from klein.interfaces import ISession, ISessionStore
 from klein.storage.sql import applyBasicSchema, authorizerFor
 
-
 foodTable = """
 CREATE TABLE food (
     name VARCHAR NOT NULL,

--- a/docs/introduction/codeexamples/foodwiki/anon/foodwiki_templates.py
+++ b/docs/introduction/codeexamples/foodwiki/anon/foodwiki_templates.py
@@ -2,7 +2,6 @@ from twisted.web.template import Tag, slot, tags
 
 from klein import Plating
 
-
 page = Plating(
     tags=tags.html(
         tags.head(

--- a/docs/introduction/codeexamples/foodwiki/auth/foodwiki_config.py
+++ b/docs/introduction/codeexamples/foodwiki/auth/foodwiki_config.py
@@ -11,7 +11,6 @@ from klein import Klein, Requirer
 from klein.interfaces import ISession
 from klein.storage.sql import SQLSessionProcurer
 
-
 DB_FILE = "food-wiki.sqlite"
 
 

--- a/docs/introduction/codeexamples/foodwiki/auth/foodwiki_db.py
+++ b/docs/introduction/codeexamples/foodwiki/auth/foodwiki_db.py
@@ -18,7 +18,6 @@ from klein.interfaces import (
 )
 from klein.storage.sql import SQLAuthorizer, applyBasicSchema, authorizerFor
 
-
 foodTable = """
 CREATE TABLE food (
     name VARCHAR NOT NULL,
@@ -106,12 +105,10 @@ class RatingsDB(Protocol):
     )
     def ratingsByUserID(self, accountID: str) -> AsyncIterable[FoodRating]: ...
 
-    @statement(
-        sql="""
+    @statement(sql="""
         insert into food (rated_by, name, rating)
         values ({accountID}, {name}, {rating})
-        """
-    )
+        """)
     async def addRating(
         self, accountID: str, name: str, rating: int
     ) -> None: ...

--- a/docs/introduction/codeexamples/foodwiki/auth/foodwiki_templates.py
+++ b/docs/introduction/codeexamples/foodwiki/auth/foodwiki_templates.py
@@ -2,14 +2,12 @@ from twisted.web.template import Tag, slot, tags
 
 from klein import Plating
 
-
 page = Plating(
     tags=tags.html(
         tags.head(
             tags.title("Food Ratings Example: ", slot("pageTitle")),
             slot("headExtras"),
-            tags.style(
-                """
+            tags.style("""
             .nav a {
                 padding-left: 2em;
             }
@@ -22,8 +20,7 @@ page = Plating(
                 display: block;
                 padding: 0.2em;
             }
-            """
-            ),
+            """),
         ),
         tags.body(
             tags.div(class_="nav")(

--- a/docs/introduction/codeexamples/forms.py
+++ b/docs/introduction/codeexamples/forms.py
@@ -4,7 +4,6 @@ from klein import Field, Form, Klein, Plating, Requirer, SessionProcurer
 from klein.interfaces import ISession
 from klein.storage.memory import MemorySessionStore
 
-
 app = Klein()
 
 sessions = MemorySessionStore()

--- a/docs/introduction/codeexamples/googleProxy.py
+++ b/docs/introduction/codeexamples/googleProxy.py
@@ -2,7 +2,6 @@ import treq
 
 from klein import Klein
 
-
 app = Klein()
 
 

--- a/docs/introduction/codeexamples/helloWorldClass.py
+++ b/docs/introduction/codeexamples/helloWorldClass.py
@@ -1,6 +1,5 @@
 from klein import Klein
 
-
 app = Klein()
 
 

--- a/docs/introduction/codeexamples/moreRoutes.py
+++ b/docs/introduction/codeexamples/moreRoutes.py
@@ -1,6 +1,5 @@
 from klein import Klein
 
-
 app = Klein()
 
 

--- a/docs/introduction/codeexamples/orderMatters.py
+++ b/docs/introduction/codeexamples/orderMatters.py
@@ -1,6 +1,5 @@
 from klein import Klein
 
-
 app = Klein()
 
 

--- a/docs/introduction/codeexamples/staticFiles.py
+++ b/docs/introduction/codeexamples/staticFiles.py
@@ -2,7 +2,6 @@ from twisted.web.static import File
 
 from klein import Klein
 
-
 app = Klein()
 
 

--- a/docs/introduction/codeexamples/twistdPlugin.py
+++ b/docs/introduction/codeexamples/twistdPlugin.py
@@ -1,6 +1,5 @@
 from klein import Klein
 
-
 app = Klein()
 
 

--- a/docs/introduction/codeexamples/variableRoutes.py
+++ b/docs/introduction/codeexamples/variableRoutes.py
@@ -1,6 +1,5 @@
 from klein import Klein
 
-
 app = Klein()
 
 

--- a/docs/introduction/codeexamples/variableRoutesTypes.py
+++ b/docs/introduction/codeexamples/variableRoutesTypes.py
@@ -1,6 +1,5 @@
 from klein import Klein
 
-
 app = Klein()
 
 

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,5 @@
 from setuptools import setup
 
-
 if __name__ == "__main__":
     with open("README.rst") as f:
         long_description = f.read()

--- a/src/klein/__init__.py
+++ b/src/klein/__init__.py
@@ -19,7 +19,6 @@ from ._requirer import Requirer
 from ._session import Authorization, SessionProcurer
 from ._version import __version__ as _incremental_version
 
-
 if TYPE_CHECKING:
     # Inform mypy of import shenanigans.
     from .resource import _SpecialModuleObject

--- a/src/klein/_app.py
+++ b/src/klein/_app.py
@@ -40,7 +40,6 @@ from ._interfaces import IKleinRequest, KleinQueryValue
 from ._paramspec_workaround import _normalFunction, _werkzeugRuleArgs
 from ._resource import KleinResource, route_metadata
 
-
 _KleinSynchronousRenderable = Union[
     str, bytes, IResource, IRenderable, Tag, None
 ]

--- a/src/klein/_decorators.py
+++ b/src/klein/_decorators.py
@@ -2,7 +2,6 @@ from collections.abc import Callable
 from functools import wraps
 from typing import TypeVar
 
-
 C = TypeVar("C", bound=Callable)
 
 

--- a/src/klein/_form.py
+++ b/src/klein/_form.py
@@ -36,7 +36,6 @@ from .interfaces import (
     ValueAbsent,
 )
 
-
 _Self = TypeVar("_Self")
 
 
@@ -299,7 +298,7 @@ class Field:
         cls,
         minimum: _N | None = None,
         maximum: _N | None = None,
-        kind: Callable[[str], _N] = float,  # type:ignore[assignment]
+        kind: Callable[[str], _N] = float,  # type: ignore[assignment]
         **kw: Any,
     ) -> "Field":
         """

--- a/src/klein/_headers.py
+++ b/src/klein/_headers.py
@@ -19,7 +19,6 @@ from ._imessage import (
     RawHeaders,
 )
 
-
 __all__ = ()
 
 

--- a/src/klein/_headers_compat.py
+++ b/src/klein/_headers_compat.py
@@ -25,7 +25,6 @@ from ._headers import (
     rawHeaderNameAndValue,
 )
 
-
 __all__ = ()
 
 

--- a/src/klein/_imessage.py
+++ b/src/klein/_imessage.py
@@ -18,7 +18,6 @@ from hyperlink import DecodedURL
 from tubes.itube import IFount
 from zope.interface import Attribute, Interface
 
-
 __all__ = ()
 
 
@@ -63,15 +62,13 @@ class IHTTPHeaders(Interface):
     well-behaved implementations.
     """
 
-    rawHeaders: RawHeaders = Attribute(
-        """
+    rawHeaders: RawHeaders = Attribute("""
         Raw header data as a tuple in the from: C{((name, value), ...)}.
         C{name} and C{value} are bytes.
         Headers are provided in the order that they were received.
         Headers with multiple values are provided as separate name and value
         pairs.
-        """
-    )
+        """)
 
     def getValues(name: AnyStr) -> Iterable[AnyStr]:
         """

--- a/src/klein/_interfaces.py
+++ b/src/klein/_interfaces.py
@@ -12,7 +12,6 @@ from typing import Union
 
 from zope.interface import Attribute, Interface
 
-
 KleinQueryValue = Union[str, int, float]
 
 

--- a/src/klein/_isession.py
+++ b/src/klein/_isession.py
@@ -18,7 +18,6 @@ from twisted.internet.defer import Deferred
 from twisted.python.components import Componentized
 from twisted.web.iweb import IRequest
 
-
 if TYPE_CHECKING:
     from ._app import KleinRenderable
 
@@ -87,8 +86,7 @@ class ISession(Interface):
     about how the session was negotiated with the client software, and
     """
 
-    identifier: str = Attribute(
-        """
+    identifier: str = Attribute("""
         L{str} identifying a session.
 
         This value should be:
@@ -99,25 +97,20 @@ class ISession(Interface):
                should be able to guess what it is
 
             3. I{opaque} - it should contain no interesting information
-        """
-    )
+        """)
 
-    isConfidential = Attribute(
-        """
+    isConfidential = Attribute("""
         A L{bool} indicating whether this session mechanism transmitted over an
         encrypted transport, i.e., HTTPS.  If C{True}, this means that this
         session can be used for sensitive information; otherwise, the
         information contained in it should be considered to be available to
         attackers.
-        """
-    )
+        """)
 
-    authenticatedBy = Attribute(
-        """
+    authenticatedBy = Attribute("""
         A L{SessionMechanism} indicating what mechanism was used to
         authenticate this session.
-        """
-    )
+        """)
 
     def authorize(
         interfaces: Iterable[type[object]],
@@ -239,17 +232,13 @@ class ISimpleAccount(Interface):
     Data-store agnostic account interface.
     """
 
-    username: str = Attribute(
-        """
+    username: str = Attribute("""
         Unicode username.
-        """
-    )
+        """)
 
-    accountID: str = Attribute(
-        """
+    accountID: str = Attribute("""
         Unicode account-ID.
-        """
-    )
+        """)
 
     def bindSession(session: ISession) -> Deferred[None]:
         """

--- a/src/klein/_message.py
+++ b/src/klein/_message.py
@@ -14,7 +14,6 @@ from tubes.itube import IFount
 from ._imessage import FountAlreadyAccessedError
 from ._tubes import bytesToFount, fountToBytes
 
-
 __all__ = ()
 
 

--- a/src/klein/_paramspec_workaround.py
+++ b/src/klein/_paramspec_workaround.py
@@ -35,7 +35,6 @@ from typing import (
 
 from werkzeug.routing import Rule
 
-
 if TYPE_CHECKING:
     from ._app import Klein
 
@@ -125,7 +124,7 @@ def _routeArgsWith(
     ) -> _RuleCopy[P, R]:
         # branch kw-only arg is encoded in `P` via kwOnlyBranchArg so we cannot
         # check it here.
-        return decoratee  # type:ignore[return-value]
+        return decoratee  # type: ignore[return-value]
 
     return decorator
 

--- a/src/klein/_plating.py
+++ b/src/klein/_plating.py
@@ -3,6 +3,7 @@
 """
 Templating wrapper support for Klein.
 """
+
 from __future__ import annotations
 
 from collections.abc import Callable, Generator
@@ -21,7 +22,6 @@ from twisted.web.template import Element, Tag, TagLoader, slot
 
 from ._app import _call
 from ._decorators import bindable, modified, originalName
-
 
 StackType = list[tuple[Any, Callable[[Any], None]]]
 

--- a/src/klein/_request.py
+++ b/src/klein/_request.py
@@ -5,7 +5,6 @@
 HTTP request API.
 """
 
-
 from attr import Factory, attrib, attrs
 from attr.validators import instance_of
 from hyperlink import DecodedURL
@@ -15,7 +14,6 @@ from zope.interface import implementer
 from ._attrs_zope import provides
 from ._imessage import IHTTPHeaders, IHTTPRequest
 from ._message import MessageState, bodyAsBytes, bodyAsFount, validateBody
-
 
 __all__ = ()
 

--- a/src/klein/_request_compat.py
+++ b/src/klein/_request_compat.py
@@ -23,7 +23,6 @@ from ._message import FountAlreadyAccessedError, MessageState
 from ._request import IHTTPRequest
 from ._tubes import IOFount, fountToBytes
 
-
 __all__ = ()
 
 

--- a/src/klein/_resource.py
+++ b/src/klein/_resource.py
@@ -18,7 +18,6 @@ from twisted.web.template import renderElement
 from ._dihttp import Response
 from ._interfaces import IKleinRequest
 
-
 if TYPE_CHECKING:
     # NB: circular import, must not be imported at runtime.
     from ._app import (
@@ -31,7 +30,7 @@ if TYPE_CHECKING:
 
 
 def route_metadata(handler: KleinRouteHandler) -> RouteMetadata:
-    return handler  # type:ignore[return-value]
+    return handler  # type: ignore[return-value]
 
 
 def ensure_utf8_bytes(v: str | bytes) -> bytes:
@@ -200,7 +199,7 @@ class KleinResource(Resource):
             # to percolate up. If that happens it will be handled below in
             # processing_failed, either by a user-registered error handler or
             # one of our defaults.
-            (rule, kwargs) = mapper.match(return_rule=True)
+            rule, kwargs = mapper.match(return_rule=True)
             endpoint = rule.endpoint
 
             # Try pretty hard to fix up prepath and postpath.

--- a/src/klein/_response.py
+++ b/src/klein/_response.py
@@ -5,7 +5,6 @@
 HTTP response API.
 """
 
-
 from attr import Factory, attrib, attrs
 from attr.validators import instance_of
 from tubes.itube import IFount
@@ -14,7 +13,6 @@ from zope.interface import implementer
 from ._attrs_zope import provides
 from ._imessage import IHTTPHeaders, IHTTPResponse
 from ._message import MessageState, bodyAsBytes, bodyAsFount, validateBody
-
 
 __all__ = ()
 

--- a/src/klein/_session.py
+++ b/src/klein/_session.py
@@ -82,7 +82,7 @@ async def cookieLoader(
     )
 
     # https://github.com/twisted/twisted/issues/11865
-    wrongSignature: Request = request  # type:ignore[assignment]
+    wrongSignature: Request = request  # type: ignore[assignment]
     wrongSignature.addCookie(
         cookieName,
         session.identifier,

--- a/src/klein/_tubes.py
+++ b/src/klein/_tubes.py
@@ -18,7 +18,6 @@ from twisted.python.failure import Failure
 
 from ._attrs_zope import provides
 
-
 __all__ = ()
 
 

--- a/src/klein/_util.py
+++ b/src/klein/_util.py
@@ -5,7 +5,6 @@ from typing import TYPE_CHECKING, ParamSpec, TypeVar
 
 from twisted.internet.defer import Deferred
 
-
 _T = TypeVar("_T")
 _P = ParamSpec("_P")
 

--- a/src/klein/app.py
+++ b/src/klein/app.py
@@ -10,7 +10,6 @@ from ._app import (
     urlFor,
 )
 
-
 __all__ = (
     "Klein",
     "KleinRequest",

--- a/src/klein/interfaces.py
+++ b/src/klein/interfaces.py
@@ -17,7 +17,6 @@ from ._isession import (
     TransactionEnded,
 )
 
-
 __all__ = (
     "EarlyExit",
     "IDependencyInjector",

--- a/src/klein/resource.py
+++ b/src/klein/resource.py
@@ -17,7 +17,6 @@ from ._app import resource as _globalResourceMethod
 from ._resource import KleinResource as _KleinResource
 from ._resource import ensure_utf8_bytes
 
-
 KleinResource = _KleinResource
 
 

--- a/src/klein/storage/memory/__init__.py
+++ b/src/klein/storage/memory/__init__.py
@@ -8,7 +8,6 @@ databases.
 from ._memory import MemorySessionStore, declareMemoryAuthorizer
 from ._memory_users import MemoryAccountStore
 
-
 __all__ = [
     "declareMemoryAuthorizer",
     "MemorySessionStore",

--- a/src/klein/storage/memory/_memory.py
+++ b/src/klein/storage/memory/_memory.py
@@ -28,7 +28,6 @@ from klein.interfaces import (
 from ..._isession import AuthorizationMap
 from ..._util import eagerDeferredCoroutine
 
-
 _authCB = Callable[[type[object], ISession, Componentized], Any]
 
 
@@ -53,7 +52,7 @@ class MemorySession:
         Authorize each interface by calling back to the session store's
         authorization callback.
         """
-        result: AuthorizationMap = {}  # type:ignore[assignment]
+        result: AuthorizationMap = {}  # type: ignore[assignment]
         for interface in interfaces:
             provider = self._authorizationCallback(
                 interface, self, self._components

--- a/src/klein/storage/passwords/__init__.py
+++ b/src/klein/storage/passwords/__init__.py
@@ -5,7 +5,6 @@ Testable, secure hashing for passwords.
 from ._interfaces import PasswordEngine
 from ._scrypt import InvalidPasswordRecord, defaultSecureEngine
 
-
 __all__ = [
     "InvalidPasswordRecord",
     "defaultSecureEngine",

--- a/src/klein/storage/passwords/testing.py
+++ b/src/klein/storage/passwords/testing.py
@@ -12,7 +12,6 @@ production.
 
 from ._testing import engineForTesting, hashUpgradeCount
 
-
 __all__ = [
     "engineForTesting",
     "hashUpgradeCount",

--- a/src/klein/storage/sql/__init__.py
+++ b/src/klein/storage/sql/__init__.py
@@ -11,7 +11,6 @@ from ._sql_glue import (
     authorizerFor,
 )
 
-
 __all__ = [
     "SQLAuthorizer",
     "SQLSessionProcurer",

--- a/src/klein/storage/sql/_sql_dal.py
+++ b/src/klein/storage/sql/_sql_dal.py
@@ -62,14 +62,12 @@ class SessionDAL(Protocol):
         Delete all sessions with the given security level by session ID.
         """
 
-    @statement(
-        sql="""
+    @statement(sql="""
         insert into session
             ( session_id,  confidential,   created,   mechanism )
         values
             ({sessionID}, {confidential}, {created}, {mechanism})
-        """
-    )
+        """)
     async def insertSession(
         self, sessionID: str, confidential: bool, created: float, mechanism: str
     ) -> None:
@@ -130,13 +128,11 @@ class SessionDAL(Protocol):
         Load an account by username.
         """
 
-    @statement(
-        sql="""
+    @statement(sql="""
         update account
             set password_blob = {newBlob}
         where account_id = {accountID}
-        """
-    )
+        """)
     async def resetPassword(self, accountID: str, newBlob: str) -> None:
         """
         Reset the password for the given account ID.
@@ -160,11 +156,9 @@ class SessionDAL(Protocol):
         Load all account objects bound to the given session id.
         """
 
-    @statement(
-        sql="""
+    @statement(sql="""
         delete from session_account where session_id = {sessionID}
-        """
-    )
+        """)
     async def unbindSession(self, sessionID: str) -> None:
         """
         Un-bind the given session from the account it's currently bound to.

--- a/src/klein/storage/sql/_sql_glue.py
+++ b/src/klein/storage/sql/_sql_glue.py
@@ -42,7 +42,6 @@ from ..passwords import PasswordEngine, defaultSecureEngine
 from ._sql_dal import AccountRecord, SessionDAL, SessionDB, SessionRecord
 from ._transactions import requestBoundTransaction
 
-
 T = TypeVar("T")
 
 
@@ -338,9 +337,7 @@ class SQLSessionProcurer:
         """
         alreadyProcured: ISession | None = ISession(request, None)
 
-        assert (
-            alreadyProcured is None
-        ), """
+        assert alreadyProcured is None, """
         Sessions should only be procured once during the lifetime of the
         request, and it should not be possible to invoke procureSession
         multiple times when getting them from dependency injection.
@@ -422,7 +419,7 @@ def authorizerFor(
     def decorator(
         decorated: _authorizerFunction[T],
     ) -> _FunctionWithAuthorizer[T]:
-        result: _FunctionWithAuthorizer = decorated  # type:ignore[assignment]
+        result: _FunctionWithAuthorizer = decorated  # type: ignore[assignment]
         result.authorizer = ConcreteSQLAuthorizer[T](
             authorizationType, decorated
         )

--- a/src/klein/storage/sql/_transactions.py
+++ b/src/klein/storage/sql/_transactions.py
@@ -25,7 +25,6 @@ from klein.interfaces import (
 from ..._util import eagerDeferredCoroutine
 from ...interfaces import IRequirementContext
 
-
 log = Logger()
 
 

--- a/src/klein/storage/sql/test/test_dal.py
+++ b/src/klein/storage/sql/test/test_dal.py
@@ -8,7 +8,6 @@ from dbxs.testing import MemoryPool, immediateTest
 from .._sql_dal import SessionDB
 from .._sql_glue import applyBasicSchema
 
-
 T = TypeVar("T")
 
 

--- a/src/klein/storage/test/test_common.py
+++ b/src/klein/storage/test/test_common.py
@@ -37,7 +37,6 @@ from ...test.util import makeStub as StubTreq
 from ..passwords.testing import engineForTesting, hashUpgradeCount
 from ..sql import SQLSessionProcurer, applyBasicSchema
 
-
 T = TypeVar("T")
 
 

--- a/src/klein/test/_trial.py
+++ b/src/klein/test/_trial.py
@@ -4,13 +4,11 @@
 Extensions to L{twisted.trial}.
 """
 
-
 from zope.interface import Interface
 from zope.interface.exceptions import Invalid
 from zope.interface.verify import verifyObject
 
 from twisted.trial.unittest import SynchronousTestCase
-
 
 __all__ = ()
 

--- a/src/klein/test/not_hypothesis.py
+++ b/src/klein/test/not_hypothesis.py
@@ -15,7 +15,6 @@ from typing import TypeVar
 
 from hyperlink import DecodedURL
 
-
 T = TypeVar("T")
 S = TypeVar("S")
 

--- a/src/klein/test/test_form.py
+++ b/src/klein/test/test_form.py
@@ -265,7 +265,7 @@ class TestForms(SynchronousTestCase):
                 # https://github.com/twisted/treq/issues/436
                 headers={
                     b"X-Test-Session": session.identifier
-                },  # type:ignore[arg-type]
+                },  # type: ignore[arg-type]
             )
         )
         self.assertEqual(response.code, 200)
@@ -292,7 +292,7 @@ class TestForms(SynchronousTestCase):
                 # https://github.com/twisted/treq/issues/436
                 headers={
                     b"X-Test-Session": session.identifier
-                },  # type:ignore[arg-type]
+                },  # type: ignore[arg-type]
             )
         )
         self.assertEqual(response.code, 200)
@@ -321,7 +321,7 @@ class TestForms(SynchronousTestCase):
                 # https://github.com/twisted/treq/issues/436
                 headers={
                     b"X-Test-Session": session.identifier
-                },  # type:ignore[arg-type]
+                },  # type: ignore[arg-type]
             )
         )
         tooHigh = self.successResultOf(
@@ -331,7 +331,7 @@ class TestForms(SynchronousTestCase):
                 # https://github.com/twisted/treq/issues/436
                 headers={
                     b"X-Test-Session": session.identifier
-                },  # type:ignore[arg-type]
+                },  # type: ignore[arg-type]
             )
         )
         justRight = self.successResultOf(
@@ -341,7 +341,7 @@ class TestForms(SynchronousTestCase):
                 # https://github.com/twisted/treq/issues/436
                 headers={
                     b"X-Test-Session": session.identifier
-                },  # type:ignore[arg-type]
+                },  # type: ignore[arg-type]
             )
         )
 
@@ -371,7 +371,7 @@ class TestForms(SynchronousTestCase):
                 # https://github.com/twisted/treq/issues/436
                 headers={
                     b"X-Test-Session": session.identifier
-                },  # type:ignore[arg-type]
+                },  # type: ignore[arg-type]
             )
         )
         self.assertEqual(response.code, 400)
@@ -402,7 +402,7 @@ class TestForms(SynchronousTestCase):
                 # https://github.com/twisted/treq/issues/436
                 headers={
                     b"X-Test-Session": session.identifier
-                },  # type:ignore[arg-type]
+                },  # type: ignore[arg-type]
             )
         )
         self.assertEqual(response.code, 500)
@@ -419,7 +419,7 @@ class TestForms(SynchronousTestCase):
                 # https://github.com/twisted/treq/issues/436
                 headers={
                     b"X-Test-Session": session.identifier
-                },  # type:ignore[arg-type]
+                },  # type: ignore[arg-type]
             ),
         )
         self.assertEqual(response.code, 500)
@@ -528,7 +528,7 @@ class TestForms(SynchronousTestCase):
                 # https://github.com/twisted/treq/issues/436
                 headers={
                     "X-Test-Session": session.identifier
-                },  # type:ignore[arg-type]
+                },  # type: ignore[arg-type]
             )
         )
         self.assertEqual(response.code, 200)
@@ -555,7 +555,7 @@ class TestForms(SynchronousTestCase):
                 # https://github.com/twisted/treq/issues/436
                 headers={
                     b"X-Test-Session": session.identifier
-                },  # type:ignore[arg-type]
+                },  # type: ignore[arg-type]
             )
         )
         response2 = self.successResultOf(
@@ -565,7 +565,7 @@ class TestForms(SynchronousTestCase):
                 # https://github.com/twisted/treq/issues/436
                 headers={
                     b"X-Test-Session": session.identifier
-                },  # type:ignore[arg-type]
+                },  # type: ignore[arg-type]
             )
         )
         self.assertEqual(response.code, 200)
@@ -591,7 +591,7 @@ class TestForms(SynchronousTestCase):
                 # https://github.com/twisted/treq/issues/436
                 headers={
                     b"X-Test-Session": session.identifier
-                },  # type:ignore[arg-type]
+                },  # type: ignore[arg-type]
             )
         )
         self.assertEqual(response.code, 200)
@@ -625,7 +625,7 @@ class TestForms(SynchronousTestCase):
                 # https://github.com/twisted/treq/issues/436
                 headers={
                     b"X-Test-Session": session.identifier
-                },  # type:ignore[arg-type]
+                },  # type: ignore[arg-type]
             )
         )
         self.assertEqual(response.code, 200)
@@ -657,7 +657,7 @@ class TestForms(SynchronousTestCase):
                 # https://github.com/twisted/treq/issues/436
                 headers={
                     b"X-Test-Session": session.identifier
-                },  # type:ignore[arg-type]
+                },  # type: ignore[arg-type]
             )
         )
         self.assertEqual(response.code, 200)
@@ -692,7 +692,7 @@ class TestForms(SynchronousTestCase):
                 # https://github.com/twisted/treq/issues/436
                 headers={
                     b"X-Test-Session": session.identifier
-                },  # type:ignore[arg-type]
+                },  # type: ignore[arg-type]
             )
         )
         self.assertEqual(response.code, 200)
@@ -730,7 +730,7 @@ class TestForms(SynchronousTestCase):
                 # https://github.com/twisted/treq/issues/436
                 headers={
                     b"X-Test-Session": session.identifier
-                },  # type:ignore[arg-type]
+                },  # type: ignore[arg-type]
             )
         )
         self.assertEqual(response.code, 200)
@@ -757,7 +757,7 @@ class TestForms(SynchronousTestCase):
                 # https://github.com/twisted/treq/issues/436
                 headers={
                     b"X-Test-Session": session.identifier
-                },  # type:ignore[arg-type]
+                },  # type: ignore[arg-type]
                 json={"value": 300},
             )
         )

--- a/src/klein/test/test_headers.py
+++ b/src/klein/test/test_headers.py
@@ -41,7 +41,6 @@ from .not_hypothesis import (
     textHeaderPairs,
 )
 
-
 __all__ = ()
 
 

--- a/src/klein/test/test_headers_compat.py
+++ b/src/klein/test/test_headers_compat.py
@@ -16,7 +16,6 @@ from .._headers_compat import HTTPHeadersWrappingHeaders
 from ._trial import TestCase
 from .test_headers import MutableHTTPHeadersTestsMixIn
 
-
 try:
     from twisted.web.http_headers import _sanitizeLinearWhitespace
 except ImportError:  # pragma: no cover

--- a/src/klein/test/test_message.py
+++ b/src/klein/test/test_message.py
@@ -15,7 +15,6 @@ from .._message import FountAlreadyAccessedError, bytesToFount, fountToBytes
 from ._trial import TestCase
 from .not_hypothesis import binary, given
 
-
 __all__ = ()
 
 

--- a/src/klein/test/test_plating.py
+++ b/src/klein/test/test_plating.py
@@ -18,7 +18,6 @@ from .._plating import ATOM_TYPES, PlatedElement, resolveDeferredObjects
 from .not_hypothesis import booleans, given, jsonObjects
 from .test_resource import MockRequest, _render
 
-
 page = Plating(
     defaults={
         "title": "default title unchanged",

--- a/src/klein/test/test_request.py
+++ b/src/klein/test/test_request.py
@@ -13,7 +13,6 @@ from .._request import FrozenHTTPRequest, IHTTPRequest
 from ._trial import TestCase
 from .test_message import FrozenHTTPMessageTestsMixIn
 
-
 __all__ = ()
 
 

--- a/src/klein/test/test_request_compat.py
+++ b/src/klein/test/test_request_compat.py
@@ -27,7 +27,6 @@ from ._trial import TestCase
 from .not_hypothesis import binary, decoded_urls, given, text
 from .test_resource import MockRequest
 
-
 __all__ = ()
 
 

--- a/src/klein/test/test_resource.py
+++ b/src/klein/test/test_resource.py
@@ -34,7 +34,6 @@ from .._resource import (
 )
 from .util import EqualityTestsMixin, recover
 
-
 emptyMapping: Mapping[Any, Any] = MappingProxyType({})
 
 
@@ -1325,7 +1324,7 @@ class ExtractURLpartsTests(SynchronousTestCase):
         Raises URLDecodeError if SERVER_NAME can't be decoded.
         """
         request = MockRequest(b"/foo")
-        request.getRequestHostname = (  # type:ignore[method-assign]
+        request.getRequestHostname = (  # type: ignore[method-assign]
             lambda: b"f\xc3\xc3\xb6"
         )
         e = self.assertRaises(URLDecodeError, extractURLparts, request)
@@ -1355,7 +1354,7 @@ class ExtractURLpartsTests(SynchronousTestCase):
         """
         request = MockRequest(b"/f\xc3\xc3\xb6")
         request.prepath = [b"f\xc3\xc3\xb6"]
-        request.getRequestHostname = (  # type:ignore[method-assign]
+        request.getRequestHostname = (  # type: ignore[method-assign]
             lambda: b"f\xc3\xc3\xb6"
         )
         e = self.assertRaises(URLDecodeError, extractURLparts, request)

--- a/src/klein/test/test_response.py
+++ b/src/klein/test/test_response.py
@@ -11,7 +11,6 @@ from .._response import FrozenHTTPResponse, IHTTPResponse
 from ._trial import TestCase
 from .test_message import FrozenHTTPMessageTestsMixIn
 
-
 __all__ = ()
 
 

--- a/src/klein/test/test_session.py
+++ b/src/klein/test/test_session.py
@@ -19,7 +19,6 @@ from klein.storage.memory import MemorySessionStore, declareMemoryAuthorizer
 from .util import StubWithTypes
 from .util import makeStub as StubTreq
 
-
 Sessions = list[ISession]
 Errors = list[NoSuchSession]
 

--- a/src/klein/test/test_trial.py
+++ b/src/klein/test/test_trial.py
@@ -8,7 +8,6 @@ from zope.interface import Interface, implementer
 
 from ._trial import TestCase
 
-
 __all__ = ()
 
 

--- a/src/klein/test/util.py
+++ b/src/klein/test/util.py
@@ -150,4 +150,4 @@ def makeStub(resource: IResource) -> StubWithTypes:
     """
     Create a StubTreq but give it a more convincing type signature.
     """
-    return _StubTreq(resource)  # type:ignore[return-value]
+    return _StubTreq(resource)  # type: ignore[return-value]


### PR DESCRIPTION
As described in https://github.com/PyCQA/isort/issues/2452, black >= 26 conflicts with `lines_after_imports = 2` in isort.  This doesn't seem worth arguing about, so just drop that bit of isort configuration.

This should remove the current blocker to #836.